### PR TITLE
fix(ci): ensure gemini-triage returns json

### DIFF
--- a/.github/commands/gemini-triage.toml
+++ b/.github/commands/gemini-triage.toml
@@ -51,4 +51,10 @@ You are an issue triage assistant. Analyze the current GitHub issue and identify
     ```
     echo "SELECTED_LABELS=bug,enhancement" >> "/tmp/runner/env"
     ```
+
+5. Return a JSON object containing the selected labels as the final response:
+
+    ```json
+    { "selected_labels": ["bug", "enhancement"] }
+    ```
 """


### PR DESCRIPTION
Summary:
- Updated the prompt in `gemini-triage.toml` to explicitly instruct the model to return a JSON object as the final response.
- This addresses the 'Gemini CLI output was not valid JSON' error in the `gemini-triage` workflow.