### PR TITLE
feat(icons): smart hydration — instant icons on first render

### DIFF
--- a/recipe-lanes/app/actions.ts
+++ b/recipe-lanes/app/actions.ts
@@ -24,9 +24,9 @@ import { getAuthService } from '@/lib/auth-service';
 import { z } from 'zod';
 import { generateRecipePrompt, parseRecipeGraph, extractServes, generateHydeQueriesPrompt, parseHydeQueries } from '@/lib/recipe-lanes/parser';
 import { generateAdjustmentPrompt } from '@/lib/recipe-lanes/adjuster';
-import type { RecipeGraph, IconStats } from '@/lib/recipe-lanes/types';
+import type { RecipeGraph, IconStats, FastMatch } from '@/lib/recipe-lanes/types';
 import { standardizeIngredientName } from '@/lib/utils';
-import { cosineSimilarity, getIconThumbUrl, getNodeIconUrl, getShortlistIconAt, preserveNodeShortlist, buildShortlistEntry, mutateNodesByIngredient, markEntryImpressedAtIndex, getEntryIcon } from '@/lib/recipe-lanes/model-utils';
+import { cosineSimilarity, getIconThumbUrl, getNodeIconUrl, getShortlistIconAt, preserveNodeShortlist, buildShortlistEntry, mutateNodesByIngredient, markEntryImpressedAtIndex, getEntryIcon, extractBatchIngredients, getNodeIngredientName } from '@/lib/recipe-lanes/model-utils';
 import { db } from '@/lib/firebase-admin';
 import { DB_COLLECTION_RECIPES, DB_COLLECTION_QUEUE } from '@/lib/config';
 import { unifiedIconSearch, serverBatchIconSearch } from '@/lib/search-orchestrator';
@@ -151,8 +151,42 @@ export async function createVisualRecipeAction(recipeText: string, currentId?: s
             graph.serves = 1;
         }
 
-        // 2. Optimistic Cache Lookup & Queuing (Unified)
-        console.log('[createVisualRecipeAction] 🔍 Checking cache & queuing...');
+        // 2. Synchronous icon pre-population — hydrate the top match per node before saving
+        // so the UI renders with icons on first snapshot, then the client hydrates the rest.
+        console.log('[createVisualRecipeAction] 🔍 Looking up icons from index...');
+        try {
+            const ingredients = extractBatchIngredients(graph.nodes);
+            if (ingredients.length > 0) {
+                const batchResults = await serverBatchIconSearch(ingredients, 12);
+                const topMatchesToHydrate: { name: string; fast_matches: FastMatch[] }[] = [];
+                const allMatchesByName = new Map<string, FastMatch[]>();
+
+                for (const res of batchResults) {
+                    if (res.fast_matches && res.fast_matches.length > 0) {
+                        allMatchesByName.set(res.name, res.fast_matches);
+                        topMatchesToHydrate.push({ name: res.name, fast_matches: [res.fast_matches[0]] });
+                    }
+                }
+
+                if (topMatchesToHydrate.length > 0) {
+                    const hydratedResults = await hydrateBatch(topMatchesToHydrate);
+                    for (const node of graph.nodes) {
+                        if (!node.visualDescription) continue;
+                        const stdName = standardizeIngredientName(getNodeIngredientName(node));
+                        const result = hydratedResults.find(r => r.name === stdName);
+                        if (result && result.icons.length > 0) {
+                            const icon = result.icons[0];
+                            node.iconShortlist = [buildShortlistEntry(icon, 'search', result.matchScores[icon.id] ?? 0)];
+                            node.shortlistIndex = 0;
+                        }
+                        const allMatches = allMatchesByName.get(stdName);
+                        if (allMatches && allMatches.length > 0) node.fastMatches = allMatches;
+                    }
+                }
+            }
+        } catch (e) {
+            console.warn('[createVisualRecipeAction] Icon pre-population failed (non-fatal):', e);
+        }
 
         // 3. Save to Firestore (Initial)
         const session = await getAuthService().verifyAuth();

