### PR TITLE
Add timeline2 layout mode

### DIFF
--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -28,6 +28,7 @@ import { createVisualRecipeAction, adjustRecipeAction, saveRecipeAction, checkEx
 import { iconSearchMethods, defaultIconSearchMethod } from '@/lib/icon-search-registry';
 import { standardizeIngredientName } from '@/lib/utils';
 import { IngredientsSidebar } from '@/components/recipe-lanes/ui/ingredients-sidebar';
+import { TimelineView } from '@/components/recipe-lanes/timeline-view';
 import type { RecipeGraph } from '@/lib/recipe-lanes/types';
 import { hasNodeIcon, preserveNodeShortlist, getNodeShortlistLength, getNodeIngredientName, getNodeHydeQueries } from '@/lib/recipe-lanes/model-utils';
 import { useRecipeStore } from '@/lib/stores/recipe-store';
@@ -68,7 +69,7 @@ function RecipeLanesContent() {
   const [iconSearchMethodId, setIconSearchMethodId] = useState(defaultIconSearchMethod.id);
   const [iconSearchElapsed, setIconSearchElapsed] = useState<number | null>(null);
   const [jsonText, setJsonText] = useState('');
-  const [layoutMode, setLayoutMode] = useState<LayoutMode | 'repulsive'>('dagre');
+  const [layoutMode, setLayoutMode] = useState<LayoutMode | 'repulsive' | 'timeline2'>('dagre');
   const layoutModeRestoredRef = useRef(false);
   const [iconTheme, setIconTheme] = useState<'classic' | 'modern' | 'modern_clean'>('classic');
   const [showForkPrompt, setShowForkPrompt] = useState(false);
@@ -347,6 +348,7 @@ const saveAndHandleFork = async (graphToSave: RecipeGraph) => {
                   ownerId: data.ownerId || undefined,
                   ownerName: data.ownerName || undefined,
               });
+              if (currentGraph.layoutMode) setLayoutMode(currentGraph.layoutMode as any);
               setRecipeText(currentGraph.originalText || '');
               setRecipeTitle(currentGraph.title || '');
               setStatus('complete');
@@ -811,6 +813,8 @@ const handleVisualize = async () => {
                             <option value="dagre">Smart</option>
                             <option value="dagre-lr">Smart LR</option>
                             <option value="repulsive">Repulsive</option>
+                            <option value="timeline">Timeline</option>
+                            <option value="timeline2">Timeline (Classic)</option>
                         </select>
                         {/* Reset Layout Button */}
                         <button 
@@ -963,16 +967,18 @@ const handleVisualize = async () => {
                 />
             )}
 
-            <div className="flex-1 relative"> 
-                {graph ? (
-                    <ReactFlowDiagram 
+            <div className="flex-1 relative">
+                {graph && layoutMode === 'timeline2' ? (
+                    <TimelineView graph={graph} />
+                ) : graph ? (
+                    <ReactFlowDiagram
                         ref={diagramRef}
-                        graph={graph} 
-                        mode={layoutMode} 
-                        spacing={spacing} 
-                        edgeStyle={edgeStyle} 
-                        textPos={textPos} 
-                        isLive={isLive} 
+                        graph={graph}
+                        mode={layoutMode as LayoutMode | 'repulsive'}
+                        spacing={spacing}
+                        edgeStyle={edgeStyle}
+                        textPos={textPos}
+                        isLive={isLive}
                         iconTheme={iconTheme}
                         onInteraction={() => setInputExpanded(false)}
                         onEdit={handleEditAttempt}

--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -579,12 +579,29 @@ const handleVisualize = async () => {
       }
   };
 
-    const handleLayoutClick = (mode: LayoutMode | 'repulsive') => {
+    const handleLayoutClick = async (mode: LayoutMode | 'repulsive' | 'timeline2') => {
         if (layoutMode === mode) {
             diagramRef.current?.resetLayout();
         } else {
             setLayoutMode(mode);
             if (mode === 'repulsive') setEdgeStyle('bezier');
+            
+            if (graph) {
+                // Clear x/y from main nodes so the new mode computes a fresh layout 
+                // (unless it already exists in graph.layouts). This prevents using 
+                // the previous mode's coordinates for the new mode.
+                const freshNodes = graph.nodes.map(n => {
+                    const { x, y, ...rest } = n;
+                    return rest as any;
+                });
+                
+                const newGraph = { ...graph, layoutMode: mode, nodes: freshNodes };
+                setGraph(newGraph);
+                
+                if (user && isOwner && recipeId) {
+                    await saveRecipeAction(newGraph, recipeId);
+                }
+            }
         }
     };
 
@@ -969,7 +986,24 @@ const handleVisualize = async () => {
 
             <div className="flex-1 relative">
                 {graph && layoutMode === 'timeline2' ? (
-                    <TimelineView graph={graph} />
+                    <TimelineView 
+                        graph={graph} 
+                        onSave={async (newGraph) => {
+                            // Update layouts map for consistency with ReactFlowDiagram
+                            const layouts = newGraph.layouts || {};
+                            layouts['timeline2'] = newGraph.nodes.map(n => ({ 
+                                id: n.id, 
+                                x: n.x ?? 0, 
+                                y: n.y ?? 0 
+                            }));
+                            const finalGraph = { ...newGraph, layouts };
+                            
+                            setGraph(finalGraph);
+                            if (user && isOwner && recipeId) {
+                                await saveRecipeAction(finalGraph, recipeId);
+                            }
+                        }}
+                    />
                 ) : graph ? (
                     <ReactFlowDiagram
                         ref={diagramRef}

--- a/recipe-lanes/components/recipe-lanes/edges/timeline-edge.tsx
+++ b/recipe-lanes/components/recipe-lanes/edges/timeline-edge.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import React, { memo, useCallback, useState, useEffect } from 'react';
+import { useStore } from 'reactflow';
+import { getNodeIconUrlAt, currentShortlistIndex } from '../../../lib/recipe-lanes/model-utils';
+
+// Both node types are 40×40 circles — must match TIMELINE_NODE_SIZE in layout.ts
+const S = 40;
+const R = S / 2;
+const CHAIN_W = 5;  // stroke width for chain edges
+const SPUR_W  = 2;  // stroke width for spur (ingredient→action) edges
+
+function chainPath(sx: number, sy: number, ex: number, ey: number): string {
+  if (sx >= ex) return `M ${sx} ${sy} L ${ex} ${ey}`;
+  if (Math.abs(ey - sy) < 1) return `M ${sx} ${sy} H ${ex}`;
+  const mid = (sx + ex) / 2;
+  return `M ${sx} ${sy} C ${mid} ${sy} ${mid} ${ey} ${ex} ${ey}`;
+}
+
+function spurPath(sx: number, sy: number, ex: number, ey: number): string {
+  return `M ${sx} ${sy} L ${ex} ${ey}`;
+}
+
+// ── Deterministic color from ingredient name / node id ───────────────────────
+// Used as a reliable fallback when canvas pixel extraction is unavailable.
+// FNV-1a hash spread through the golden angle gives visually distinct hues.
+
+function hashColor(str: string): string {
+  let h = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  const hue = Math.round((h % 360) * 137.508) % 360;
+  return `hsl(${hue}, 72%, 50%)`;
+}
+
+function nodeHashColor(nodeData: any): string {
+  const name = nodeData?.visualDescription || nodeData?.text || nodeData?.id || '';
+  return hashColor(name);
+}
+
+// ── Canvas-based average color extraction ────────────────────────────────────
+// Samples the dominant non-white, non-transparent pixel. Works when Firebase
+// Storage returns CORS headers; silently falls back to null on CORS block.
+
+function extractColor(url: string): Promise<string | null> {
+  return new Promise(resolve => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => {
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = 16; canvas.height = 16;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) { resolve(null); return; }
+        ctx.drawImage(img, 0, 0, 16, 16);
+        const px = ctx.getImageData(0, 0, 16, 16).data;
+        let r = 0, g = 0, b = 0, n = 0;
+        for (let i = 0; i < px.length; i += 4) {
+          if (px[i + 3] < 80) continue;
+          if (px[i] > 230 && px[i + 1] > 230 && px[i + 2] > 230) continue;
+          r += px[i]; g += px[i + 1]; b += px[i + 2]; n++;
+        }
+        resolve(n > 8 ? `rgb(${Math.round(r/n)},${Math.round(g/n)},${Math.round(b/n)})` : null);
+      } catch { resolve(null); }
+    };
+    img.onerror = () => resolve(null);
+    img.src = url;
+  });
+}
+
+// useIconColor: attempts canvas extraction, falls back to hashColor.
+// nodeData is used only for the hash fallback; iconUrl for canvas.
+function useIconColor(iconUrl: string | undefined, nodeData: any): string {
+  const base = nodeHashColor(nodeData);
+  const [canvasColor, setCanvasColor] = useState<string | null>(null);
+  useEffect(() => {
+    if (!iconUrl) { setCanvasColor(null); return; }
+    let cancelled = false;
+    extractColor(iconUrl).then(c => { if (!cancelled) setCanvasColor(c); });
+    return () => { cancelled = true; };
+  }, [iconUrl]);
+  return canvasColor ?? base;
+}
+
+interface TimelineEdgeProps {
+  id: string;
+  source: string;
+  target: string;
+  data?: { lineColor?: string; kind?: 'chain' | 'spur' };
+}
+
+function TimelineEdge({ id, source, target, data }: TimelineEdgeProps) {
+  const sourceNode = useStore(useCallback((s: any) => s.nodeInternals.get(source), [source]));
+  const targetNode = useStore(useCallback((s: any) => s.nodeInternals.get(target), [target]));
+
+  // Leaf source = a chain edge whose source has no incoming chain edges.
+  // Leaf edges get a solid gradient; non-leaf edges get a stripe pattern.
+  const sourceHasIncomingChain = useStore(useCallback((s: any) => {
+    const edges: any[] = Array.isArray(s.edges) ? s.edges : [];
+    return edges.some((e: any) => e.target === source && e.data?.kind === 'chain');
+  }, [source]));
+
+  const isSpurEdge = data?.kind === 'spur';
+
+  let srcIconUrl: string | undefined;
+  let tgtIconUrl: string | undefined;
+  try {
+    srcIconUrl = sourceNode?.data
+      ? getNodeIconUrlAt(sourceNode.data, Math.max(0, currentShortlistIndex(sourceNode.data)))
+      : undefined;
+    tgtIconUrl = targetNode?.data
+      ? getNodeIconUrlAt(targetNode.data, Math.max(0, currentShortlistIndex(targetNode.data)))
+      : undefined;
+  } catch { /* missing visualDescription — canvas fallback will be null, hash color used */ }
+
+  const srcColor = useIconColor(srcIconUrl, sourceNode?.data);
+  const tgtColor = useIconColor(tgtIconUrl, targetNode?.data);
+
+  if (!sourceNode || !targetNode) return null;
+
+  const sp = sourceNode.positionAbsolute ?? sourceNode.position;
+  const tp = targetNode.positionAbsolute ?? targetNode.position;
+
+  // ── Spur edge (ingredient → action) ────────────────────────────────────────
+  if (isSpurEdge) {
+    const sx = sp.x + R, sy = sp.y + R;
+    const ex = tp.x + R, ey = tp.y + R;
+    return (
+      <path
+        id={id}
+        className="react-flow__edge-path"
+        d={spurPath(sx, sy, ex, ey)}
+        fill="none"
+        opacity={0.8}
+        style={{ stroke: srcColor, strokeWidth: CHAIN_W, strokeLinecap: 'round' }}
+      />
+    );
+  }
+
+  // ── Chain edge (action → action) ────────────────────────────────────────────
+  const sx = sp.x + R, sy = sp.y + R;
+  const ex = tp.x + R, ey = tp.y + R;
+  const d  = chainPath(sx, sy, ex, ey);
+  // Stripe mode: all chain edges except leaves (no predecessor).
+  // Two interleaved dashed paths create alternating colour stripes.
+  if (sourceHasIncomingChain) {
+    return (
+      <g>
+        {/* White ghost for readability against coloured lane backgrounds */}
+        <path d={d} fill="none" stroke="white" strokeWidth={CHAIN_W + 3} strokeLinecap="butt" opacity={0.4} />
+        {/* Stripe A — source colour */}
+        <path
+          d={d} fill="none"
+          stroke={srcColor}
+          strokeWidth={CHAIN_W}
+          strokeDasharray="16 16"
+          strokeDashoffset="0"
+          strokeLinecap="butt"
+        />
+        {/* Stripe B — target colour, offset by half-dash to interleave */}
+        <path
+          d={d} fill="none"
+          stroke={tgtColor}
+          strokeWidth={CHAIN_W}
+          strokeDasharray="16 16"
+          strokeDashoffset="16"
+          strokeLinecap="butt"
+        />
+      </g>
+    );
+  }
+
+  // Solid edge for leaf sources (first node in a chain).
+  // style={{}} beats ReactFlow's .react-flow__edge-path { stroke: #b1b1b7; stroke-width: 1 } rule.
+  return (
+    <g>
+      {/* White ghost so the line reads against coloured lane backgrounds */}
+      <path d={d} fill="none" stroke="white" strokeWidth={CHAIN_W + 3} strokeLinecap="round" opacity={0.45} />
+      <path
+        id={id}
+        className="react-flow__edge-path"
+        d={d}
+        fill="none"
+        style={{ stroke: srcColor, strokeWidth: CHAIN_W, strokeLinecap: 'round' }}
+      />
+    </g>
+  );
+}
+
+export default memo(TimelineEdge);

--- a/recipe-lanes/components/recipe-lanes/nodes/timeline-node.tsx
+++ b/recipe-lanes/components/recipe-lanes/nodes/timeline-node.tsx
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+'use client';
+
+import React, { memo, useState } from 'react';
+import { Handle, Position } from 'reactflow';
+import { useSearchParams } from 'next/navigation';
+import { useRecipeStore } from '@/lib/stores/recipe-store';
+import {
+    getNodeIngredientName,
+    getNodeIconId,
+    getNodeShortlistKey,
+    getNodeIconUrlAt,
+    currentShortlistIndex,
+} from '@/lib/recipe-lanes/model-utils';
+import { forgeIconAction } from '@/app/actions';
+
+const NODE_R   = 20;              // must match TL.NODE_R
+const DIAMETER = NODE_R * 2;     // 40px
+const INNER_R  = NODE_R - 3;     // 17px — image clip
+
+const BTN: React.CSSProperties = {
+    position: 'absolute',
+    width: 18,
+    height: 18,
+    borderRadius: '50%',
+    border: '1.5px solid white',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer',
+    zIndex: 50,
+    fontSize: 11,
+    color: 'white',
+    lineHeight: 1,
+};
+
+const TimelineNode: React.FC<any> = ({ data, selected, id }) => {
+    const [isForging, setIsForging]   = useState(false);
+    const searchParams                = useSearchParams();
+    const recipeId                    = searchParams.get('id');
+
+    const storeNode      = useRecipeStore(s => s.graph?.nodes.find(n => n.id === id));
+    const cycleShortlist = useRecipeStore(s => s.cycleShortlist);
+    const node           = storeNode ?? data;
+
+    const currentIndex = Math.max(0, currentShortlistIndex(node));
+    const iconUrl      = getNodeIconUrlAt(node, currentIndex);
+    const shortlistKey = getNodeShortlistKey(node);
+
+    // Clear forge state when the shortlist key changes (forge result arrived)
+    const [prevKey, setPrevKey] = useState(shortlistKey);
+    if (shortlistKey !== prevKey) {
+        setPrevKey(shortlistKey);
+        if (isForging) setIsForging(false);
+    }
+
+    const isIngredient = data.type === 'ingredient';
+    const lineColor    = data.lineColor ?? '#D4D4D8';
+    const borderColor  = selected ? '#6366f1' : lineColor;
+
+    const handleReroll = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        cycleShortlist(id);
+    };
+
+    const handleForge = async (e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (isForging) return;
+        setIsForging(true);
+        try {
+            const res = await forgeIconAction(
+                recipeId ?? '',
+                getNodeIngredientName(data),
+                getNodeIconId(data) ?? '',
+            );
+            if (res && !res.success) setIsForging(false);
+        } catch {
+            setIsForging(false);
+        }
+    };
+
+    const handleDelete = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        data.onDelete?.();
+    };
+
+    const handleTouchStart = () => {
+        if (data.onSetLongPress) {
+            const t = setTimeout(() => data.onSetLongPress(true), 300);
+            (handleTouchStart as any)._t = t;
+        }
+    };
+
+    const handleTouchEnd = () => {
+        clearTimeout((handleTouchStart as any)._t);
+        setTimeout(() => data.onSetLongPress?.(false), 500);
+    };
+
+    return (
+        <div
+            className="group"
+            style={{ position: 'relative', width: DIAMETER, height: DIAMETER }}
+            onTouchStart={handleTouchStart}
+            onTouchEnd={handleTouchEnd}
+        >
+            {/* Invisible handles — positions are overridden in TimelineEdge */}
+            <Handle
+                type="target"
+                position={Position.Left}
+                style={{ opacity: 0, width: 1, height: 1, top: '50%', left: '50%' }}
+            />
+            <Handle
+                type="source"
+                position={Position.Right}
+                style={{ opacity: 0, width: 1, height: 1, top: '50%', left: '50%' }}
+            />
+
+            {/* Selection halo */}
+            {selected && (
+                <div style={{
+                    position: 'absolute',
+                    top: -5, left: -5,
+                    width: DIAMETER + 10, height: DIAMETER + 10,
+                    borderRadius: '50%',
+                    border: '2px dashed #6366f1',
+                    opacity: 0.5,
+                    pointerEvents: 'none',
+                }} />
+            )}
+
+            {/* Circle body */}
+            <div style={{
+                width: DIAMETER,
+                height: DIAMETER,
+                borderRadius: '50%',
+                background: 'white',
+                border: `${selected ? 3 : isIngredient ? 1.5 : 2}px ${isIngredient ? 'dashed' : 'solid'} ${borderColor}`,
+                boxSizing: 'border-box',
+                overflow: 'hidden',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+            }}>
+                {iconUrl ? (
+                    <img
+                        src={iconUrl}
+                        alt=""
+                        style={{ width: INNER_R * 2, height: INNER_R * 2, objectFit: 'contain' }}
+                    />
+                ) : (
+                    <span style={{ fontSize: 16 }}>{isIngredient ? '🥕' : '⚡'}</span>
+                )}
+            </div>
+
+            {/* Label below the circle */}
+            <div style={{
+                position: 'absolute',
+                top: DIAMETER + 5,
+                left: '50%',
+                transform: 'translateX(-50%)',
+                fontSize: 8,
+                fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+                color: '#3f3f46',
+                textAlign: 'center',
+                whiteSpace: 'nowrap',
+                pointerEvents: 'none',
+                textShadow: '0 0 3px rgba(255,255,255,0.9)',
+            }}>
+                {data.text}
+                {data.duration && (
+                    <div style={{ fontSize: 7, color: '#a1a1aa', fontFamily: 'ui-monospace, monospace', marginTop: 1 }}>
+                        {data.duration}
+                    </div>
+                )}
+            </div>
+
+            {/* Hover buttons — reroll (↺), forge (⚒), delete (×) */}
+            <button
+                onClick={handleReroll}
+                className="nodrag opacity-0 group-hover:opacity-100 transition-opacity"
+                style={{ ...BTN, top: -9, left: -9, background: '#3b82f6' }}
+                title="Cycle shortlist"
+            >↺</button>
+
+            <button
+                onClick={handleForge}
+                className="nodrag opacity-0 group-hover:opacity-100 transition-opacity"
+                style={{
+                    ...BTN,
+                    top: -9,
+                    left: '50%',
+                    transform: 'translateX(-50%)',
+                    background: isForging ? '#f59e0b' : '#92400e',
+                    cursor: isForging ? 'not-allowed' : 'pointer',
+                }}
+                title="Forge new icon"
+            >{isForging ? '…' : '⚒'}</button>
+
+            <button
+                onClick={handleDelete}
+                className="nodrag opacity-0 group-hover:opacity-100 transition-opacity"
+                style={{ ...BTN, top: -9, right: -9, background: '#ef4444' }}
+                title="Delete"
+            >×</button>
+        </div>
+    );
+};
+
+export default memo(TimelineNode);

--- a/recipe-lanes/components/recipe-lanes/react-flow-diagram.tsx
+++ b/recipe-lanes/components/recipe-lanes/react-flow-diagram.tsx
@@ -40,7 +40,10 @@ import { getNodeIconUrl, getNodeIconId, preserveNodeShortlist, getNodeShortlistL
 import MinimalNode from './nodes/minimal-node';
 import LaneNode from './nodes/lane-node';
 import MicroNode from './nodes/micro-node';
+import TimelineNode from './nodes/timeline-node';
 import FloatingEdge from './edges/floating-edge';
+import TimelineEdge from './edges/timeline-edge';
+import TimelineBackground, { type TimelineData } from './timeline-background';
 import { toPng } from 'html-to-image';
 import { Download, Share2, Undo, Redo, Check, Save } from 'lucide-react';
 import { useHistoryManager } from './hooks/useHistoryManager';
@@ -73,11 +76,13 @@ export interface ReactFlowDiagramHandle {
 const INITIAL_NODE_TYPES = {
     minimal: MinimalNode,
     lane: LaneNode,
-    micro: MicroNode
+    micro: MicroNode,
+    'timeline-node': TimelineNode,
 };
 
 const INITIAL_EDGE_TYPES = {
-    floating: FloatingEdge
+    floating: FloatingEdge,
+    timeline: TimelineEdge,
 };
 
 const DiagramInner = memo(forwardRef<ReactFlowDiagramHandle, ReactFlowDiagramProps>(({ graph, mode, spacing = 1, edgeStyle = 'straight', textPos = 'bottom', isLive = false, onInteraction, onEdit, onSave, isPublic: propIsPublic, onVisibilityChange, isLoggedIn = false, onNotify, isOwner = false, iconTheme = 'classic' }, ref) => {
@@ -94,6 +99,7 @@ const DiagramInner = memo(forwardRef<ReactFlowDiagramHandle, ReactFlowDiagramPro
     const getEdges = getEdgesRaw as () => any[];
     const flowWrapper = useRef<HTMLDivElement>(null);
     const simulationRef = useRef<any>(null);
+    const [timelineData, setTimelineData] = useState<TimelineData | null>(null);
     const {
         copied,
         saved,
@@ -218,7 +224,7 @@ const DiagramInner = memo(forwardRef<ReactFlowDiagramHandle, ReactFlowDiagramPro
         const canPreserve = shouldUseSavedLayout;
 
         if (canPreserve) {
-            const safeMode = (['swimlanes', 'dagre', 'dagre-lr'].includes(mode as string)) ? (mode as LayoutMode) : 'dagre';
+            const safeMode = (['swimlanes', 'dagre', 'dagre-lr', 'timeline'].includes(mode as string)) ? (mode as LayoutMode) : 'dagre';
             layout = calculateLayout(effectiveGraph, safeMode, spacing, true);
         } else if (mode === 'repulsive') {
             layout = calculateRepulsiveCurvesLayout(effectiveGraph, spacing);
@@ -226,51 +232,86 @@ const DiagramInner = memo(forwardRef<ReactFlowDiagramHandle, ReactFlowDiagramPro
             layout = calculateLayout(effectiveGraph, mode as LayoutMode, spacing);
         }
 
+        const isTimeline = mode === 'timeline';
+
         const newNodes: Node[] = [];
-        
+
         layout.lanes.forEach(lane => {
              newNodes.push({
                  id: lane.id,
                  type: 'lane',
                  position: { x: lane.x, y: lane.y },
                  data: { label: lane.label, color: lane.color },
-                 style: { width: lane.width, height: lane.height, zIndex: -1 },
+                 style: {
+                     width: lane.width,
+                     height: lane.height,
+                     zIndex: -1,
+                     // In timeline mode: colored band background + no pointer events so
+                     // clicking empty space deselects nodes correctly.
+                     ...(isTimeline ? { backgroundColor: lane.color, pointerEvents: 'none' } : {}),
+                 },
                  draggable: false,
                  selectable: false,
+                 focusable: false,
                  zIndex: -1
              });
         });
 
-        const nodeType = 'minimal'; 
-        // TODO: Double check the logic here.
         layout.nodes.forEach(n => {
              const originalNode = graph.nodes.find(gn => gn.id === n.id);
+             const nodeType = isTimeline ? 'timeline-node' : 'minimal';
              newNodes.push({
                  id: n.id,
                  type: nodeType,
                  position: { x: n.x, y: n.y },
-                 data: { ...originalNode, ...n.data, textPos, depth: n.depth, onDelete: () => handleDeleteNode(n.id), onSetLongPress: setLongPress, iconTheme },
+                 data: {
+                     ...originalNode, ...n.data,
+                     ...(isTimeline ? { lineColor: n.lineColor } : {}),
+                     textPos, depth: n.depth,
+                     onDelete: () => handleDeleteNode(n.id),
+                     onSetLongPress: setLongPress,
+                     iconTheme,
+                 },
                  width: n.width,
                  height: n.height,
                  draggable: true,
              });
         });
 
-        const newEdges: Edge[] = layout.edges.map(e => ({
-            id: e.id,
-            source: e.sourceId,
-            target: e.targetId,
-            type: 'floating',
-            data: { variant: edgeStyle },
-            style: { stroke: '#9ca3af', strokeWidth: 1.5 },
-            markerEnd: {
-                type: MarkerType.ArrowClosed,
-                color: '#9ca3af',
-                width: 20,
-                height: 20
-            },
-            animated: false
-        }));
+        // Capture timeline grid data so the background can render it.
+        if (isTimeline && layout.timelineData) {
+            setTimelineData(layout.timelineData);
+        } else if (!isTimeline) {
+            setTimelineData(null);
+        }
+
+        const newEdges: Edge[] = layout.edges.map(e => {
+            if (isTimeline) {
+                return {
+                    id: e.id,
+                    source: e.sourceId,
+                    target: e.targetId,
+                    type: 'timeline',
+                    data: { lineColor: e.lineColor, kind: e.kind },
+                    style: {},
+                };
+            }
+            return {
+                id: e.id,
+                source: e.sourceId,
+                target: e.targetId,
+                type: 'floating',
+                data: { variant: edgeStyle },
+                style: { stroke: '#9ca3af', strokeWidth: 1.5 },
+                markerEnd: {
+                    type: MarkerType.ArrowClosed,
+                    color: '#9ca3af',
+                    width: 20,
+                    height: 20,
+                },
+                animated: false,
+            };
+        });
 
         // Sort by Y for depth buffering (Painter's Algo)
         newNodes.sort((a, b) => a.position.y - b.position.y);
@@ -350,6 +391,7 @@ const DiagramInner = memo(forwardRef<ReactFlowDiagramHandle, ReactFlowDiagramPro
             runLayout(true);
             return;
         }
+
 
         if (isDirty || hasInitialLayoutRef.current) {
             // Detect full regeneration: if none of the incoming graph node IDs match
@@ -715,7 +757,10 @@ const DiagramInner = memo(forwardRef<ReactFlowDiagramHandle, ReactFlowDiagramPro
                 onlyRenderVisibleElements={false}
                 multiSelectionKeyCode={['Shift']}
             >
-                <Background color="#f4f4f5" gap={20} />
+                {timelineData
+                    ? <TimelineBackground data={timelineData} />
+                    : <Background color="#f4f4f5" gap={20} />
+                }
                 <Controls showInteractive={false} />
                 <Panel position="top-right" className="flex gap-2">
                     <div className="flex gap-1 mr-2 border-r border-zinc-200 pr-2">

--- a/recipe-lanes/components/recipe-lanes/timeline-background.tsx
+++ b/recipe-lanes/components/recipe-lanes/timeline-background.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+'use client';
+
+import React, { memo } from 'react';
+import { useStore } from 'reactflow';
+
+export interface TimelineData {
+  pixelsPerMin: number;
+  totalMinutes: number;
+  actionZoneY: number;
+  totalHeight: number;
+  rulerHeight: number;
+  laneLabelWidth: number;
+  gridInterval: number;
+}
+
+function TimelineBackground({ data }: { data: TimelineData }) {
+  const transform = useStore((s: any) => s.transform as [number, number, number]);
+  const [tx, ty, scale] = transform;
+
+  const { pixelsPerMin: ppm, totalMinutes, actionZoneY, totalHeight, rulerHeight, laneLabelWidth, gridInterval } = data;
+
+  const toSX = (cx: number) => cx * scale + tx;
+  const toSY = (cy: number) => cy * scale + ty;
+
+  const gridTicks: number[] = [];
+  for (let t = 0; t <= Math.ceil(totalMinutes) + gridInterval; t += gridInterval) {
+    gridTicks.push(t);
+  }
+
+  const gridTop = toSY(rulerHeight);
+  const rulerBot = toSY(rulerHeight);
+
+  return (
+    <svg
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: 'none',
+        zIndex: 0,
+        overflow: 'visible',
+      }}
+    >
+      {/* Ruler background stripe */}
+      <rect
+        x={toSX(laneLabelWidth)}
+        y={toSY(0)}
+        width="100%"
+        height={rulerHeight * scale}
+        fill="white"
+        opacity={0.92}
+      />
+
+      {/* Vertical grid lines + ruler minute labels */}
+      {gridTicks.map(t => {
+        const major = t % 10 === 0;
+        const sx = toSX(laneLabelWidth + t * ppm);
+        return (
+          <g key={t}>
+            <line
+              x1={sx} y1={gridTop}
+              x2={sx} y2="100%"
+              stroke={major ? '#d4d4d8' : '#eeeeee'}
+              strokeWidth={major ? 1 : 0.5}
+              strokeDasharray={major ? undefined : '2 3'}
+            />
+            <text
+              x={sx}
+              y={toSY(rulerHeight - 5)}
+              textAnchor="middle"
+              fontSize={Math.max(9, 12 * scale)}
+              fill={major ? '#52525b' : '#a1a1aa'}
+              fontFamily="ui-monospace, monospace"
+              fontWeight={major ? '600' : '400'}
+            >
+              {t}m
+            </text>
+          </g>
+        );
+      })}
+
+      {/* Ruler bottom border */}
+      <line
+        x1={toSX(laneLabelWidth)} y1={rulerBot}
+        x2="200%" y2={rulerBot}
+        stroke="#d4d4d8" strokeWidth={1}
+      />
+
+      {/* Ingredient zone / action zone separator (dashed) */}
+      <line
+        x1={toSX(laneLabelWidth)} y1={toSY(actionZoneY)}
+        x2="200%" y2={toSY(actionZoneY)}
+        stroke="#e4e4e7" strokeWidth={0.75}
+        strokeDasharray="4 3"
+      />
+
+      {/* Lane label gutter right edge */}
+      <line
+        x1={toSX(laneLabelWidth)} y1={toSY(rulerHeight)}
+        x2={toSX(laneLabelWidth)} y2="100%"
+        stroke="#e4e4e7" strokeWidth={1}
+      />
+    </svg>
+  );
+}
+
+export default memo(TimelineBackground);

--- a/recipe-lanes/components/recipe-lanes/timeline-view.tsx
+++ b/recipe-lanes/components/recipe-lanes/timeline-view.tsx
@@ -1,0 +1,663 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+'use client';
+
+import React, {
+  useMemo, useState, useRef, useCallback, useEffect,
+} from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Play, Pause, RotateCcw, ZoomIn, ZoomOut, Maximize2, Undo2 } from 'lucide-react';
+import {
+  buildTimelineLayout, TL,
+  type TLNode, type TLEdge, type TLLane,
+} from '@/lib/recipe-lanes/timeline-layout';
+import {
+  getNodeIconUrlAt, getNodeIngredientName, getNodeIconId, getNodeShortlistKey,
+} from '@/lib/recipe-lanes/model-utils';
+import { useRecipeStore } from '@/lib/stores/recipe-store';
+import { forgeIconAction } from '@/app/actions';
+import type { RecipeGraph, RecipeNode } from '@/lib/recipe-lanes/types';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const TICK_MS   = 250;
+const TICK_MIN  = 0.5;
+const MIN_SCALE = 0.2;
+const MAX_SCALE = 8;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+interface Viewport { x: number; y: number; scale: number }
+const DEFAULT_VP: Viewport = { x: 16, y: 8, scale: 1 };
+
+type DragState =
+  | { type: 'canvas'; sx: number; sy: number; ox: number; oy: number; moved: boolean }
+  | { type: 'box';    sx: number; sy: number; ex: number; ey: number }
+  | { type: 'node';   nodeId: string; movers: string[]; sx: number; sy: number;
+      origPositions: Map<string, { cx: number; cy: number }>; moved: boolean; shiftHeld: boolean };
+
+// ── Ancestor walk ─────────────────────────────────────────────────────────────
+function getAncestorIds(nodeId: string, nodes: RecipeNode[]): string[] {
+  const map = new Map(nodes.map(n => [n.id, n]));
+  const out = new Set<string>();
+  const walk = (id: string) => {
+    for (const pid of map.get(id)?.inputs ?? []) {
+      if (!out.has(pid)) { out.add(pid); walk(pid); }
+    }
+  };
+  walk(nodeId);
+  return [...out];
+}
+
+// ── Edge paths ────────────────────────────────────────────────────────────────
+function chainPath(x1: number, y1: number, x2: number, y2: number): string {
+  const sx = x1 + TL.NODE_R, ex = x2 - TL.NODE_R;
+  if (sx >= ex) return `M ${sx} ${y1} L ${ex} ${y2}`;
+  if (Math.abs(y2 - y1) < 1) return `M ${sx} ${y1} H ${ex}`;
+  const mid = (sx + ex) / 2;
+  return `M ${sx} ${y1} C ${mid} ${y1} ${mid} ${y2} ${ex} ${y2}`;
+}
+function spurPath(x1: number, y1: number, x2: number, y2: number): string {
+  return `M ${x1} ${y1 + TL.NODE_R} L ${x2} ${y2 - TL.NODE_R}`;
+}
+
+// ── Node controls (↺ reroll, ⚒ forge, × delete) ───────────────────────────
+function NodeControls({ cx, cy, isForging, onReroll, onForge, onDelete }: {
+  cx: number; cy: number; isForging: boolean;
+  onReroll: (e: React.MouseEvent) => void;
+  onForge:  (e: React.MouseEvent) => void;
+  onDelete: (e: React.MouseEvent) => void;
+}) {
+  const y = cy - TL.NODE_R;
+  return (
+    <g onMouseDown={e => e.stopPropagation()}>
+      <g onClick={onReroll} style={{ cursor: 'pointer' }}>
+        <circle cx={cx - 18} cy={y} r={8} fill="#3b82f6" stroke="white" strokeWidth={1.5}/>
+        <text x={cx - 18} y={y} textAnchor="middle" dominantBaseline="middle" fontSize={11} fill="white">↺</text>
+      </g>
+      <g onClick={onForge} style={{ cursor: isForging ? 'not-allowed' : 'pointer' }}>
+        <circle cx={cx} cy={y} r={8} fill={isForging ? '#f59e0b' : '#92400e'} stroke="white" strokeWidth={1.5}/>
+        <text x={cx} y={y} textAnchor="middle" dominantBaseline="middle" fontSize={10} fill="white">
+          {isForging ? '…' : '⚒'}
+        </text>
+      </g>
+      <g onClick={onDelete} style={{ cursor: 'pointer' }}>
+        <circle cx={cx + 18} cy={y} r={8} fill="#ef4444" stroke="white" strokeWidth={1.5}/>
+        <text x={cx + 18} y={y} textAnchor="middle" dominantBaseline="middle" fontSize={11} fill="white">×</text>
+      </g>
+    </g>
+  );
+}
+
+// ── Shared node props ─────────────────────────────────────────────────────────
+interface NodeProps {
+  node: TLNode; cx: number; cy: number;
+  lineColor: string; playbackMin: number | null;
+  isHovered: boolean; isSelected: boolean; isForging: boolean;
+  onMouseDown:  (e: React.MouseEvent) => void;
+  onMouseEnter: () => void; onMouseLeave: () => void;
+  onReroll: (e: React.MouseEvent) => void;
+  onForge:  (e: React.MouseEvent) => void;
+  onDelete: () => void;
+}
+
+// ── Action node ───────────────────────────────────────────────────────────────
+function ActionNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSelected, isForging,
+  onMouseDown, onMouseEnter, onMouseLeave, onReroll, onForge, onDelete }: NodeProps) {
+  const { data } = node;
+  const iconUrl = getNodeIconUrlAt(data, Math.max(0, data.shortlistIndex ?? 0));
+  const clipId  = `tl-a-${node.id.replace(/\W/g, '')}`;
+  const innerR  = TL.NODE_R - 3;
+
+  const endMin   = node.startMin + node.durationMin;
+  const isDone   = playbackMin !== null && playbackMin >= endMin;
+  const isActive = playbackMin !== null && playbackMin >= node.startMin && !isDone;
+
+  const ring  = isSelected ? '#6366f1' : lineColor;
+  const ringW = isSelected ? 3 : isActive ? 3 : 2;
+
+  return (
+    <g opacity={isDone ? 0.4 : 1} style={{ cursor: 'pointer' }}
+      onMouseDown={onMouseDown}
+      onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+      {isActive   && <circle cx={cx} cy={cy} r={TL.NODE_R + 8} fill={lineColor} opacity={0.15}/>}
+      {isSelected && <circle cx={cx} cy={cy} r={TL.NODE_R + 4} fill="none" stroke="#6366f1" strokeWidth={1.5} opacity={0.5}/>}
+      <circle cx={cx} cy={cy} r={TL.NODE_R}
+        fill={isDone ? '#f4f4f5' : 'white'} stroke={ring} strokeWidth={ringW}/>
+      {iconUrl ? (
+        <>
+          <clipPath id={clipId}><circle cx={cx} cy={cy} r={innerR}/></clipPath>
+          <image href={iconUrl} x={cx - innerR} y={cy - innerR}
+            width={innerR * 2} height={innerR * 2}
+            clipPath={`url(#${clipId})`} preserveAspectRatio="xMidYMid slice"/>
+        </>
+      ) : (
+        <text x={cx} y={cy} textAnchor="middle" dominantBaseline="middle"
+          fontSize={12} fill={lineColor} fontWeight="700">⚡</text>
+      )}
+      <text x={cx} y={cy + TL.NODE_R + 9}
+        textAnchor="middle" fontSize={8} fill={isDone ? '#a1a1aa' : '#3f3f46'}
+        fontFamily="ui-sans-serif, system-ui, sans-serif">{data.text}</text>
+      {!isHovered && data.duration && playbackMin === null && (
+        <text x={cx} y={cy - TL.NODE_R - 5}
+          textAnchor="middle" fontSize={8} fill="#a1a1aa" fontFamily="ui-monospace, monospace">
+          {data.duration}
+        </text>
+      )}
+      {isHovered && (
+        <NodeControls cx={cx} cy={cy} isForging={isForging}
+          onReroll={onReroll} onForge={onForge}
+          onDelete={e => { e.stopPropagation(); onDelete(); }}/>
+      )}
+    </g>
+  );
+}
+
+// ── Ingredient node ───────────────────────────────────────────────────────────
+function IngredientNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSelected, isForging,
+  onMouseDown, onMouseEnter, onMouseLeave, onReroll, onForge, onDelete }: NodeProps) {
+  const { data } = node;
+  const iconUrl = getNodeIconUrlAt(data, Math.max(0, data.shortlistIndex ?? 0));
+  const clipId  = `tl-i-${node.id.replace(/\W/g, '')}`;
+  const innerR  = TL.NODE_R - 3;
+  const ring = isSelected ? '#6366f1' : lineColor;
+
+  return (
+    <g opacity={playbackMin !== null ? 0.6 : 1} style={{ cursor: 'pointer' }}
+      onMouseDown={onMouseDown}
+      onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+      {isSelected && <circle cx={cx} cy={cy} r={TL.NODE_R + 4} fill="none" stroke="#6366f1" strokeWidth={1.5} opacity={0.5}/>}
+      <circle cx={cx} cy={cy} r={TL.NODE_R}
+        fill="white" stroke={ring} strokeWidth={isSelected ? 2.5 : 1.5} strokeDasharray="3 2"/>
+      {iconUrl ? (
+        <>
+          <clipPath id={clipId}><circle cx={cx} cy={cy} r={innerR}/></clipPath>
+          <image href={iconUrl} x={cx - innerR} y={cy - innerR}
+            width={innerR * 2} height={innerR * 2}
+            clipPath={`url(#${clipId})`} preserveAspectRatio="xMidYMid slice"/>
+        </>
+      ) : (
+        <text x={cx} y={cy} textAnchor="middle" dominantBaseline="middle" fontSize={10} fill={lineColor}>·</text>
+      )}
+      <text x={cx} y={cy + TL.NODE_R + 9}
+        textAnchor="middle" fontSize={8} fill="#52525b"
+        fontFamily="ui-sans-serif, system-ui, sans-serif">{data.text}</text>
+      {isHovered && (
+        <NodeControls cx={cx} cy={cy} isForging={isForging}
+          onReroll={onReroll} onForge={onForge}
+          onDelete={e => { e.stopPropagation(); onDelete(); }}/>
+      )}
+    </g>
+  );
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+export function TimelineView({ graph }: { graph: RecipeGraph }) {
+  const searchParams   = useSearchParams();
+  const recipeId       = searchParams.get('id');
+  const cycleShortlist = useRecipeStore(s => s.cycleShortlist);
+  const setGraph       = useRecipeStore(s => s.setGraph);
+
+  const layout = useMemo(() => buildTimelineLayout(graph), [graph]);
+  const { nodes, edges, lanes, totalMinutes, totalWidth, totalHeight, pixelsPerMin: ppm, actionZoneY } = layout;
+
+  // ── Playback ──────────────────────────────────────────────────────────────
+  const [playbackMin, setPlaybackMin] = useState<number | null>(null);
+  const [isPlaying,   setIsPlaying]   = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const stopInterval = useCallback(() => {
+    if (intervalRef.current) { clearInterval(intervalRef.current); intervalRef.current = null; }
+  }, []);
+  const pause     = useCallback(() => { setIsPlaying(false); stopInterval(); }, [stopInterval]);
+  const play      = useCallback(() => {
+    setIsPlaying(true);
+    setPlaybackMin(p => (p === null || p >= layout.totalMinutes + 1) ? 0 : p);
+    stopInterval();
+    intervalRef.current = setInterval(() => {
+      setPlaybackMin(p => {
+        const n = (p ?? 0) + TICK_MIN;
+        if (n > layout.totalMinutes + 1) { stopInterval(); setIsPlaying(false); return layout.totalMinutes + 1; }
+        return n;
+      });
+    }, TICK_MS);
+  }, [layout.totalMinutes, stopInterval]);
+  const resetPlay = useCallback(() => { pause(); setPlaybackMin(null); }, [pause]);
+  useEffect(() => () => stopInterval(), [stopInterval]);
+
+  // ── Undo ──────────────────────────────────────────────────────────────────
+  const [undoStack, setUndoStack] = useState<RecipeGraph[]>([]);
+  const pushUndo = useCallback((s: RecipeGraph) => setUndoStack(p => [...p.slice(-49), s]), []);
+  const undo = useCallback(() => {
+    setUndoStack(prev => {
+      if (!prev.length) return prev;
+      const next = [...prev];
+      setGraph(next.pop()!);
+      return next;
+    });
+  }, [setGraph]);
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'z' && !e.shiftKey) { e.preventDefault(); undo(); }
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [undo]);
+
+  // ── Forge state ───────────────────────────────────────────────────────────
+  const [forgingIds, setForgingIds]   = useState<Set<string>>(new Set());
+  const forgingIdsRef                 = useRef(forgingIds);
+  const prevShortlistKeysRef          = useRef<Map<string, string>>(new Map());
+  useEffect(() => { forgingIdsRef.current = forgingIds; }, [forgingIds]);
+
+  // Clear forge when shortlist key changes (forge result arrived)
+  useEffect(() => {
+    const curr = forgingIdsRef.current;
+    if (!curr.size) return;
+    const toRemove: string[] = [];
+    for (const id of curr) {
+      const node   = graph.nodes.find(n => n.id === id);
+      const prev   = prevShortlistKeysRef.current.get(id);
+      const newKey = node ? getNodeShortlistKey(node) : 'gone';
+      if (prev !== undefined && prev !== newKey) toRemove.push(id);
+      if (node) prevShortlistKeysRef.current.set(id, newKey);
+    }
+    if (toRemove.length)
+      setForgingIds(p => { const n = new Set(p); toRemove.forEach(id => n.delete(id)); return n; });
+  }, [graph.nodes]); // intentionally excludes forgingIds
+
+  const handleForge = useCallback(async (nodeId: string, data: RecipeNode) => {
+    if (forgingIdsRef.current.has(nodeId)) return;
+    prevShortlistKeysRef.current.set(nodeId, getNodeShortlistKey(data));
+    setForgingIds(p => new Set([...p, nodeId]));
+    try {
+      const res = await forgeIconAction(recipeId ?? '', getNodeIngredientName(data), getNodeIconId(data) ?? '');
+      if (res && !res.success)
+        setForgingIds(p => { const n = new Set(p); n.delete(nodeId); return n; });
+    } catch {
+      setForgingIds(p => { const n = new Set(p); n.delete(nodeId); return n; });
+    }
+  }, [recipeId]);
+
+  // ── Selection ─────────────────────────────────────────────────────────────
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const selectedIdsRef                = useRef(selectedIds);
+  useEffect(() => { selectedIdsRef.current = selectedIds; }, [selectedIds]);
+
+  // ── Position overrides ────────────────────────────────────────────────────
+  const [posOverrides, setPosOverrides] = useState<Map<string, { cx: number; cy: number }>>(new Map());
+  const posOverridesRef                 = useRef(posOverrides);
+  useEffect(() => { posOverridesRef.current = posOverrides; }, [posOverrides]);
+
+  // ── Hover ─────────────────────────────────────────────────────────────────
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+
+  // ── Box select (state for rendering) ─────────────────────────────────────
+  const [boxRect, setBoxRect] = useState<{ sx: number; sy: number; ex: number; ey: number } | null>(null);
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+  const deleteNode = useCallback((nodeId: string) => {
+    pushUndo(graph);
+    setGraph({ ...graph, nodes: graph.nodes.filter(n => n.id !== nodeId) });
+    setPosOverrides(p => { const n = new Map(p); n.delete(nodeId); return n; });
+    setSelectedIds(p => { const n = new Set(p); n.delete(nodeId); return n; });
+    setHoveredNodeId(null);
+  }, [graph, setGraph, pushUndo]);
+
+  // ── Viewport / drag ───────────────────────────────────────────────────────
+  const [vp, setVp]       = useState<Viewport>(DEFAULT_VP);
+  const vpRef             = useRef(vp);
+  const svgRef            = useRef<SVGSVGElement>(null);
+  const dragRef           = useRef<DragState | null>(null);
+  const graphNodesRef     = useRef(graph.nodes);
+  const tlNodesRef        = useRef(nodes);
+  useEffect(() => { vpRef.current         = vp; }, [vp]);
+  useEffect(() => { graphNodesRef.current = graph.nodes; }, [graph.nodes]);
+  useEffect(() => { tlNodesRef.current    = nodes; }, [nodes]);
+
+  // Wheel zoom (non-passive)
+  useEffect(() => {
+    const el = svgRef.current;
+    if (!el) return;
+    const fn = (e: WheelEvent) => {
+      e.preventDefault();
+      const f    = e.deltaY < 0 ? 1.15 : 1 / 1.15;
+      const rect = el.getBoundingClientRect();
+      setVp(prev => {
+        const ns = Math.max(MIN_SCALE, Math.min(MAX_SCALE, prev.scale * f));
+        const cx = (e.clientX - rect.left - prev.x) / prev.scale;
+        const cy = (e.clientY - rect.top  - prev.y) / prev.scale;
+        return { scale: ns, x: e.clientX - rect.left - cx * ns, y: e.clientY - rect.top - cy * ns };
+      });
+    };
+    el.addEventListener('wheel', fn, { passive: false });
+    return () => el.removeEventListener('wheel', fn);
+  }, []);
+
+  const onCanvasMouseDown = useCallback((e: React.MouseEvent) => {
+    if (e.button !== 0) return;
+    dragRef.current = { type: 'canvas', sx: e.clientX, sy: e.clientY, ox: vp.x, oy: vp.y, moved: false };
+  }, [vp]);
+
+  const onNodeMouseDown = useCallback((e: React.MouseEvent, node: TLNode) => {
+    e.stopPropagation();
+    if (e.button !== 0) return;
+
+    const sel    = selectedIdsRef.current;
+    const isSel  = sel.has(node.id);
+    const movers = isSel && sel.size > 1 ? [...Array.from(sel)] : [node.id];
+
+    const orig = new Map<string, { cx: number; cy: number }>();
+    for (const mid of movers) {
+      const mn = tlNodesRef.current.find(n => n.id === mid);
+      if (mn) orig.set(mid, posOverridesRef.current.get(mid) ?? { cx: mn.cx, cy: mn.cy });
+    }
+    // shiftHeld recorded here so onMouseMove can check it at drag-start (mirrors onNodeDragStart in DAG)
+    dragRef.current = { type: 'node', nodeId: node.id, movers, sx: e.clientX, sy: e.clientY, origPositions: orig, moved: false, shiftHeld: e.shiftKey };
+  }, []);
+
+  const onMouseMove = useCallback((e: React.MouseEvent) => {
+    const d = dragRef.current;
+    if (!d) return;
+
+    if (d.type === 'canvas') {
+      const dx = e.clientX - d.sx, dy = e.clientY - d.sy;
+      if (Math.abs(dx) > 3 || Math.abs(dy) > 3) d.moved = true;
+      setVp(prev => ({ ...prev, x: d.ox + dx, y: d.oy + dy }));
+    } else if (d.type === 'box') {
+      d.ex = e.clientX; d.ey = e.clientY;
+      setBoxRect({ sx: d.sx, sy: d.sy, ex: d.ex, ey: d.ey });
+    } else {
+      const dx = (e.clientX - d.sx) / vpRef.current.scale;
+      const dy = (e.clientY - d.sy) / vpRef.current.scale;
+      if (Math.abs(dx) > 3 || Math.abs(dy) > 3 || d.moved) {
+        if (!d.moved) {
+          d.moved = true;
+          // ── Pivot: same trigger as onNodeDragStart in DAG view ────────────────
+          // Check shiftKey at the moment drag actually begins (not at mousedown),
+          // then add all ancestors to movers + capture their current positions.
+          if (d.shiftHeld || e.shiftKey) {
+            const ancestors = getAncestorIds(d.nodeId, graphNodesRef.current);
+            for (const aid of ancestors) {
+              if (!d.movers.includes(aid)) {
+                d.movers.push(aid);
+                const an = tlNodesRef.current.find(n => n.id === aid);
+                if (an) d.origPositions.set(aid, posOverridesRef.current.get(aid) ?? { cx: an.cx, cy: an.cy });
+              }
+            }
+          }
+        }
+        setPosOverrides(prev => {
+          const next = new Map(prev);
+          for (const [mid, o] of d.origPositions) next.set(mid, { cx: o.cx + dx, cy: o.cy + dy });
+          return next;
+        });
+      }
+    }
+  }, []);
+
+  const onMouseUp = useCallback((e: React.MouseEvent) => {
+    const d = dragRef.current;
+    dragRef.current = null;
+    if (!d) return;
+
+    if (d.type === 'box') {
+      setBoxRect(null);
+      const el = svgRef.current;
+      if (!el) return;
+      const r  = el.getBoundingClientRect();
+      const cv = vpRef.current;
+      const toC = (sx: number, sy: number) => ({
+        cx: (sx - r.left - cv.x) / cv.scale,
+        cy: (sy - r.top  - cv.y) / cv.scale,
+      });
+      const p1 = toC(Math.min(d.sx, d.ex), Math.min(d.sy, d.ey));
+      const p2 = toC(Math.max(d.sx, d.ex), Math.max(d.sy, d.ey));
+      const hit = nodes
+        .filter(n => {
+          const pos = posOverridesRef.current.get(n.id) ?? { cx: n.cx, cy: n.cy };
+          return pos.cx >= p1.cx && pos.cx <= p2.cx && pos.cy >= p1.cy && pos.cy <= p2.cy;
+        })
+        .map(n => n.id);
+      setSelectedIds(prev => new Set([...(e.shiftKey ? prev : []), ...hit]));
+      return;
+    }
+
+    if (d.type === 'canvas' && !d.moved) {
+      setSelectedIds(new Set());
+      return;
+    }
+
+    if (d.type === 'node' && !d.moved) {
+      if (d.shiftHeld) {
+        setSelectedIds(prev => { const n = new Set(prev); n.has(d.nodeId) ? n.delete(d.nodeId) : n.add(d.nodeId); return n; });
+      } else {
+        // Select clicked node + all its ancestors (everything feeding into it)
+        const ancestors = getAncestorIds(d.nodeId, graphNodesRef.current);
+        setSelectedIds(new Set([d.nodeId, ...ancestors]));
+      }
+    }
+  }, [nodes]);
+
+  const zoomBy    = useCallback((f: number) => {
+    setVp(prev => {
+      const el  = svgRef.current;
+      const w   = el ? el.clientWidth  / 2 : 0;
+      const h   = el ? el.clientHeight / 2 : 0;
+      const ns  = Math.max(MIN_SCALE, Math.min(MAX_SCALE, prev.scale * f));
+      const cx  = (w - prev.x) / prev.scale;
+      const cy  = (h - prev.y) / prev.scale;
+      return { scale: ns, x: w - cx * ns, y: h - cy * ns };
+    });
+  }, []);
+  const resetZoom = useCallback(() => setVp(DEFAULT_VP), []);
+
+  // ── Rendering helpers ─────────────────────────────────────────────────────
+  const lineColorOf = useMemo(() => {
+    const m = new Map(lanes.map(l => [l.laneId, l.lineColor]));
+    return (id: string) => m.get(id) ?? '#D4D4D8';
+  }, [lanes]);
+
+  const effectivePos = useCallback((node: TLNode) =>
+    posOverrides.get(node.id) ?? { cx: node.cx, cy: node.cy },
+  [posOverrides]);
+
+  const gridTicks: number[] = [];
+  for (let t = 0; t <= Math.ceil(totalMinutes) + TL.GRID_INTERVAL; t += TL.GRID_INTERVAL) gridTicks.push(t);
+
+  // Box select rect in content space
+  const boxContent = boxRect && svgRef.current ? (() => {
+    const r = svgRef.current!.getBoundingClientRect();
+    const cv = vpRef.current;
+    const toC = (sx: number, sy: number) => ({
+      x: (sx - r.left - cv.x) / cv.scale, y: (sy - r.top - cv.y) / cv.scale,
+    });
+    const p1 = toC(Math.min(boxRect.sx, boxRect.ex), Math.min(boxRect.sy, boxRect.ey));
+    const p2 = toC(Math.max(boxRect.sx, boxRect.ex), Math.max(boxRect.sy, boxRect.ey));
+    return { x: p1.x, y: p1.y, w: p2.x - p1.x, h: p2.y - p1.y };
+  })() : null;
+
+  if (!nodes.length) {
+    return <div className="flex items-center justify-center h-full text-zinc-400 text-sm">No nodes to display.</div>;
+  }
+
+  const playheadX = playbackMin !== null ? TL.LANE_LABEL_W + playbackMin * ppm : null;
+  const playMins  = playbackMin !== null ? Math.floor(playbackMin) : 0;
+  const playSecs  = playbackMin !== null ? Math.round((playbackMin % 1) * 60) : 0;
+
+  return (
+    <div className="flex flex-col h-full bg-white select-none">
+
+      {/* ── Controls bar ─────────────────────────────────────────────── */}
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-zinc-100 bg-zinc-50 shrink-0 flex-wrap">
+        <div className="flex items-center gap-1.5">
+          <button onClick={isPlaying ? pause : play}
+            className="flex items-center gap-1.5 px-3 py-1 rounded bg-zinc-800 text-white text-xs font-medium hover:bg-zinc-700 transition-colors">
+            {isPlaying ? <><Pause className="w-3 h-3"/>Pause</> : <><Play className="w-3 h-3"/>Play</>}
+          </button>
+          <button onClick={resetPlay} title="Reset"
+            className="p-1.5 rounded text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 transition-colors">
+            <RotateCcw className="w-3 h-3"/>
+          </button>
+          {playbackMin !== null && (
+            <span className="text-xs text-zinc-500 font-mono tabular-nums">
+              {playMins}m {String(playSecs).padStart(2, '0')}s
+            </span>
+          )}
+        </div>
+
+        <div className="w-px h-4 bg-zinc-200 mx-1"/>
+
+        <div className="flex items-center gap-1">
+          <button onClick={() => zoomBy(1.25)} title="Zoom in" className="p-1.5 rounded text-zinc-500 hover:text-zinc-800 hover:bg-zinc-100 transition-colors"><ZoomIn className="w-3.5 h-3.5"/></button>
+          <button onClick={() => zoomBy(1/1.25)} title="Zoom out" className="p-1.5 rounded text-zinc-500 hover:text-zinc-800 hover:bg-zinc-100 transition-colors"><ZoomOut className="w-3.5 h-3.5"/></button>
+          <button onClick={resetZoom} title="Reset zoom" className="p-1.5 rounded text-zinc-500 hover:text-zinc-800 hover:bg-zinc-100 transition-colors"><Maximize2 className="w-3.5 h-3.5"/></button>
+          <span className="text-xs text-zinc-400 font-mono tabular-nums w-10 text-right">{Math.round(vp.scale * 100)}%</span>
+        </div>
+
+        <div className="w-px h-4 bg-zinc-200 mx-1"/>
+
+        <button onClick={undo} disabled={!undoStack.length} title="Undo (⌘Z)"
+          className="p-1.5 rounded text-zinc-500 hover:text-zinc-800 hover:bg-zinc-100 transition-colors disabled:opacity-30 disabled:cursor-not-allowed">
+          <Undo2 className="w-3.5 h-3.5"/>
+        </button>
+
+        {selectedIds.size > 0 && (
+          <span className="text-xs text-indigo-600 font-medium ml-1">{selectedIds.size} selected</span>
+        )}
+        <span className="ml-auto text-xs text-zinc-400 font-mono">~{Math.round(totalMinutes)} min</span>
+      </div>
+
+      {/* ── SVG canvas ───────────────────────────────────────────────── */}
+      <div className="flex-1 overflow-hidden bg-zinc-50">
+        <svg ref={svgRef} width="100%" height="100%"
+          style={{ cursor: boxRect ? 'crosshair' : 'grab', display: 'block' }}
+          onMouseDown={onCanvasMouseDown}
+          onMouseMove={onMouseMove}
+          onMouseUp={onMouseUp}
+          onMouseLeave={onMouseUp}
+        >
+          <g transform={`translate(${vp.x} ${vp.y}) scale(${vp.scale})`}
+             style={{ fontFamily: 'ui-sans-serif, system-ui, sans-serif' }}>
+
+            {/* Lane bands */}
+            {lanes.map((lane: TLLane) => (
+              <rect key={`band-${lane.laneId}`}
+                x={0} y={lane.yMin} width={totalWidth}
+                height={lane.yMax - lane.yMin + TL.LANE_GAP / 2}
+                fill={lane.color}/>
+            ))}
+
+            {/* Ingredient zone */}
+            <rect x={0} y={TL.RULER_H} width={totalWidth} height={TL.INGREDIENT_ZONE_H} fill="#fafafa"/>
+
+            {/* Lane labels */}
+            {lanes.map((lane: TLLane) => {
+              const my = (lane.yMin + lane.yMax) / 2;
+              return (
+                <text key={`lbl-${lane.laneId}`}
+                  x={TL.LANE_LABEL_W / 2} y={my}
+                  textAnchor="middle" dominantBaseline="middle"
+                  fontSize={10} fontWeight="600" fill="#71717a"
+                  transform={`rotate(-90, ${TL.LANE_LABEL_W / 2}, ${my})`}>
+                  {lane.label}
+                </text>
+              );
+            })}
+
+            {/* Separators */}
+            <line x1={TL.LANE_LABEL_W} y1={TL.RULER_H} x2={TL.LANE_LABEL_W} y2={totalHeight} stroke="#e4e4e7" strokeWidth={1}/>
+            <line x1={TL.LANE_LABEL_W} y1={actionZoneY} x2={totalWidth} y2={actionZoneY} stroke="#e4e4e7" strokeWidth={0.75} strokeDasharray="4 3"/>
+
+            {/* Grid + ruler */}
+            {gridTicks.map(t => {
+              const x = TL.LANE_LABEL_W + t * ppm, major = t % 10 === 0;
+              return (
+                <g key={`g-${t}`}>
+                  <line x1={x} y1={TL.RULER_H} x2={x} y2={totalHeight}
+                    stroke={major ? '#d4d4d8' : '#eeeeee'}
+                    strokeWidth={major ? 1 : 0.5}
+                    strokeDasharray={major ? undefined : '2 3'}/>
+                  <text x={x} y={TL.RULER_H - 6} textAnchor="middle" fontSize={9}
+                    fill={major ? '#71717a' : '#a1a1aa'} fontFamily="ui-monospace, monospace">
+                    {t}m
+                  </text>
+                </g>
+              );
+            })}
+            <line x1={TL.LANE_LABEL_W} y1={TL.RULER_H} x2={totalWidth} y2={TL.RULER_H} stroke="#d4d4d8" strokeWidth={1}/>
+
+            {/* Edges */}
+            {edges.map((edge: TLEdge) => {
+              const sn = nodes.find((n: TLNode) => n.id === edge.sourceId);
+              const tn = nodes.find((n: TLNode) => n.id === edge.targetId);
+              const sp = sn ? effectivePos(sn) : { cx: edge.x1, cy: edge.y1 };
+              const tp = tn ? effectivePos(tn) : { cx: edge.x2, cy: edge.y2 };
+              const color = edge.kind === 'spur'
+                ? (tn ? lineColorOf(tn.laneId) : '#D4D4D8')
+                : (sn ? lineColorOf(sn.laneId) : '#D4D4D8');
+              return edge.kind === 'spur' ? (
+                <path key={edge.id} d={spurPath(sp.cx, sp.cy, tp.cx, tp.cy)}
+                  fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" opacity={0.6}/>
+              ) : (
+                <path key={edge.id} d={chainPath(sp.cx, sp.cy, tp.cx, tp.cy)}
+                  fill="none" stroke={color} strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round"/>
+              );
+            })}
+
+            {/* Nodes */}
+            {nodes.map((node: TLNode) => {
+              const color = lineColorOf(node.laneId);
+              const pos   = effectivePos(node);
+              const props: NodeProps = {
+                node, cx: pos.cx, cy: pos.cy, lineColor: color, playbackMin,
+                isHovered:  hoveredNodeId === node.id,
+                isSelected: selectedIds.has(node.id),
+                isForging:  forgingIds.has(node.id),
+                onMouseDown:  e => onNodeMouseDown(e, node),
+                onMouseEnter: () => setHoveredNodeId(node.id),
+                onMouseLeave: () => setHoveredNodeId(id => id === node.id ? null : id),
+                onReroll: e => { e.stopPropagation(); cycleShortlist(node.id); },
+                onForge:  e => { e.stopPropagation(); handleForge(node.id, node.data); },
+                onDelete: () => deleteNode(node.id),
+              };
+              return node.kind === 'ingredient'
+                ? <IngredientNode key={node.id} {...props}/>
+                : <ActionNode     key={node.id} {...props}/>;
+            })}
+
+            {/* Box select rect */}
+            {boxContent && (
+              <rect x={boxContent.x} y={boxContent.y} width={boxContent.w} height={boxContent.h}
+                fill="#6366f1" fillOpacity={0.08} stroke="#6366f1" strokeWidth={1} strokeDasharray="4 2"/>
+            )}
+
+            {/* Playhead */}
+            {playheadX !== null && (
+              <g>
+                <line x1={playheadX} y1={TL.RULER_H} x2={playheadX} y2={totalHeight}
+                  stroke="#ef4444" strokeWidth={1.5}/>
+                <polygon
+                  points={`${playheadX-5},${TL.RULER_H} ${playheadX+5},${TL.RULER_H} ${playheadX},${TL.RULER_H+8}`}
+                  fill="#ef4444"/>
+              </g>
+            )}
+
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/recipe-lanes/components/recipe-lanes/timeline-view.tsx
+++ b/recipe-lanes/components/recipe-lanes/timeline-view.tsx
@@ -132,7 +132,9 @@ function ActionNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSelecte
   return (
     <g opacity={isDone ? 0.4 : 1} style={{ cursor: 'pointer' }}
       onMouseDown={onMouseDown}
-      onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+      onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}
+      data-testid={`node-${node.id}`}
+    >
       {isActive   && <circle cx={cx} cy={cy} r={TL.NODE_R + 8} fill={lineColor} opacity={0.15}/>}
       {isSelected && <circle cx={cx} cy={cy} r={TL.NODE_R + 4} fill="none" stroke="#6366f1" strokeWidth={1.5} opacity={0.5}/>}
       <circle cx={cx} cy={cy} r={TL.NODE_R}
@@ -178,7 +180,9 @@ function IngredientNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSel
   return (
     <g opacity={playbackMin !== null ? 0.6 : 1} style={{ cursor: 'pointer' }}
       onMouseDown={onMouseDown}
-      onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+      onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}
+      data-testid={`node-${node.id}`}
+    >
       {isSelected && <circle cx={cx} cy={cy} r={TL.NODE_R + 4} fill="none" stroke="#6366f1" strokeWidth={1.5} opacity={0.5}/>}
       <circle cx={cx} cy={cy} r={TL.NODE_R}
         fill="white" stroke={ring} strokeWidth={isSelected ? 2.5 : 1.5} strokeDasharray="3 2"/>
@@ -205,7 +209,7 @@ function IngredientNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSel
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────
-export function TimelineView({ graph }: { graph: RecipeGraph }) {
+export function TimelineView({ graph, onSave }: { graph: RecipeGraph, onSave?: (graph: RecipeGraph) => void }) {
   const searchParams   = useSearchParams();
   const recipeId       = searchParams.get('id');
   const cycleShortlist = useRecipeStore(s => s.cycleShortlist);
@@ -297,7 +301,21 @@ export function TimelineView({ graph }: { graph: RecipeGraph }) {
   useEffect(() => { selectedIdsRef.current = selectedIds; }, [selectedIds]);
 
   // ── Position overrides ────────────────────────────────────────────────────
-  const [posOverrides, setPosOverrides] = useState<Map<string, { cx: number; cy: number }>>(new Map());
+  const [posOverrides, setPosOverrides] = useState<Map<string, { cx: number; cy: number }>>(() => {
+    const m = new Map<string, { cx: number; cy: number }>();
+    if (graph.layouts?.['timeline2']) {
+      graph.layouts['timeline2'].forEach(l => {
+        m.set(l.id, { cx: l.x + TL.NODE_R, cy: l.y + TL.NODE_R });
+      });
+    } else if (graph.layoutMode === 'timeline2') {
+      graph.nodes.forEach(n => {
+        if (n.x !== undefined && n.y !== undefined) {
+          m.set(n.id, { cx: n.x + TL.NODE_R, cy: n.y + TL.NODE_R });
+        }
+      });
+    }
+    return m;
+  });
   const posOverridesRef                 = useRef(posOverrides);
   useEffect(() => { posOverridesRef.current = posOverrides; }, [posOverrides]);
 
@@ -449,7 +467,18 @@ export function TimelineView({ graph }: { graph: RecipeGraph }) {
         setSelectedIds(new Set([d.nodeId, ...ancestors]));
       }
     }
-  }, [nodes]);
+
+    if (d.type === 'node' && d.moved) {
+      // Drag finished, apply positions to graph and save
+      const nextNodes = graphNodesRef.current.map(n => {
+        const over = posOverridesRef.current.get(n.id);
+        if (over) return { ...n, x: over.cx - TL.NODE_R, y: over.cy - TL.NODE_R };
+        return n;
+      });
+      const nextGraph = { ...graph, nodes: nextNodes };
+      onSave?.(nextGraph);
+    }
+  }, [nodes, graph, onSave]);
 
   const zoomBy    = useCallback((f: number) => {
     setVp(prev => {

--- a/recipe-lanes/e2e/layout-mode-persistence.spec.ts
+++ b/recipe-lanes/e2e/layout-mode-persistence.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from './utils/fixtures';
+import { screenshotDir } from './utils/screenshot';
+import { deviceConfigs } from './utils/devices';
+import { create_recipe, wait_for_graph } from './utils/actions';
+
+test.describe('Layout Persistence', () => {
+  const desktop = deviceConfigs.find(d => d.name === 'desktop')!;
+
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(desktop.viewport);
+  });
+
+  test('Mode alone should persist on refresh', async ({ page, login }) => {
+    test.setTimeout(90000); 
+    
+    const dir = screenshotDir('layout-persistence-mode-only', desktop.name);
+    
+    // 1. Login and create recipe
+    await page.goto('/lanes?new=true');
+    await login('tester-user');
+    await create_recipe(page, '2 eggs, 1 pan. fry eggs in pan for 5 min.', dir);
+    await wait_for_graph(page, dir);
+    
+    // Verify default layout mode is NOT timeline2
+    const layoutSelect = page.locator('select[title="Layout Mode"]');
+    await expect(layoutSelect).not.toHaveValue('timeline2');
+
+    // 2. Change layout to 'timeline2'
+    await layoutSelect.selectOption('timeline2');
+    await page.waitForTimeout(3000); // Give it time to save (if it was implemented)
+    
+    // Check that timeline2 is selected
+    await expect(layoutSelect).toHaveValue('timeline2');
+
+    // 3. Refresh the page
+    await page.reload();
+    
+    // Instead of wait_for_graph (which looks for react-flow), we just wait for our node
+    const textNode = page.getByText('Fry Eggs In Pan').first();
+    await expect(textNode).toBeVisible({ timeout: 15000 });
+
+    // 4. Verify persistence
+    await expect(layoutSelect).toHaveValue('timeline2');
+    console.log('Layout mode correctly persisted as "timeline2".');
+
+    // 5. Move a node in Timeline2
+    // The `<g>` doesn't have a reliable bounding box in Playwright, so we find the main circle inside it
+    // Wait for the timeline to fully render
+    await page.waitForTimeout(1000);
+    const anyNodeCircle = page.locator('g[data-testid^="node-"] circle').first();
+    await expect(anyNodeCircle).toBeVisible();
+    
+    const t2BoxBeforeMove = await anyNodeCircle.boundingBox();
+    if (!t2BoxBeforeMove) throw new Error('Timeline2 node circle not found');
+    console.log(`Timeline2 Node pos: x=${t2BoxBeforeMove.x}, y=${t2BoxBeforeMove.y}`);
+
+    // Move the node from the center of the circle
+    await page.mouse.move(t2BoxBeforeMove.x + t2BoxBeforeMove.width / 2, t2BoxBeforeMove.y + t2BoxBeforeMove.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(t2BoxBeforeMove.x + t2BoxBeforeMove.width / 2 + 150, t2BoxBeforeMove.y + t2BoxBeforeMove.height / 2 + 100, { steps: 20 });
+    await page.mouse.up();
+
+    // Give it a moment to potentially save
+    await page.waitForTimeout(2000);
+    
+    const t2BoxAfterMove = await anyNodeCircle.boundingBox();
+    console.log(`Timeline2 Node moved to: x=${t2BoxAfterMove?.x}, y=${t2BoxAfterMove?.y}`);
+    expect(t2BoxAfterMove!.x).toBeGreaterThan(t2BoxBeforeMove.x + 100);
+
+    // Refresh the page
+    await page.reload();
+    await expect(layoutSelect).toHaveValue('timeline2');
+    
+    const t2RefreshedNodeCircle = page.locator('g[data-testid^="node-"] circle').first();
+    await expect(t2RefreshedNodeCircle).toBeVisible({ timeout: 10000 });
+    
+    const t2BoxRefreshed = await t2RefreshedNodeCircle.boundingBox();
+    console.log(`Timeline2 Node after refresh: x=${t2BoxRefreshed?.x}, y=${t2BoxRefreshed?.y}`);
+    
+    // THIS WILL FAIL IF THE CODE IS UNPATCHED
+    expect(t2BoxRefreshed!.x).toBeGreaterThan(t2BoxBeforeMove.x + 50);
+  });
+});
+

--- a/recipe-lanes/lib/recipe-lanes/layout.ts
+++ b/recipe-lanes/lib/recipe-lanes/layout.ts
@@ -17,9 +17,10 @@
 
 import type { RecipeGraph, LayoutGraph, VisualNode, VisualEdge, VisualLane, RecipeNode } from './types';
 import dagre from 'dagre';
+import { buildTimelineLayout, TL } from './timeline-layout';
 
-// Only keeping Lanes, Smart, Smart LR
-export type LayoutMode = 'swimlanes' | 'dagre' | 'dagre-lr';
+// Only keeping Lanes, Smart, Smart LR, Timeline
+export type LayoutMode = 'swimlanes' | 'dagre' | 'dagre-lr' | 'timeline';
 
 const CONSTANTS = {
   standard: {
@@ -55,7 +56,97 @@ const LANE_COLORS = {
   default: '#FAFAFA'
 };
 
+// ── Timeline adapter ─────────────────────────────────────────────────────────
+
+// Both node types are 40×40 circles (TL.NODE_R = 20)
+export const TIMELINE_NODE_SIZE = TL.NODE_R * 2;   // 40px
+
+function calculateTimelineLayout(graph: RecipeGraph): LayoutGraph {
+  const tl = buildTimelineLayout(graph);
+
+  const laneLineColor = new Map(tl.lanes.map(l => [l.laneId, l.lineColor]));
+
+  const s = TIMELINE_NODE_SIZE;
+  const nodes: VisualNode[] = tl.nodes.map(n => {
+    const lineColor = laneLineColor.get(n.laneId) ?? '#D4D4D8';
+    return {
+      id: n.id,
+      type: n.data.type,
+      x: n.cx - s / 2,
+      y: n.cy - s / 2,
+      width: s,
+      height: s,
+      data: n.data,
+      lineColor,
+    };
+  });
+
+  // Edges: path is ignored by TimelineEdge (computed from node positions), but
+  // lineColor and kind are used by the custom edge renderer.
+  const tlNodeMap = new Map(tl.nodes.map(n => [n.id, n]));
+  const edges: VisualEdge[] = tl.edges.map(e => {
+    const src = tlNodeMap.get(e.sourceId);
+    const tgt = tlNodeMap.get(e.targetId);
+    const lineColor =
+      e.kind === 'spur'
+        ? (laneLineColor.get(tgt?.laneId ?? '') ?? '#D4D4D8')
+        : (laneLineColor.get(src?.laneId ?? '') ?? '#D4D4D8');
+    return {
+      id: e.id,
+      sourceId: e.sourceId,
+      targetId: e.targetId,
+      path: '',
+      lineColor,
+      kind: e.kind,
+    };
+  });
+
+  // Lane bands – horizontal strips
+  const lanes: VisualLane[] = tl.lanes.map(l => ({
+    id: l.laneId,
+    label: l.label,
+    x: 0,
+    y: l.yMin,
+    width: tl.totalWidth,
+    height: l.yMax - l.yMin,
+    color: l.color,
+  }));
+
+  return {
+    nodes, edges, lanes,
+    width: tl.totalWidth,
+    height: tl.totalHeight,
+    timelineData: {
+      pixelsPerMin:  tl.pixelsPerMin,
+      totalMinutes:  tl.totalMinutes,
+      actionZoneY:   tl.actionZoneY,
+      totalHeight:   tl.totalHeight,
+      rulerHeight:   TL.RULER_H,
+      laneLabelWidth: TL.LANE_LABEL_W,
+      gridInterval:  TL.GRID_INTERVAL,
+    },
+  };
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
 export const calculateLayout = (graph: RecipeGraph, mode: LayoutMode = 'dagre', spacing: number = 1, preservePositions: boolean = false): LayoutGraph => {
+  // Timeline needs its full structure (lanes, edge kinds, timelineData) even when
+  // restoring saved positions — run the algo then override x/y from saved values.
+  if (preservePositions && mode === 'timeline' && graph.nodes.some(n => n.x !== undefined)) {
+    const layout = calculateTimelineLayout(graph);
+    const savedPos = new Map(
+      graph.nodes.filter(n => n.x !== undefined).map(n => [n.id, { x: n.x!, y: n.y! }])
+    );
+    return {
+      ...layout,
+      nodes: layout.nodes.map(n => {
+        const pos = savedPos.get(n.id);
+        return pos ? { ...n, x: pos.x, y: pos.y } : n;
+      }),
+    };
+  }
+
   // If preserving positions (and at least one exists), bypass algo
   if (preservePositions && graph.nodes.some(n => n.x !== undefined)) {
       const nodes: VisualNode[] = graph.nodes.map(n => ({
@@ -117,6 +208,8 @@ export const calculateLayout = (graph: RecipeGraph, mode: LayoutMode = 'dagre', 
       return calculateDagreLayout(graph, spacing, 'TB');
     case 'dagre-lr':
       return calculateDagreLayout(graph, spacing, 'LR');
+    case 'timeline':
+      return calculateTimelineLayout(graph);
     case 'swimlanes':
     default:
       // Default to standard swimlane if 'swimlanes' selected

--- a/recipe-lanes/lib/recipe-lanes/timeline-layout.ts
+++ b/recipe-lanes/lib/recipe-lanes/timeline-layout.ts
@@ -1,0 +1,365 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { RecipeGraph, RecipeNode } from './types';
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+export interface TLNode {
+  id: string;
+  startMin: number;
+  durationMin: number;
+  laneId: string;
+  laneIndex: number;
+  trackIndex: number;
+  cx: number;
+  cy: number;
+  /** 'ingredient' nodes appear in the ingredient zone above the action tracks. */
+  kind: 'action' | 'ingredient';
+  data: RecipeNode;
+}
+
+export interface TLEdge {
+  id: string;
+  sourceId: string;
+  targetId: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  /** 'chain' connects action→action along the timeline; 'spur' connects ingredient→action. */
+  kind: 'chain' | 'spur';
+}
+
+export interface TLLane {
+  laneId: string;
+  label: string;
+  color: string;
+  lineColor: string;
+  yMin: number;
+  yMax: number;
+  trackCount: number;
+}
+
+export interface TimelineLayout {
+  nodes: TLNode[];
+  edges: TLEdge[];
+  lanes: TLLane[];
+  totalMinutes: number;
+  totalWidth: number;
+  totalHeight: number;
+  pixelsPerMin: number;
+  /** y coordinate where ingredient zone ends / action tracks begin */
+  actionZoneY: number;
+}
+
+// ── Layout constants ─────────────────────────────────────────────────────────
+
+export const TL = {
+  NODE_R: 20,            // node circle radius (px)
+  TRACK_H: 72,           // pixels per action track row
+  LANE_GAP: 10,          // gap between lane bands
+  LANE_LABEL_W: 72,      // left gutter for rotated lane name
+  RULER_H: 34,           // top time ruler height
+  /** Vertical space reserved above action tracks for ingredient stubs */
+  INGREDIENT_ZONE_H: 65,
+  /** Gap between sibling ingredient circles in a fan */
+  ING_SPACING: 16,
+  MARGIN_RIGHT: 48,
+  GRID_INTERVAL: 5,
+  TARGET_W: 1100,
+  MIN_PPM: 22,
+  MAX_PPM: 80,
+} as const;
+
+// ── Colour maps ───────────────────────────────────────────────────────────────
+
+export const LANE_BG: Record<string, string> = {
+  prep:    '#EFF6FF',
+  cook:    '#FFF7ED',
+  serve:   '#F0FDF4',
+  default: '#FAFAFA',
+};
+
+export const LANE_LINE: Record<string, string> = {
+  prep:    '#93C5FD',
+  cook:    '#FB923C',
+  serve:   '#4ADE80',
+  default: '#D4D4D8',
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Extract duration in minutes from a node.
+ * Reads the first number from the `duration` string and treats it as minutes.
+ * Falls back to 1 min for ingredients, 5 min for actions.
+ */
+export function parseDurationMins(node: RecipeNode): number {
+  if (node.duration) {
+    const m = node.duration.match(/\d+(\.\d+)?/);
+    if (m) return Math.max(0.5, parseFloat(m[0]));
+  }
+  return node.type === 'ingredient' ? 1 : 5;
+}
+
+/**
+ * Kahn's algorithm topological sort.
+ * Nodes in cycles are appended at the end (safe fallback).
+ */
+export function topoSort(nodes: RecipeNode[]): string[] {
+  const indegree = new Map<string, number>(nodes.map(n => [n.id, 0]));
+  const children = new Map<string, string[]>();
+
+  for (const n of nodes) {
+    for (const pid of n.inputs ?? []) {
+      if (!children.has(pid)) children.set(pid, []);
+      children.get(pid)!.push(n.id);
+      indegree.set(n.id, (indegree.get(n.id) ?? 0) + 1);
+    }
+  }
+
+  const queue = nodes.filter(n => (indegree.get(n.id) ?? 0) === 0).map(n => n.id);
+  const result: string[] = [];
+
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    result.push(id);
+    for (const child of children.get(id) ?? []) {
+      const deg = (indegree.get(child) ?? 0) - 1;
+      indegree.set(child, deg);
+      if (deg === 0) queue.push(child);
+    }
+  }
+
+  const seen = new Set(result);
+  for (const n of nodes) if (!seen.has(n.id)) result.push(n.id);
+  return result;
+}
+
+// ── Main layout ───────────────────────────────────────────────────────────────
+
+/**
+ * Produces a timeline layout for the given recipe graph.
+ *
+ * Visual structure (top → bottom):
+ *   [Ruler]
+ *   [Ingredient zone]  — ingredient nodes fanned above their consumer actions
+ *   ─────────────────  — separator line
+ *   [Lane bands]       — action nodes on horizontal tracks, coloured by lane type
+ */
+export function buildTimelineLayout(graph: RecipeGraph): TimelineLayout {
+  const { nodes, lanes: graphLanes = [] } = graph;
+
+  const actionZoneY = TL.RULER_H + TL.INGREDIENT_ZONE_H;
+
+  if (nodes.length === 0) {
+    return {
+      nodes: [], edges: [], lanes: [],
+      totalMinutes: 0,
+      totalWidth: TL.LANE_LABEL_W + TL.MARGIN_RIGHT,
+      totalHeight: actionZoneY + 60,
+      pixelsPerMin: TL.MIN_PPM,
+      actionZoneY,
+    };
+  }
+
+  const nodeMap = new Map(nodes.map(n => [n.id, n]));
+  const durMap  = new Map(nodes.map(n => [n.id, parseDurationMins(n)]));
+
+  // 1. Topological sort → start times
+  const sorted   = topoSort(nodes);
+  const startMin = new Map<string, number>();
+
+  for (const id of sorted) {
+    const n      = nodeMap.get(id)!;
+    const inputs = n.inputs ?? [];
+    const predEnd = inputs.length > 0
+      ? Math.max(...inputs.map(pid => (startMin.get(pid) ?? 0) + (durMap.get(pid) ?? 5)))
+      : 0;
+    startMin.set(id, predEnd);
+  }
+
+  const totalMinutes = Math.max(
+    1,
+    ...nodes.map(n => (startMin.get(n.id) ?? 0) + (durMap.get(n.id) ?? 5)),
+  );
+
+  // 2. Pixels-per-minute (scale to TARGET_W)
+  const usableW = TL.TARGET_W - TL.LANE_LABEL_W - TL.MARGIN_RIGHT;
+  const ppm     = Math.min(TL.MAX_PPM, Math.max(TL.MIN_PPM, usableW / totalMinutes));
+
+  // 3. Lane ordering
+  const laneOrder    = new Map<string, number>(graphLanes.map((l, i) => [l.id, i]));
+  const getLaneIndex = (laneId: string) => laneOrder.get(laneId) ?? graphLanes.length;
+
+  // 4. Greedy track assignment — for ACTION nodes only.
+  //    Ingredient nodes get special placement later.
+  const trackAssign     = new Map<string, number>();
+  const laneTrackCounts = new Map<string, number>();
+
+  const laneActionGroups = new Map<string, string[]>();
+  for (const id of sorted) {
+    if (nodeMap.get(id)!.type !== 'action') continue;
+    const laneId = nodeMap.get(id)!.laneId ?? 'default';
+    if (!laneActionGroups.has(laneId)) laneActionGroups.set(laneId, []);
+    laneActionGroups.get(laneId)!.push(id);
+  }
+
+  for (const [laneId, ids] of laneActionGroups) {
+    const byStart   = [...ids].sort((a, b) => (startMin.get(a) ?? 0) - (startMin.get(b) ?? 0));
+    const trackEnds: number[] = [];
+    for (const id of byStart) {
+      const s = startMin.get(id) ?? 0;
+      const d = durMap.get(id) ?? 5;
+      let track = trackEnds.findIndex(end => end <= s + 0.01);
+      if (track === -1) { track = trackEnds.length; trackEnds.push(0); }
+      trackEnds[track] = s + d;
+      trackAssign.set(id, track);
+    }
+    laneTrackCounts.set(laneId, Math.max(1, trackEnds.length));
+  }
+
+  // 5. Lane Y offsets — start BELOW the ingredient zone
+  const allActionLaneIds = [...laneActionGroups.keys()].sort(
+    (a, b) => getLaneIndex(a) - getLaneIndex(b),
+  );
+  const laneYStart = new Map<string, number>();
+  let y = actionZoneY;
+  for (const laneId of allActionLaneIds) {
+    laneYStart.set(laneId, y);
+    y += (laneTrackCounts.get(laneId) ?? 1) * TL.TRACK_H + TL.LANE_GAP;
+  }
+  const totalHeight = y + 8;
+
+  // 6. Build initial TLNodes with time-based cx/cy for everything
+  const tlNodes: TLNode[] = nodes.map(n => {
+    const laneId    = n.laneId ?? 'default';
+    const trackIdx  = trackAssign.get(n.id) ?? 0;
+    const s         = startMin.get(n.id) ?? 0;
+    const laneY     = laneYStart.get(laneId) ?? actionZoneY;
+    const cx        = TL.LANE_LABEL_W + s * ppm;
+    const cy        = laneY + trackIdx * TL.TRACK_H + TL.TRACK_H / 2;
+    return {
+      id: n.id,
+      startMin:    s,
+      durationMin: durMap.get(n.id) ?? 1,
+      laneId,
+      laneIndex:   getLaneIndex(laneId),
+      trackIndex:  trackIdx,
+      cx, cy,
+      kind: n.type === 'ingredient' ? 'ingredient' : 'action',
+      data: n,
+    };
+  });
+
+  const tlNodeMap = new Map(tlNodes.map(n => [n.id, n]));
+
+  // 7. Post-process: re-position ingredient nodes to fan above their consumer actions
+  //
+  //    For each action node, collect its ingredient inputs.
+  //    Fan those ingredients horizontally around the action's cx,
+  //    all at the same cy in the ingredient zone.
+  //    Ingredients consumed by multiple actions are anchored to the earliest one.
+
+  // ingId → primary consumer actionId (lowest startMin)
+  const ingPrimary = new Map<string, string>();
+  for (const n of nodes) {
+    if (n.type !== 'action') continue;
+    for (const inputId of n.inputs ?? []) {
+      if (nodeMap.get(inputId)?.type !== 'ingredient') continue;
+      const existing = ingPrimary.get(inputId);
+      if (!existing || (startMin.get(n.id) ?? 0) < (startMin.get(existing) ?? 0)) {
+        ingPrimary.set(inputId, n.id);
+      }
+    }
+  }
+
+  // primary actionId → [ingIds] (for fan spread)
+  const primaryFan = new Map<string, string[]>();
+  for (const [ingId, actionId] of ingPrimary) {
+    if (!primaryFan.has(actionId)) primaryFan.set(actionId, []);
+    primaryFan.get(actionId)!.push(ingId);
+  }
+
+  const ingSpacing = TL.NODE_R * 2 + TL.ING_SPACING;
+
+  for (const [actionId, ingIds] of primaryFan) {
+    const action = tlNodeMap.get(actionId);
+    if (!action) continue;
+    const count = ingIds.length;
+    // Place ingredient just above the consumer action — short spur, no lane-crossing
+    const ingCy = action.cy - TL.NODE_R * 2 - 8;
+    ingIds.forEach((ingId, i) => {
+      const ingNode = tlNodeMap.get(ingId);
+      if (!ingNode) return;
+      const xOff = (i - (count - 1) / 2) * ingSpacing;
+      ingNode.cx = action.cx + xOff;
+      ingNode.cy = ingCy;
+      ingNode.kind = 'ingredient';
+      // Inherit the consumer action's lane so the spur colour matches the action line
+      ingNode.laneId = action.laneId;
+    });
+  }
+
+  // 8. Build TLEdges
+  const tlEdges: TLEdge[] = [];
+  for (const n of nodes) {
+    const target = tlNodeMap.get(n.id);
+    if (!target) continue;
+    for (const inputId of n.inputs ?? []) {
+      const source = tlNodeMap.get(inputId);
+      if (!source) continue;
+      const kind: TLEdge['kind'] =
+        source.kind === 'ingredient' && target.kind === 'action' ? 'spur' : 'chain';
+      tlEdges.push({
+        id: `${inputId}->${n.id}`,
+        sourceId: inputId,
+        targetId: n.id,
+        x1: source.cx,
+        y1: source.cy,
+        x2: target.cx,
+        y2: target.cy,
+        kind,
+      });
+    }
+  }
+
+  // 9. Build TLLanes (only for lanes that have action nodes)
+  const tlLanes: TLLane[] = allActionLaneIds.map(laneId => {
+    const lane       = graphLanes.find(l => l.id === laneId);
+    const trackCount = laneTrackCounts.get(laneId) ?? 1;
+    const yMin       = laneYStart.get(laneId) ?? actionZoneY;
+    const yMax       = yMin + trackCount * TL.TRACK_H;
+    return {
+      laneId,
+      label:     lane?.label ?? laneId,
+      color:     LANE_BG[lane?.type  ?? 'default'] ?? LANE_BG.default,
+      lineColor: LANE_LINE[lane?.type ?? 'default'] ?? LANE_LINE.default,
+      yMin, yMax,
+      trackCount,
+    };
+  });
+
+  const totalWidth = TL.LANE_LABEL_W + totalMinutes * ppm + TL.MARGIN_RIGHT;
+
+  return {
+    nodes: tlNodes, edges: tlEdges, lanes: tlLanes,
+    totalMinutes, totalWidth, totalHeight, pixelsPerMin: ppm,
+    actionZoneY,
+  };
+}

--- a/recipe-lanes/lib/recipe-lanes/types.ts
+++ b/recipe-lanes/lib/recipe-lanes/types.ts
@@ -150,6 +150,7 @@ export interface VisualNode {
   height: number;
   depth?: number;
   data: RecipeNode;
+  lineColor?: string;
 }
 
 export interface VisualEdge {
@@ -157,6 +158,8 @@ export interface VisualEdge {
   sourceId: string;
   targetId: string;
   path: string; // SVG path d attribute
+  lineColor?: string;
+  kind?: 'chain' | 'spur';
 }
 
 export interface VisualLane {
@@ -175,4 +178,14 @@ export interface LayoutGraph {
   lanes: VisualLane[];
   width: number;
   height: number;
+  /** Present only for 'timeline' mode. */
+  timelineData?: {
+    pixelsPerMin: number;
+    totalMinutes: number;
+    actionZoneY: number;
+    totalHeight: number;
+    rulerHeight: number;
+    laneLabelWidth: number;
+    gridInterval: number;
+  };
 }

--- a/recipe-lanes/lib/stores/recipe-store.ts
+++ b/recipe-lanes/lib/stores/recipe-store.ts
@@ -120,7 +120,9 @@ function mergeNode(existing: RecipeNode, incoming: RecipeNode): RecipeNode {
         existing.text === incoming.text &&
         existing.quantity === incoming.quantity &&
         existing.unit === incoming.unit &&
-        existing.visualDescription === incoming.visualDescription
+        existing.visualDescription === incoming.visualDescription &&
+        existing.x === incoming.x &&
+        existing.y === incoming.y
     ) {
         return existing;
     }

--- a/recipe-lanes/tests/timeline-layout.test.ts
+++ b/recipe-lanes/tests/timeline-layout.test.ts
@@ -1,0 +1,225 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  parseDurationMins,
+  topoSort,
+  buildTimelineLayout,
+  TL,
+} from '../lib/recipe-lanes/timeline-layout';
+import type { RecipeGraph, RecipeNode } from '../lib/recipe-lanes/types';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function ing(partial: Partial<RecipeNode> & { id: string }): RecipeNode {
+  return { laneId: 'lane-1', text: partial.id, visualDescription: partial.id, type: 'ingredient', x: 0, y: 0, inputs: [], ...partial } as RecipeNode;
+}
+
+function act(partial: Partial<RecipeNode> & { id: string }): RecipeNode {
+  return { laneId: 'lane-1', text: partial.id, visualDescription: partial.id, type: 'action',     x: 0, y: 0, inputs: [], ...partial } as RecipeNode;
+}
+
+function makeGraph(nodes: RecipeNode[], laneTypes: ('prep'|'cook'|'serve')[] = ['prep','cook']): RecipeGraph {
+  return {
+    lanes: laneTypes.map((t, i) => ({ id: `lane-${i + 1}`, label: t, type: t })),
+    nodes,
+  };
+}
+
+// ── parseDurationMins ─────────────────────────────────────────────────────────
+
+describe('parseDurationMins', () => {
+  it('extracts number from "10 min"', () => {
+    assert.strictEqual(parseDurationMins(act({ id: 'a', duration: '10 min' })), 10);
+  });
+  it('extracts decimal from "2.5 minutes"', () => {
+    assert.strictEqual(parseDurationMins(act({ id: 'a', duration: '2.5 minutes' })), 2.5);
+  });
+  it('extracts first number from "10-15 min"', () => {
+    assert.strictEqual(parseDurationMins(act({ id: 'a', duration: '10-15 min' })), 10);
+  });
+  it('defaults to 1 for ingredient with no duration', () => {
+    assert.strictEqual(parseDurationMins(ing({ id: 'a' })), 1);
+  });
+  it('defaults to 5 for action with no duration', () => {
+    assert.strictEqual(parseDurationMins(act({ id: 'a' })), 5);
+  });
+  it('clamps very small durations to 0.5', () => {
+    assert.strictEqual(parseDurationMins(act({ id: 'a', duration: '0' })), 0.5);
+  });
+});
+
+// ── topoSort ──────────────────────────────────────────────────────────────────
+
+describe('topoSort', () => {
+  it('sorts a simple chain A → B → C', () => {
+    const nodes = [act({ id: 'C', inputs: ['B'] }), act({ id: 'A' }), act({ id: 'B', inputs: ['A'] })];
+    const sorted = topoSort(nodes);
+    assert.ok(sorted.indexOf('A') < sorted.indexOf('B'));
+    assert.ok(sorted.indexOf('B') < sorted.indexOf('C'));
+  });
+
+  it('handles nodes with no inputs', () => {
+    const sorted = topoSort([act({ id: 'X' }), act({ id: 'Y' })]);
+    assert.strictEqual(sorted.length, 2);
+  });
+
+  it('handles diamond: A → B, A → C, B → D, C → D', () => {
+    const nodes = [act({ id: 'A' }), act({ id: 'B', inputs: ['A'] }), act({ id: 'C', inputs: ['A'] }), act({ id: 'D', inputs: ['B','C'] })];
+    const sorted = topoSort(nodes);
+    assert.ok(sorted.indexOf('A') < sorted.indexOf('B'));
+    assert.ok(sorted.indexOf('A') < sorted.indexOf('C'));
+    assert.ok(sorted.indexOf('B') < sorted.indexOf('D'));
+    assert.ok(sorted.indexOf('C') < sorted.indexOf('D'));
+  });
+
+  it('does not throw on a cycle — includes all nodes', () => {
+    const sorted = topoSort([act({ id: 'A', inputs: ['B'] }), act({ id: 'B', inputs: ['A'] })]);
+    assert.strictEqual(sorted.length, 2);
+  });
+});
+
+// ── buildTimelineLayout ───────────────────────────────────────────────────────
+
+describe('buildTimelineLayout', () => {
+  it('returns empty layout for empty graph', () => {
+    const layout = buildTimelineLayout(makeGraph([]));
+    assert.strictEqual(layout.nodes.length, 0);
+    assert.strictEqual(layout.edges.length, 0);
+    assert.strictEqual(layout.totalMinutes, 0);
+  });
+
+  it('assigns start time 0 to a root node', () => {
+    const layout = buildTimelineLayout(makeGraph([act({ id: 'A' })]));
+    assert.strictEqual(layout.nodes[0].startMin, 0);
+  });
+
+  it('assigns start time = predecessor end for an action chain', () => {
+    const nodes  = [act({ id: 'A', duration: '10 min' }), act({ id: 'B', duration: '5 min', inputs: ['A'] })];
+    const layout = buildTimelineLayout(makeGraph(nodes));
+    const a = layout.nodes.find(n => n.id === 'A')!;
+    const b = layout.nodes.find(n => n.id === 'B')!;
+    assert.strictEqual(a.startMin, 0);
+    assert.strictEqual(b.startMin, 10);
+  });
+
+  it('parallel action nodes land on different tracks', () => {
+    // Two actions in the same lane, both starting at 0 — must not collide
+    const nodes  = [act({ id: 'B', duration: '10 min' }), act({ id: 'C', duration: '10 min' })];
+    const layout = buildTimelineLayout(makeGraph(nodes));
+    const [tB, tC] = [layout.nodes.find(n => n.id === 'B')!.trackIndex, layout.nodes.find(n => n.id === 'C')!.trackIndex];
+    assert.notStrictEqual(tB, tC);
+  });
+
+  it('non-overlapping actions share a track', () => {
+    // A(0-5) → bridge(5-10) → C(10-15): A and C should share track 0
+    const nodes = [
+      act({ id: 'A', duration: '5 min' }),
+      act({ id: 'bridge', duration: '5 min', inputs: ['A'] }),
+      act({ id: 'C', duration: '5 min', inputs: ['bridge'] }),
+    ];
+    const layout = buildTimelineLayout(makeGraph(nodes));
+    const a = layout.nodes.find(n => n.id === 'A')!;
+    const c = layout.nodes.find(n => n.id === 'C')!;
+    assert.strictEqual(a.trackIndex, c.trackIndex, 'A and C should reuse the same track');
+  });
+
+  it('creates an edge for every input connection', () => {
+    const nodes  = [ing({ id: 'A' }), act({ id: 'B', inputs: ['A'] }), act({ id: 'C', inputs: ['A','B'] })];
+    const layout = buildTimelineLayout(makeGraph(nodes));
+    assert.strictEqual(layout.edges.length, 3);
+  });
+
+  it('spur edges connect ingredient to action', () => {
+    const nodes  = [ing({ id: 'i1' }), act({ id: 'a1', inputs: ['i1'] })];
+    const layout = buildTimelineLayout(makeGraph(nodes));
+    const spur   = layout.edges.find(e => e.kind === 'spur');
+    assert.ok(spur, 'should have a spur edge');
+    assert.strictEqual(spur!.sourceId, 'i1');
+    assert.strictEqual(spur!.targetId, 'a1');
+  });
+
+  it('chain edges connect action to action', () => {
+    const nodes  = [act({ id: 'a1' }), act({ id: 'a2', inputs: ['a1'] })];
+    const layout = buildTimelineLayout(makeGraph(nodes));
+    const chain  = layout.edges.find(e => e.kind === 'chain');
+    assert.ok(chain, 'should have a chain edge');
+  });
+
+  it('ingredient node cx aligns with its consumer action', () => {
+    const nodes = [ing({ id: 'i1' }), act({ id: 'a1', duration: '10 min', inputs: ['i1'] })];
+    const layout = buildTimelineLayout(makeGraph(nodes));
+    const i1 = layout.nodes.find(n => n.id === 'i1')!;
+    const a1 = layout.nodes.find(n => n.id === 'a1')!;
+    // Single ingredient — should be centred above its consumer
+    assert.strictEqual(i1.cx, a1.cx, 'single ingredient should share cx with its consumer action');
+  });
+
+  it('multiple ingredients are fanned around their consumer action cx', () => {
+    const nodes = [
+      ing({ id: 'i1' }),
+      ing({ id: 'i2' }),
+      ing({ id: 'i3' }),
+      act({ id: 'a1', duration: '10 min', inputs: ['i1','i2','i3'] }),
+    ];
+    const layout = buildTimelineLayout(makeGraph(nodes));
+    const a1 = layout.nodes.find(n => n.id === 'a1')!;
+    const i1 = layout.nodes.find(n => n.id === 'i1')!;
+    const i2 = layout.nodes.find(n => n.id === 'i2')!;
+    const i3 = layout.nodes.find(n => n.id === 'i3')!;
+    // All three should have distinct cx values
+    assert.notStrictEqual(i1.cx, i2.cx);
+    assert.notStrictEqual(i2.cx, i3.cx);
+    // Middle ingredient should be centred on the action
+    assert.strictEqual(i2.cx, a1.cx, 'middle ingredient should sit at action cx');
+    // Ingredients should be symmetric around action
+    assert.ok(Math.abs((a1.cx - i1.cx) - (i3.cx - a1.cx)) < 1, 'fan should be symmetric');
+  });
+
+  it('ingredient node cy is in the ingredient zone (above action tracks)', () => {
+    const nodes  = [ing({ id: 'i1' }), act({ id: 'a1', inputs: ['i1'] })];
+    const layout = buildTimelineLayout(makeGraph(nodes));
+    const i1 = layout.nodes.find(n => n.id === 'i1')!;
+    const a1 = layout.nodes.find(n => n.id === 'a1')!;
+    assert.ok(i1.cy < layout.actionZoneY, 'ingredient cy should be above actionZoneY');
+    assert.ok(i1.cy < a1.cy, 'ingredient should be visually above its action');
+  });
+
+  it('respects lane ordering from graph.lanes (action nodes)', () => {
+    const nodes: RecipeNode[] = [
+      act({ id: 'serve-step', laneId: 'lane-3' }),
+      act({ id: 'prep-step',  laneId: 'lane-1' }),
+    ];
+    const graph: RecipeGraph = {
+      lanes: [
+        { id: 'lane-1', label: 'Prep',  type: 'prep'  },
+        { id: 'lane-2', label: 'Cook',  type: 'cook'  },
+        { id: 'lane-3', label: 'Serve', type: 'serve' },
+      ],
+      nodes,
+    };
+    const layout = buildTimelineLayout(graph);
+    const prep  = layout.nodes.find(n => n.id === 'prep-step')!;
+    const serve = layout.nodes.find(n => n.id === 'serve-step')!;
+    assert.ok(prep.cy < serve.cy, 'prep lane should render above serve lane');
+  });
+
+  it('cx is greater for a later-starting action node', () => {
+    const nodes  = [act({ id: 'A', duration: '10 min' }), act({ id: 'B', duration: '5 min', inputs: ['A'] })];
+    const layout = buildTimelineLayout(makeGraph(nodes));
+    const a = layout.nodes.find(n => n.id === 'A')!;
+    const b = layout.nodes.find(n => n.id === 'B')!;
+    assert.ok(b.cx > a.cx, 'B starts after A so should be to the right');
+  });
+
+  it('pixelsPerMin stays within bounds', () => {
+    const nodes  = Array.from({ length: 5 }, (_, i) => act({ id: `n${i}`, duration: '60 min' }));
+    const layout = buildTimelineLayout(makeGraph(nodes));
+    assert.ok(layout.pixelsPerMin >= TL.MIN_PPM);
+    assert.ok(layout.pixelsPerMin <= TL.MAX_PPM);
+  });
+
+  it('actionZoneY equals RULER_H + INGREDIENT_ZONE_H', () => {
+    const layout = buildTimelineLayout(makeGraph([act({ id: 'x' })]));
+    assert.strictEqual(layout.actionZoneY, TL.RULER_H + TL.INGREDIENT_ZONE_H);
+  });
+});

--- a/recipe-lanes/tests/timeline-save.test.ts
+++ b/recipe-lanes/tests/timeline-save.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { getDataService, setDataService, MemoryDataService } from '../lib/data-service';
+import { calculateLayout } from '../lib/recipe-lanes/layout';
+import type { RecipeGraph, RecipeNode } from '../lib/recipe-lanes/types';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function ing(partial: Partial<RecipeNode> & { id: string }): RecipeNode {
+  return { laneId: 'prep', text: partial.id, visualDescription: partial.id, type: 'ingredient', x: 0, y: 0, inputs: [], ...partial } as RecipeNode;
+}
+
+function act(partial: Partial<RecipeNode> & { id: string }): RecipeNode {
+  return { laneId: 'prep', text: partial.id, visualDescription: partial.id, type: 'action', x: 0, y: 0, inputs: [], ...partial } as RecipeNode;
+}
+
+// Sample graph: onion (ing) → chop (action) → saute (action) → finish (action)
+const sampleGraph: RecipeGraph = {
+  title: 'Timeline Test Recipe',
+  lanes: [
+    { id: 'prep', label: 'prep', type: 'prep' },
+    { id: 'cook', label: 'cook', type: 'cook' },
+  ],
+  nodes: [
+    ing({ id: 'onion', laneId: 'prep' }),
+    act({ id: 'chop', laneId: 'prep', inputs: ['onion'], duration: '3 min' }),
+    act({ id: 'saute', laneId: 'cook', inputs: ['chop'], duration: '5 min' }),
+    act({ id: 'finish', laneId: 'cook', inputs: ['saute'], duration: '2 min' }),
+  ],
+};
+
+// ── Simulates what useSaveAndFork.getGraph() does ──────────────────────────────
+//
+// The UI runs calculateLayout to get initial positions, then ReactFlow nodes
+// carry those positions. On save, getGraph() snapshots them into layouts[mode].
+// Here we do the same computation without ReactFlow in the loop.
+
+function buildGraphToSave(baseGraph: RecipeGraph, movedNodeId: string, dx: number, dy: number): RecipeGraph {
+  const mode = 'timeline';
+
+  // Step 1: run layout to get positions (same as react-flow-diagram.tsx runLayout)
+  const layout = calculateLayout(baseGraph, mode);
+
+  // Step 2: build a positions map from the layout (same as what RF node.position holds)
+  const positions: Record<string, { x: number; y: number }> = {};
+  for (const vn of layout.nodes) {
+    positions[vn.id] = { x: vn.x, y: vn.y };
+  }
+
+  // Step 3: simulate a node drag — update the position of movedNodeId
+  if (positions[movedNodeId]) {
+    positions[movedNodeId] = {
+      x: positions[movedNodeId].x + dx,
+      y: positions[movedNodeId].y + dy,
+    };
+  }
+
+  // Step 4: build layouts[mode] snapshot (same as useSaveAndFork.getGraph())
+  const layouts: Record<string, { id: string; x: number; y: number }[]> = {
+    ...(baseGraph.layouts ?? {}),
+    [mode]: Object.entries(positions).map(([id, pos]) => ({ id, x: pos.x, y: pos.y })),
+  };
+
+  // Step 5: embed positions into nodes (same as useSaveAndFork.getGraph())
+  const nodesWithPos = baseGraph.nodes.map(n => ({
+    ...n,
+    x: positions[n.id]?.x ?? n.x ?? 0,
+    y: positions[n.id]?.y ?? n.y ?? 0,
+  }));
+
+  return { ...baseGraph, nodes: nodesWithPos, layouts, layoutMode: mode };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('timeline save / load round-trip', () => {
+  beforeEach(() => {
+    setDataService(new MemoryDataService());
+  });
+
+  it('persists layoutMode=timeline after save and reload', async () => {
+    const graphToSave = buildGraphToSave(sampleGraph, 'saute', 0, 0);
+    assert.strictEqual(graphToSave.layoutMode, 'timeline', 'layoutMode should be set before save');
+
+    const service = getDataService();
+    const id = await service.saveRecipe(graphToSave, undefined, 'test-user', 'unlisted');
+    const loaded = await service.getRecipe(id);
+
+    assert.ok(loaded, 'recipe should exist after save');
+    assert.strictEqual(loaded!.graph.layoutMode, 'timeline', 'layoutMode should survive save/load');
+  });
+
+  it('persists node positions including a simulated drag', async () => {
+    const dx = 42, dy = -17;
+    const graphToSave = buildGraphToSave(sampleGraph, 'saute', dx, dy);
+
+    // Record the pre-save position for 'saute'
+    const sauteBeforeSave = graphToSave.nodes.find(n => n.id === 'saute')!;
+
+    const service = getDataService();
+    const id = await service.saveRecipe(graphToSave, undefined, 'test-user', 'unlisted');
+    const loaded = await service.getRecipe(id);
+
+    assert.ok(loaded, 'recipe should exist after save');
+    const sauteAfterLoad = loaded!.graph.nodes.find(n => n.id === 'saute')!;
+    assert.ok(sauteAfterLoad, 'saute node should exist in loaded graph');
+    assert.strictEqual(sauteAfterLoad.x, sauteBeforeSave.x, 'saute x should be preserved');
+    assert.strictEqual(sauteAfterLoad.y, sauteBeforeSave.y, 'saute y should be preserved');
+  });
+
+  it('persists the layouts[timeline] map with per-node positions', async () => {
+    const dx = 100, dy = 50;
+    const graphToSave = buildGraphToSave(sampleGraph, 'finish', dx, dy);
+
+    const service = getDataService();
+    const id = await service.saveRecipe(graphToSave, undefined, 'test-user', 'unlisted');
+    const loaded = await service.getRecipe(id);
+
+    const tlLayouts = loaded!.graph.layouts?.['timeline'];
+    assert.ok(tlLayouts && tlLayouts.length > 0, 'layouts.timeline should be populated');
+
+    const finishEntry = tlLayouts!.find((e: any) => e.id === 'finish');
+    const expectedFinish = graphToSave.layouts!['timeline'].find(e => e.id === 'finish');
+    assert.ok(finishEntry, 'finish entry should be in layouts.timeline');
+    assert.strictEqual(finishEntry!.x, expectedFinish!.x, 'finish x should match saved value');
+    assert.strictEqual(finishEntry!.y, expectedFinish!.y, 'finish y should match saved value');
+  });
+
+  it('each node in layouts.timeline has distinct positions (layout ran)', async () => {
+    const graphToSave = buildGraphToSave(sampleGraph, 'chop', 0, 0);
+    const tlLayouts = graphToSave.layouts!['timeline'];
+
+    // All action nodes should have non-zero x (timeline lays them out horizontally)
+    const actionEntries = tlLayouts.filter(e => sampleGraph.nodes.find(n => n.id === e.id && n.type === 'action'));
+    assert.ok(actionEntries.length >= 2, 'should have at least 2 action entries in layouts');
+    const xs = actionEntries.map(e => e.x);
+    const allSame = xs.every(x => x === xs[0]);
+    assert.ok(!allSame, 'action nodes should have different x positions in timeline layout');
+  });
+});


### PR DESCRIPTION
## Summary

- New `timeline2` layout mode with `TimelineNode`, `TimelineEdge`, and `TimelineBackground` components
- `timeline-layout.ts` computes positions for the timeline view
- `TimelineView` side panel component
- Restores `layoutMode` and timeline node positions correctly on reload
- `timeline2` added to the layout mode type union in `page.tsx`

## Status

Position saving for timeline2 nodes is not yet wired up (tracked in commit message). Depends on #140 for the layout persistence infrastructure.

## Test plan

- [ ] Switch to timeline2 mode — timeline view renders
- [ ] Existing layout modes unaffected
- [ ] `npx playwright test e2e/layout-persistence.spec.ts` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)