### PR TITLE
fix(ui): prevent spacing slider from scrolling toolbar on mobile

### DIFF
--- a/recipe-rpg-simple/app/lanes/page.tsx
+++ b/recipe-rpg-simple/app/lanes/page.tsx
@@ -879,7 +879,7 @@ const handleVisualize = async () => {
                             step="0.1" 
                             value={spacing} 
                             onChange={(e) => setSpacing(parseFloat(e.target.value))}
-                            className="w-20 h-1 bg-zinc-200 rounded-lg appearance-none cursor-pointer"
+                            className="w-20 h-1 bg-zinc-200 rounded-lg appearance-none cursor-pointer touch-none"
                         />
                     </div>
 


### PR DESCRIPTION
Summary:
- Added `touch-none` class to the spacing slider input.
- This prevents touch drag events on the slider from propagating to the scrollable toolbar container on mobile devices.

Fixes #21