--- a/recipe-lanes/app/actions.ts
+++ b/recipe-lanes/app/actions.ts
@@ -176,7 +176,10 @@ export async function createVisualRecipeAction(recipeText: string, currentId?: s
                         const result = hydratedResults.find(r => r.name === stdName);
                         if (result && result.icons.length > 0) {
                             const icon = result.icons[0];
-                            node.iconShortlist = [buildShortlistEntry(icon, 'search', result.matchScores[icon.id] ?? 0)];
+                            node.iconShortlist = markEntryImpressedAtIndex(
+                                [buildShortlistEntry(icon, 'search', result.matchScores[icon.id] ?? 0)],
+                                0,
+                            );
                             node.shortlistIndex = 0;
                         }
                         const allMatches = allMatchesByName.get(stdName);

--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -25,7 +25,7 @@ import { LogoutButton } from '@/components/logout-button';
 import ReactFlowDiagram, { ReactFlowDiagramHandle } from '@/components/recipe-lanes/react-flow-diagram';
 import { ReactFlowProvider } from 'reactflow';
 import { createVisualRecipeAction, adjustRecipeAction, saveRecipeAction, checkExistingCopiesAction, debugLogAction, applyIconSearchResultsAction } from '@/app/actions';
-import { iconSearchMethods, defaultIconSearchMethod } from '@/lib/icon-search-registry';
+import { iconSearchMethods, defaultIconSearchMethod, hydrateClientSide } from '@/lib/icon-search-registry';
 import { standardizeIngredientName } from '@/lib/utils';
 import { IngredientsSidebar } from '@/components/recipe-lanes/ui/ingredients-sidebar';
 import { TimelineView } from '@/components/recipe-lanes/timeline-view';
@@ -200,6 +200,38 @@ function RecipeLanesContent() {
       }
   };
 
+  const handleHydrateFastMatches = async () => {
+      if (!graph || !recipeId) return;
+      const itemsToHydrate: { name: string; fast_matches: { icon_id: string; score: number }[] }[] = [];
+      for (const node of graph.nodes) {
+          if (!node.fastMatches || node.fastMatches.length === 0) continue;
+          const stdName = standardizeIngredientName(getNodeIngredientName(node));
+          if (!itemsToHydrate.find(i => i.name === stdName)) {
+              itemsToHydrate.push({ name: stdName, fast_matches: node.fastMatches });
+          }
+      }
+      if (itemsToHydrate.length === 0) {
+          handleBatchIconSearch(defaultIconSearchMethod.id);
+          return;
+      }
+      setIconSearchStatus('running');
+      setIconSearchElapsed(null);
+      try {
+          const t0 = Date.now();
+          const results = await hydrateClientSide(itemsToHydrate);
+          const res = await applyIconSearchResultsAction(recipeId, results);
+          if (!res.success) throw new Error(res.error);
+          console.log(`[hydrateFastMatches] applied ${res.applied} in ${res.elapsed}ms (total: ${Date.now() - t0}ms)`);
+          setIconSearchElapsed(res.elapsed);
+          setIconSearchStatus('done');
+          setTimeout(() => setIconSearchStatus('idle'), 4000);
+      } catch (e: any) {
+          console.error('[handleHydrateFastMatches]', e);
+          setIconSearchStatus('error');
+          setTimeout(() => setIconSearchStatus('idle'), 3000);
+      }
+  };
+
 const saveAndHandleFork = async (graphToSave: RecipeGraph) => {
       const currentId = searchParams.get('id');
       const isNotOwner = (user && ownerId && user.uid !== ownerId) || (!user && ownerId);
@@ -354,13 +386,13 @@ const saveAndHandleFork = async (graphToSave: RecipeGraph) => {
       return () => unsubscribe();
   }, [recipeId]);
 
