### PR TITLE
fix: ensure firestore indexes deploy & boost test timeout

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -9,6 +9,7 @@ on:
       - 'recipe-rpg-simple/functions/**'
       - 'recipe-rpg-simple/firestore.rules'
       - 'recipe-rpg-simple/firestore.indexes.json'
+      - 'recipe-rpg-simple/storage.rules'
 
 jobs:
   deploy:
@@ -57,4 +58,4 @@ jobs:
       - name: Deploy
         run: |
           firebase use $DEPLOY_TARGET
-          firebase deploy --only functions,firestore
+          firebase deploy --only functions,firestore:rules,firestore:indexes,storage

--- a/recipe-rpg-simple/firestore.indexes.json
+++ b/recipe-rpg-simple/firestore.indexes.json
@@ -41,6 +41,44 @@
         }
       ],
       "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "recipes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "ownerId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "icons",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "marked_for_deletion",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
     }
   ],
   "fieldOverrides": []

--- a/recipe-rpg-simple/playwright.config.ts
+++ b/recipe-rpg-simple/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   testDir: './e2e',
   timeout: 30 * 1000,
   expect: {
-    timeout: 1 * 1000,
+    timeout: 5 * 1000,
   },
   retries: 0,
   workers: 1,


### PR DESCRIPTION
Summary:
- Added missing Firestore indexes for 'recipes' (ownerId query) and 'icons' (collection group query) to prevent manual index creation requirements.
- Updated 'deploy-backend.yml' to explicitly include 'firestore:indexes', 'firestore:rules', and 'storage' in the deployment command for clarity and robustness.
- Included 'storage.rules' in the workflow trigger paths.
- Increased Playwright expect timeout to 5s to reduce CI flakiness.