### PR TITLE
chore(prompt): improve ambiguity handling and tool usage instructions

### DIFF
--- a/.github/commands/gemini-invoke.toml
+++ b/.github/commands/gemini-invoke.toml
@@ -45,6 +45,8 @@ These rules are absolute and must be followed without exception.
 
 7. **Command Substitution**: When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
 
+8. **Tool Distinction**: Do NOT use `run_shell_command` to execute other tools (e.g., do not run `run_shell_command("read_file ...")`). `read_file`, `write_file`, and `replace` are distinct tools. `run_shell_command` is ONLY for actual shell binaries (git, npm, ls, etc.).
+
 -----
 
 ## Environment & Workflow

--- a/recipe-rpg-simple/lib/recipe-lanes/parser.ts
+++ b/recipe-rpg-simple/lib/recipe-lanes/parser.ts
@@ -108,11 +108,13 @@ These are cached, so simplicity and consistency is key.
 
 1. **INGREDIENT Nodes (The "Item"):**
    - **Atomic & Generic:** Visuals must be simple, singular, and reusable inventory items.
+   - **Clarify Ambiguity:** If a word has multiple meanings (e.g. "Pepper"), add a qualifier (e.g. "Black Pepper" or "Bell Pepper").
    - **NO Quantities:** Never show specific numbers (e.g. "3 eggs"). Visual should be "egg".
    - **NO Action Context:** Do not show pouring/falling/mixing. Just the item.
    - **Examples:**
      - "3 Eggs" -> "egg"
      - "A pinch of Salt" -> "Salt"
+     - "Pepper" -> "Black Pepper"
      - "Bottle of Olive Oil" -> "Olive Oil"
      - "A pat of butter melting in a non stick frying pan" -> "butter in pan"
 


### PR DESCRIPTION
Extracted from PR #88.

- Updates the parser prompt to handle ambiguous ingredients better (e.g., Pepper -> Black Pepper).
- Adds explicit instructions to avoiding running tools via run_shell_command.