-  // After a new recipe is created, auto-fill icons using the default (client-side) method
-  // once the graph has loaded. The server-side path may not have a CF URL configured.
+  // After a new recipe is created, hydrate fastMatches (pre-populated server-side) or
+  // fall back to a full client-side search if none are present.
   useEffect(() => {
       if (!autoFillIconsRef.current) return;
       if (!graph || !recipeId || graph.nodes.length === 0) return;
       autoFillIconsRef.current = false;
-      handleBatchIconSearch(defaultIconSearchMethod.id);
+      handleHydrateFastMatches();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [graph, recipeId]);
 

--- a/recipe-lanes/components/recipe-lanes/ui/loading-screen.tsx
+++ b/recipe-lanes/components/recipe-lanes/ui/loading-screen.tsx
@@ -26,20 +26,24 @@ interface LoadingScreenProps {
 export function LoadingScreen({ phase }: LoadingScreenProps) {
   if (!phase) return null;
 
+  if (phase === 'icons') {
+    return (
+      <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-50 pointer-events-none" data-testid="loading-screen">
+        <div className="bg-white border border-zinc-200 px-4 py-2 rounded-full shadow-lg flex items-center gap-2">
+          <Loader2 className="w-4 h-4 text-yellow-500 animate-spin shrink-0" />
+          <span className="text-sm font-medium text-zinc-700">Finding icons...</span>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="absolute inset-0 z-50 bg-zinc-100/80 backdrop-blur-sm flex flex-col items-center justify-center p-6 text-center" data-testid="loading-screen">
       <div className="bg-white border-2 border-zinc-200 p-8 rounded-2xl shadow-xl flex flex-col items-center max-w-sm w-full space-y-6">
         <Loader2 className="w-12 h-12 text-yellow-500 animate-spin" />
-        
         <div className="space-y-2">
-          <h2 className="text-xl font-bold text-zinc-800">
-            {phase === 'graph' ? 'Making Recipe Graph' : 'Finding Icons'}
-          </h2>
-          <p className="text-sm text-zinc-500">
-            {phase === 'graph' 
-              ? 'Parsing your ingredients and steps into a visual flow...' 
-              : 'Searching our database for the best ingredients imagery...'}
-          </p>
+          <h2 className="text-xl font-bold text-zinc-800">Making Recipe Graph</h2>
+          <p className="text-sm text-zinc-500">Parsing your ingredients and steps into a visual flow...</p>
         </div>
       </div>
     </div>

--- a/recipe-lanes/lib/data-service.ts
+++ b/recipe-lanes/lib/data-service.ts
@@ -613,7 +613,13 @@ export class FirebaseDataService implements DataService {
         ]);
         settled.forEach((r, i) => { if (r.status === 'rejected') console.warn(`[rejectRecipeIcon] task[${i}] failed:`, r.reason); });
 
-        await this.resolveRecipeIcons(recipeId, batchSearchFn);
+        if (batchSearchFn) {
+            // Normal reject: search index for a replacement, only queue if nothing found.
+            await this.resolveRecipeIcons(recipeId, batchSearchFn);
+        } else {
+            // Forge: skip the index search and queue only this one ingredient for generation.
+            await this.queueIconForGeneration(recipeId, stdName);
+        }
         return { success: true };
       } catch (e: any) {
           return { success: false, error: e.message };

--- a/recipe-lanes/lib/icon-search-registry.ts
+++ b/recipe-lanes/lib/icon-search-registry.ts
@@ -45,7 +45,7 @@ export type IconSearchMethod = {
 };
 
 // Client-side hydration from the Firestore icon_index (batches in chunks of 10)
-async function hydrateClientSide(
+export async function hydrateClientSide(
     items: { name: string; fast_matches: { icon_id: string; score: number }[] }[]
 ): Promise<SearchResult[]> {
     const allIds = [...new Set(items.flatMap(i => i.fast_matches.map(m => m.icon_id)))];

--- a/recipe-lanes/lib/recipe-lanes/types.ts
+++ b/recipe-lanes/lib/recipe-lanes/types.ts
@@ -44,6 +44,11 @@ export interface IconStats {
     searchTerms?: SearchTerm[];
 }
 
+export interface FastMatch {
+    icon_id: string;
+    score: number;
+}
+
 /** Shape of a document in the Firestore `icon_index` collection. Internal to data-service. */
 export interface IconIndexEntry {
     icon_id: string;
@@ -91,6 +96,7 @@ export interface RecipeNode {
   };
   status?: 'pending' | 'processing' | 'failed';
   hydeQueries?: string[];
+  fastMatches?: FastMatch[];
 
   type: 'ingredient' | 'action';
   inputs?: string[]; // IDs of nodes that flow into this one


### PR DESCRIPTION
## Summary

- On recipe creation, server synchronously resolves the top icon match per node **before** saving to Firestore so icons appear on the very first Firestore snapshot (no blank → pop-in delay)
- Remaining `fast_matches` are stored on each node; the client hydrates the full shortlist after load via `handleHydrateFastMatches`, falling back to a full search if none are present
- `FastMatch` type added to `types.ts`; `hydrateClientSide` exported from `icon-search-registry`

Stacked on top of #153.

## Test plan

- [ ] Create a recipe — icons should appear immediately with no loading delay
- [ ] Confirm fallback: if fast_matches are absent, full client search still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)