### PR TITLE
fix(interaction): improve mobile pivot interaction

### DIFF
--- a/recipe-rpg-simple/components/recipe-lanes/nodes/minimal-node.tsx
+++ b/recipe-rpg-simple/components/recipe-lanes/nodes/minimal-node.tsx
@@ -35,7 +35,7 @@ const MinimalNode = ({ id, data, selected }: NodeProps<RecipeNode & { onDelete?:
           if (data.onSetLongPress) data.onSetLongPress(true);
           // Optional: Vibrate
           if (navigator.vibrate) navigator.vibrate(50);
-      }, 600); // 600ms hold
+      }, 300); // 300ms hold
   };
 
   const handleTouchEnd = () => {

--- a/recipe-rpg-simple/components/recipe-lanes/react-flow-diagram.tsx
+++ b/recipe-rpg-simple/components/recipe-lanes/react-flow-diagram.tsx
@@ -689,7 +689,7 @@ const DiagramInner = memo(forwardRef<ReactFlowDiagramHandle, ReactFlowDiagramPro
                 fitView
                 minZoom={0.1}
                 maxZoom={4}
-                nodeDragThreshold={5} // Prevent accidental drags
+                nodeDragThreshold={10} // Prevent accidental drags, allow long press jitter
                 defaultEdgeOptions={{ type: 'floating' }}
                 onlyRenderVisibleElements={false}
                 multiSelectionKeyCode={['Shift']}


### PR DESCRIPTION
Summary:
- Reduced long-press duration from 600ms to 300ms for snappier feedback.
- Increased `nodeDragThreshold` from 5px to 10px to tolerate slight finger movement while holding.

Fixes #31