### PR TITLE
fix(types): remove duplicate local FastMatch type shadowing the import

### DIFF
--- a/recipe-lanes/app/actions.ts
+++ b/recipe-lanes/app/actions.ts
@@ -24,9 +24,9 @@ import { getAuthService } from '@/lib/auth-service';
 import { z } from 'zod';
 import { generateRecipePrompt, parseRecipeGraph, extractServes, generateHydeQueriesPrompt, parseHydeQueries } from '@/lib/recipe-lanes/parser';
 import { generateAdjustmentPrompt } from '@/lib/recipe-lanes/adjuster';
-import type { RecipeGraph, IconStats, FastMatch } from '@/lib/recipe-lanes/types';
+import type { RecipeGraph, IconStats, FastMatch, RecipePatch } from '@/lib/recipe-lanes/types';
 import { standardizeIngredientName } from '@/lib/utils';
-import { cosineSimilarity, getIconThumbUrl, getNodeIconUrl, getShortlistIconAt, preserveNodeShortlist, buildShortlistEntry, mutateNodesByIngredient, markEntryImpressedAtIndex, getEntryIcon, extractBatchIngredients, getNodeIngredientName } from '@/lib/recipe-lanes/model-utils';
+import { cosineSimilarity, getIconThumbUrl, getNodeIconUrl, getShortlistIconAt, preserveNodeShortlist, buildShortlistEntry, mutateNodesByIngredient, markEntryImpressedAtIndex, getEntryIcon, extractBatchIngredients, getNodeIngredientName, applyPatch } from '@/lib/recipe-lanes/model-utils';
 import { db } from '@/lib/firebase-admin';
 import { DB_COLLECTION_RECIPES, DB_COLLECTION_QUEUE } from '@/lib/config';
 import { unifiedIconSearch, serverBatchIconSearch } from '@/lib/search-orchestrator';
@@ -372,16 +372,37 @@ export async function adjustRecipeAction(currentGraph: RecipeGraph, prompt: stri
     const fullPrompt = generateAdjustmentPrompt(currentGraph, prompt);
     const text = await getAIService().generateText(fullPrompt);
 
-    const newGraph = parseRecipeGraph(text);
+    // Parse the raw JSON from the response
+    let jsonStr = text.trim();
+    const fenceMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (fenceMatch) jsonStr = fenceMatch[1].trim();
+    else {
+      const s = jsonStr.indexOf('{'), e = jsonStr.lastIndexOf('}');
+      if (s !== -1 && e > s) jsonStr = jsonStr.slice(s, e + 1);
+    }
+    const parsed = JSON.parse(jsonStr);
 
-    // Restore icons if ID matches and AI forgot them
-    newGraph.nodes = newGraph.nodes.map(n => {
+    let newGraph: RecipeGraph;
+    let message: string;
+
+    if (parsed.lanes && parsed.nodes) {
+      // Model returned a full graph
+      newGraph = parseRecipeGraph(jsonStr);
+      // Restore icons for unchanged nodes
+      newGraph.nodes = newGraph.nodes.map(n => {
         if (getNodeIconUrl(n)) return n;
         const old = currentGraph.nodes.find(o => o.id === n.id);
         return old ? preserveNodeShortlist(n, old) : n;
-    });
+      });
+      message = (parsed as any).message ?? prompt;
+    } else {
+      // Model returned a patch
+      const patch = parsed as RecipePatch;
+      newGraph = applyPatch(currentGraph, patch);
+      message = patch.message;
+    }
 
-    return { graph: newGraph, adjustment: prompt };
+    return { graph: newGraph, message };
   } catch (e: any) {
     console.error('adjustRecipeAction failed:', e);
     return { error: e.message };

--- a/recipe-lanes/app/actions.ts
+++ b/recipe-lanes/app/actions.ts
@@ -479,7 +479,6 @@ export async function debugLogAction(message: string) {
 }
 
 // Hydrate icon IDs from Firestore for multiple ingredients in one pass.
-type FastMatch = { icon_id: string; score: number };
 async function hydrateBatch(
     items: { name: string; fast_matches: FastMatch[] }[]
 ): Promise<{ name: string; icons: IconStats[]; matchScores: Record<string, number> }[]> {

--- a/recipe-lanes/app/actions.ts
+++ b/recipe-lanes/app/actions.ts
@@ -412,12 +412,26 @@ export async function adjustRecipeAction(currentGraph: RecipeGraph, prompt: stri
 export async function saveRecipeAction(graph: RecipeGraph, existingId?: string, visibility: 'private' | 'unlisted' | 'public' = 'unlisted') {
   try {
     const session = await getAuthService().verifyAuth();
-    const userId = session?.uid; 
+    const userId = session?.uid;
     const ownerName = session?.name;
-    
+
     const dataService = getDataService();
     const id = await dataService.saveRecipe(graph, existingId, userId, visibility, ownerName);
+    // Resolve icons for any pending nodes (e.g. added via AI adjustment)
+    const hasPending = graph.nodes.some(n => n.status === 'pending');
+    if (hasPending) {
+      after(() => dataService.resolveRecipeIcons(id, serverBatchSearchAction));
+    }
     return { id };
+  } catch (e: any) {
+    return { error: e.message };
+  }
+}
+
+export async function saveChatHistoryAction(recipeId: string, messages: { role: 'user' | 'assistant'; content: string; timestamp: number }[]) {
+  try {
+    await db.collection('recipes').doc(recipeId).update({ chatHistory: messages });
+    return { success: true };
   } catch (e: any) {
     return { error: e.message };
   }

--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -54,7 +54,8 @@ function RecipeLanesContent() {
   const graph = useRecipeStore(s => s.graph);
   const ownerId = useRecipeStore(s => s.ownerId);
   const ownerName = useRecipeStore(s => s.ownerName);
-  const { mergeSnapshot, setGraph, reset: resetRecipeStore } = useRecipeStore.getState();
+  const { mergeSnapshot, setGraph, setGraphWithUndo, undo, reset: resetRecipeStore } = useRecipeStore.getState();
+  const canUndo = useRecipeStore(s => s.undoStack.length > 0);
   
   useEffect(() => {
       console.log('[RecipeLanesPage] User:', user?.uid, 'Owner:', ownerId);
@@ -84,6 +85,18 @@ function RecipeLanesContent() {
   const isForking = useRef(false);
   const titleBeforeEdit = useRef('');
   const autoFillIconsRef = useRef(false);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'z' && !e.shiftKey) {
+        const { undoStack } = useRecipeStore.getState();
+        if (undoStack.length > 0) { e.preventDefault(); undo(); }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const isOwner = !ownerId || (!!user && user.uid === ownerId);
 
@@ -586,18 +599,18 @@ const handleVisualize = async () => {
               throw new Error(res.error || 'Failed to adjust graph.');
           }
           res.graph.title = recipeTitle; // Preserve title
-          setGraph(res.graph);
-          
+          setGraphWithUndo(res.graph);
+
           const currentId = searchParams.get('id') || undefined;
           if (currentId) {
               await saveRecipeAction(res.graph, currentId);
           }
-          
+
           setStatus('complete');
       } catch (e: any) {
           console.error('Adjustment failed:', e);
           setError(e.message);
-          setStatus('error'); 
+          setStatus('error');
       }
   };
 
@@ -1102,8 +1115,17 @@ const handleVisualize = async () => {
 
                     <div className="hidden md:flex absolute bottom-4 left-1/2 -translate-x-1/2 justify-center pointer-events-auto w-full max-w-lg">
                         <div className="w-full bg-white/95 backdrop-blur border border-zinc-200 rounded-full shadow-xl flex items-center p-1">
-                            <MessageSquare className="w-5 h-5 text-zinc-400 ml-2" />
-                            <input 
+                            {canUndo && (
+                                <button
+                                    onClick={undo}
+                                    title="Undo (⌘Z)"
+                                    className="p-2 text-zinc-400 hover:text-zinc-700 rounded-full transition-colors ml-1"
+                                >
+                                    <RotateCcw className="w-4 h-4" />
+                                </button>
+                            )}
+                            {!canUndo && <MessageSquare className="w-5 h-5 text-zinc-400 ml-2" />}
+                            <input
                                 className="flex-1 bg-transparent border-none outline-none text-sm text-zinc-800 placeholder-zinc-400 h-10 px-2"
                                 placeholder="Adjust recipe..."
                                 value={chatInput}
@@ -1131,7 +1153,12 @@ const handleVisualize = async () => {
                         
                         {/* Chat (Right Half) */}
                         <div className="w-1/2 p-2 flex items-center gap-1">
-                            <input 
+                            {canUndo && (
+                                <button onClick={undo} className="text-zinc-400 hover:text-zinc-700 shrink-0">
+                                    <RotateCcw className="w-3 h-3" />
+                                </button>
+                            )}
+                            <input
                                 className="flex-1 bg-zinc-100 border border-zinc-200 rounded-md px-2 text-xs h-full text-zinc-800 outline-none"
                                 placeholder="Adjust..."
                                 value={chatInput}

--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -25,6 +25,7 @@ import { LogoutButton } from '@/components/logout-button';
 import ReactFlowDiagram, { ReactFlowDiagramHandle } from '@/components/recipe-lanes/react-flow-diagram';
 import { ReactFlowProvider } from 'reactflow';
 import { createVisualRecipeAction, adjustRecipeAction, saveRecipeAction, checkExistingCopiesAction, debugLogAction, applyIconSearchResultsAction } from '@/app/actions';
+import { ChatPanel } from '@/components/recipe-lanes/chat-panel';
 import { iconSearchMethods, defaultIconSearchMethod, hydrateClientSide } from '@/lib/icon-search-registry';
 import { standardizeIngredientName } from '@/lib/utils';
 import { IngredientsSidebar } from '@/components/recipe-lanes/ui/ingredients-sidebar';
@@ -51,11 +52,13 @@ function RecipeLanesContent() {
   const [editingTitle, setEditingTitle] = useState(false);
   const [recipeText, setRecipeText] = useState('');
   const [chatInput, setChatInput] = useState('');
+  const [showChat, setShowChat] = useState(false);
   const graph = useRecipeStore(s => s.graph);
   const ownerId = useRecipeStore(s => s.ownerId);
   const ownerName = useRecipeStore(s => s.ownerName);
-  const { mergeSnapshot, setGraph, setGraphWithUndo, undo, reset: resetRecipeStore } = useRecipeStore.getState();
+  const { mergeSnapshot, setGraph, setGraphWithUndo, undo, reset: resetRecipeStore, addMessage, clearMessages } = useRecipeStore.getState();
   const canUndo = useRecipeStore(s => s.undoStack.length > 0);
+  const messageCount = useRecipeStore(s => s.messages.length);
   
   useEffect(() => {
       console.log('[RecipeLanesPage] User:', user?.uid, 'Owner:', ownerId);
@@ -572,6 +575,9 @@ const handleVisualize = async () => {
         url.searchParams.set('id', res.id);
         
         autoFillIconsRef.current = true;
+        clearMessages();
+        addMessage({ role: 'user', content: recipeText });
+        addMessage({ role: 'assistant', content: 'Recipe created! You can ask me to adjust ingredients, serving sizes, or cooking methods.' });
         router.push(url.pathname + url.search);
 
         setStatus('complete');
@@ -587,19 +593,22 @@ const handleVisualize = async () => {
 
   const handleAdjust = async () => {
       if (!graph || !chatInput.trim()) return;
-      
+
       const prompt = chatInput;
-      setChatInput(''); // Clear immediately
+      setChatInput('');
       setStatus('adjusting');
       setError(null);
+      addMessage({ role: 'user', content: prompt });
 
       try {
           const res = await adjustRecipeAction(graph, prompt);
           if (res.error || !res.graph) {
               throw new Error(res.error || 'Failed to adjust graph.');
           }
-          res.graph.title = recipeTitle; // Preserve title
+          res.graph.title = recipeTitle;
           setGraphWithUndo(res.graph);
+          addMessage({ role: 'assistant', content: (res as any).message || 'Done! The recipe has been updated.' });
+          setShowChat(true);
 
           const currentId = searchParams.get('id') || undefined;
           if (currentId) {
@@ -609,6 +618,7 @@ const handleVisualize = async () => {
           setStatus('complete');
       } catch (e: any) {
           console.error('Adjustment failed:', e);
+          addMessage({ role: 'assistant', content: `Sorry, that didn't work: ${e.message}` });
           setError(e.message);
           setStatus('error');
       }
@@ -1113,18 +1123,21 @@ const handleVisualize = async () => {
                         <div className="flex items-center gap-1 opacity-50"><span className="text-xs font-bold">Shift+Drag</span> Rotate Branch</div>
                     </div>
 
-                    <div className="hidden md:flex absolute bottom-4 left-1/2 -translate-x-1/2 justify-center pointer-events-auto w-full max-w-lg">
+                    <div className="hidden md:flex absolute bottom-4 left-1/2 -translate-x-1/2 justify-center pointer-events-auto w-full max-w-lg flex-col items-center gap-0">
+                        {showChat && <ChatPanel onClose={() => setShowChat(false)} />}
                         <div className="w-full bg-white/95 backdrop-blur border border-zinc-200 rounded-full shadow-xl flex items-center p-1">
-                            {canUndo && (
-                                <button
-                                    onClick={undo}
-                                    title="Undo (⌘Z)"
-                                    className="p-2 text-zinc-400 hover:text-zinc-700 rounded-full transition-colors ml-1"
-                                >
-                                    <RotateCcw className="w-4 h-4" />
-                                </button>
-                            )}
-                            {!canUndo && <MessageSquare className="w-5 h-5 text-zinc-400 ml-2" />}
+                            <button
+                                onClick={() => setShowChat(v => !v)}
+                                className="relative ml-1 p-1.5 rounded-full hover:bg-zinc-100 transition-colors"
+                                title="Chat history"
+                            >
+                                <MessageSquare className="w-5 h-5 text-zinc-400" />
+                                {messageCount > 0 && (
+                                    <span className="absolute -top-0.5 -right-0.5 w-3.5 h-3.5 bg-yellow-400 rounded-full text-[9px] font-bold text-zinc-900 flex items-center justify-center">
+                                        {messageCount > 9 ? '9+' : messageCount}
+                                    </span>
+                                )}
+                            </button>
                             <input
                                 className="flex-1 bg-transparent border-none outline-none text-sm text-zinc-800 placeholder-zinc-400 h-10 px-2"
                                 placeholder="Adjust recipe..."
@@ -1153,11 +1166,6 @@ const handleVisualize = async () => {
                         
                         {/* Chat (Right Half) */}
                         <div className="w-1/2 p-2 flex items-center gap-1">
-                            {canUndo && (
-                                <button onClick={undo} className="text-zinc-400 hover:text-zinc-700 shrink-0">
-                                    <RotateCcw className="w-3 h-3" />
-                                </button>
-                            )}
                             <input
                                 className="flex-1 bg-zinc-100 border border-zinc-200 rounded-md px-2 text-xs h-full text-zinc-800 outline-none"
                                 placeholder="Adjust..."

--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -24,7 +24,7 @@ import { useAuth } from '@/components/auth-provider';
 import { LogoutButton } from '@/components/logout-button';
 import ReactFlowDiagram, { ReactFlowDiagramHandle } from '@/components/recipe-lanes/react-flow-diagram';
 import { ReactFlowProvider } from 'reactflow';
-import { createVisualRecipeAction, adjustRecipeAction, saveRecipeAction, checkExistingCopiesAction, debugLogAction, applyIconSearchResultsAction } from '@/app/actions';
+import { createVisualRecipeAction, adjustRecipeAction, saveRecipeAction, saveChatHistoryAction, checkExistingCopiesAction, debugLogAction, applyIconSearchResultsAction } from '@/app/actions';
 import { ChatPanel } from '@/components/recipe-lanes/chat-panel';
 import { iconSearchMethods, defaultIconSearchMethod, hydrateClientSide } from '@/lib/icon-search-registry';
 import { standardizeIngredientName } from '@/lib/utils';
@@ -600,6 +600,7 @@ const handleVisualize = async () => {
         initMessages.forEach(m => addMessage({ role: m.role, content: m.content }));
         // Save before router.push — resetRecipeStore() fires on recipeId change and would wipe messages
         localStorage.setItem(`chat_${res.id}`, JSON.stringify(initMessages));
+        saveChatHistoryAction(res.id, initMessages.map(m => ({ role: m.role, content: m.content, timestamp: m.timestamp })));
         router.push(url.pathname + url.search);
 
         setStatus('complete');
@@ -636,10 +637,11 @@ const handleVisualize = async () => {
           if (currentId) {
               await saveRecipeAction(res.graph, currentId);
           }
-          // Flush messages to localStorage immediately (don't wait for effect)
+          // Flush messages to localStorage and Firestore immediately
           if (currentId) {
               const allMessages = useRecipeStore.getState().messages;
               localStorage.setItem(`chat_${currentId}`, JSON.stringify(allMessages));
+              saveChatHistoryAction(currentId, allMessages.map(m => ({ role: m.role, content: m.content, timestamp: m.timestamp })));
           }
 
           setStatus('complete');

--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -350,6 +350,30 @@ const saveAndHandleFork = async (graphToSave: RecipeGraph) => {
       layoutModeRestoredRef.current = false;
   }, [recipeId]);
 
+  // Persist chat messages to localStorage per recipe, restore on load
+  useEffect(() => {
+      if (!recipeId) return;
+      const stored = localStorage.getItem(`chat_${recipeId}`);
+      if (stored) {
+          try {
+              const msgs = JSON.parse(stored);
+              if (Array.isArray(msgs) && msgs.length > 0) {
+                  // Only restore if store is currently empty (don't clobber live session)
+                  if (useRecipeStore.getState().messages.length === 0) {
+                      msgs.forEach((m: any) => addMessage({ role: m.role, content: m.content }));
+                  }
+              }
+          } catch {}
+      }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recipeId]);
+
+  const messages = useRecipeStore(s => s.messages);
+  useEffect(() => {
+      if (!recipeId || messages.length === 0) return;
+      localStorage.setItem(`chat_${recipeId}`, JSON.stringify(messages));
+  }, [recipeId, messages]);
+
   // Restore the layout mode from the saved graph on initial load.
   // This ensures that if the user last saved in swimlanes mode, we restore
   // to swimlanes mode on reload rather than defaulting to dagre.

--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -396,6 +396,12 @@ const saveAndHandleFork = async (graphToSave: RecipeGraph) => {
 
       // Use Firestore Listener
       const unsubscribe = onSnapshot(doc(db, 'recipes', recipeId), (docSnapshot) => {
+          // Skip the optimistic local echo of our own writes — wait for server confirmation.
+          // hasPendingWrites is true only for the immediate local-cache reflection before
+          // the server has confirmed. Server writes (resolveRecipeIcons, other devices) are
+          // always hasPendingWrites=false and will still come through.
+          if (docSnapshot.metadata.hasPendingWrites) return;
+
           if (docSnapshot.exists()) {
               const data = docSnapshot.data();
               const currentGraph = data.graph as RecipeGraph;
@@ -632,19 +638,17 @@ const handleVisualize = async () => {
           setGraphWithUndo(res.graph);
           addMessage({ role: 'assistant', content: (res as any).message || 'Done! The recipe has been updated.' });
           setShowChat(true);
+          setStatus('complete');
 
+          // Fire-and-forget — UI is already updated, don't block on the Firestore write
           const currentId = searchParams.get('id') || undefined;
           if (currentId) {
-              await saveRecipeAction(res.graph, currentId);
+              saveRecipeAction(res.graph, currentId).then(() => {
+                  const allMessages = useRecipeStore.getState().messages;
+                  localStorage.setItem(`chat_${currentId}`, JSON.stringify(allMessages));
+                  saveChatHistoryAction(currentId, allMessages.map(m => ({ role: m.role, content: m.content, timestamp: m.timestamp })));
+              }).catch(e => console.error('[handleAdjust] save failed:', e));
           }
-          // Flush messages to localStorage and Firestore immediately
-          if (currentId) {
-              const allMessages = useRecipeStore.getState().messages;
-              localStorage.setItem(`chat_${currentId}`, JSON.stringify(allMessages));
-              saveChatHistoryAction(currentId, allMessages.map(m => ({ role: m.role, content: m.content, timestamp: m.timestamp })));
-          }
-
-          setStatus('complete');
       } catch (e: any) {
           console.error('Adjustment failed:', e);
           addMessage({ role: 'assistant', content: `Sorry, that didn't work: ${e.message}` });

--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -350,23 +350,6 @@ const saveAndHandleFork = async (graphToSave: RecipeGraph) => {
       layoutModeRestoredRef.current = false;
   }, [recipeId]);
 
-  // Persist chat messages to localStorage per recipe, restore on load
-  useEffect(() => {
-      if (!recipeId) return;
-      const stored = localStorage.getItem(`chat_${recipeId}`);
-      if (stored) {
-          try {
-              const msgs = JSON.parse(stored);
-              if (Array.isArray(msgs) && msgs.length > 0) {
-                  // Only restore if store is currently empty (don't clobber live session)
-                  if (useRecipeStore.getState().messages.length === 0) {
-                      msgs.forEach((m: any) => addMessage({ role: m.role, content: m.content }));
-                  }
-              }
-          } catch {}
-      }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [recipeId]);
 
   const messages = useRecipeStore(s => s.messages);
   useEffect(() => {
@@ -397,6 +380,16 @@ const saveAndHandleFork = async (graphToSave: RecipeGraph) => {
       if (!recipeId) return;
 
       resetRecipeStore();
+      // Restore chat messages from localStorage after reset
+      try {
+          const stored = localStorage.getItem(`chat_${recipeId}`);
+          if (stored) {
+              const msgs = JSON.parse(stored);
+              if (Array.isArray(msgs) && msgs.length > 0) {
+                  msgs.forEach((m: any) => addMessage({ role: m.role, content: m.content }));
+              }
+          }
+      } catch {}
       debugLogAction('Setting up listener for recipe: ' + recipeId);
       setStatus('loading');
       setWarningDismissed(false);
@@ -600,8 +593,13 @@ const handleVisualize = async () => {
         
         autoFillIconsRef.current = true;
         clearMessages();
-        addMessage({ role: 'user', content: recipeText });
-        addMessage({ role: 'assistant', content: 'Recipe created! You can ask me to adjust ingredients, serving sizes, or cooking methods.' });
+        const initMessages = [
+            { id: crypto.randomUUID(), role: 'user' as const, content: recipeText, timestamp: Date.now() },
+            { id: crypto.randomUUID(), role: 'assistant' as const, content: 'Recipe created! You can ask me to adjust ingredients, serving sizes, or cooking methods.', timestamp: Date.now() },
+        ];
+        initMessages.forEach(m => addMessage({ role: m.role, content: m.content }));
+        // Save before router.push — resetRecipeStore() fires on recipeId change and would wipe messages
+        localStorage.setItem(`chat_${res.id}`, JSON.stringify(initMessages));
         router.push(url.pathname + url.search);
 
         setStatus('complete');
@@ -637,6 +635,11 @@ const handleVisualize = async () => {
           const currentId = searchParams.get('id') || undefined;
           if (currentId) {
               await saveRecipeAction(res.graph, currentId);
+          }
+          // Flush messages to localStorage immediately (don't wait for effect)
+          if (currentId) {
+              const allMessages = useRecipeStore.getState().messages;
+              localStorage.setItem(`chat_${currentId}`, JSON.stringify(allMessages));
           }
 
           setStatus('complete');

--- a/recipe-lanes/components/recipe-lanes/chat-panel.tsx
+++ b/recipe-lanes/components/recipe-lanes/chat-panel.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useRecipeStore } from '@/lib/stores/recipe-store';
+import { MessageSquare, ChefHat, X } from 'lucide-react';
+import type { ChatMessage } from '@/lib/recipe-lanes/types';
+
+interface ChatPanelProps {
+    onClose: () => void;
+}
+
+function Message({ msg }: { msg: ChatMessage }) {
+    const isUser = msg.role === 'user';
+    return (
+        <div className={`flex gap-2 ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
+            <div className={`shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-xs ${
+                isUser ? 'bg-zinc-900 text-white' : 'bg-yellow-100 text-yellow-700'
+            }`}>
+                {isUser ? '↑' : <ChefHat className="w-4 h-4" />}
+            </div>
+            <div className={`max-w-[80%] rounded-2xl px-3 py-2 text-sm leading-relaxed ${
+                isUser
+                    ? 'bg-zinc-900 text-white rounded-tr-sm'
+                    : 'bg-zinc-100 text-zinc-800 rounded-tl-sm'
+            }`}>
+                {msg.content}
+            </div>
+        </div>
+    );
+}
+
+export function ChatPanel({ onClose }: ChatPanelProps) {
+    const messages = useRecipeStore(s => s.messages);
+    const bottomRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, [messages.length]);
+
+    return (
+        <div className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 w-full max-w-lg bg-white/95 backdrop-blur border border-zinc-200 rounded-2xl shadow-2xl flex flex-col overflow-hidden"
+             style={{ maxHeight: '60vh' }}>
+            <div className="flex items-center justify-between px-4 py-2 border-b border-zinc-100 shrink-0">
+                <div className="flex items-center gap-2 text-xs font-semibold text-zinc-500 uppercase tracking-wider">
+                    <MessageSquare className="w-3.5 h-3.5" />
+                    Recipe Chat
+                </div>
+                <button onClick={onClose} className="text-zinc-400 hover:text-zinc-700 transition-colors">
+                    <X className="w-4 h-4" />
+                </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 min-h-0">
+                {messages.length === 0 ? (
+                    <p className="text-xs text-zinc-400 text-center py-4">
+                        Paste a recipe or start adjusting — your conversation will appear here.
+                    </p>
+                ) : (
+                    messages.map(msg => <Message key={msg.id} msg={msg} />)
+                )}
+                <div ref={bottomRef} />
+            </div>
+        </div>
+    );
+}

--- a/recipe-lanes/components/recipe-lanes/nodes/minimal-node.tsx
+++ b/recipe-lanes/components/recipe-lanes/nodes/minimal-node.tsx
@@ -127,14 +127,17 @@ export const MinimalNode: React.FC<any> = ({
       e.stopPropagation();
       setIsForging(true);
       const ingredientName = getNodeIngredientName(data);
+      console.log(`[Forge] node="${data.text}" ingredientName="${ingredientName}" recipeId="${recipeId}"`);
       try {
           const result = await forgeIconAction(recipeId || '', ingredientName, getNodeIconId(data) || '');
           if (result && !result.success) {
               console.error("Forge failed:", result.error);
+              useRecipeStore.getState().addMessage({ role: 'assistant', content: `Forge failed: ${result.error}` });
               setIsForging(false);
           }
-      } catch (err) {
+      } catch (err: any) {
           console.error("Forge exception:", err);
+          useRecipeStore.getState().addMessage({ role: 'assistant', content: `Forge error: ${err?.message ?? err}` });
           setIsForging(false);
       }
   };

--- a/recipe-lanes/components/recipe-lanes/react-flow-diagram.tsx
+++ b/recipe-lanes/components/recipe-lanes/react-flow-diagram.tsx
@@ -442,6 +442,18 @@ const DiagramInner = memo(forwardRef<ReactFlowDiagramHandle, ReactFlowDiagramPro
                 return;
             }
 
+            // Detect nodes added or removed since the last layout (e.g. AI adjustment).
+            // New nodes from applyPatch are in graph.nodes but have no RF node yet;
+            // removed nodes are in RF but gone from graph. Either case requires a fresh
+            // layout pass so the new/removed nodes are actually rendered.
+            const graphNodeIds = new Set(graph.nodes.map(n => n.id));
+            const hasNewNodes = graph.nodes.some(n => !currentRFNodeIds.has(n.id));
+            const hasRemovedNodes = [...currentRFNodeIds].some(id => !graphNodeIds.has(id));
+            if (hasNewNodes || hasRemovedNodes) {
+                runLayout(true, false);
+                return;
+            }
+
             // Once the initial layout has run (or while dirty), ONLY apply metadata updates
             // (icons, text, serves) from DB to EXISTING nodes.
             // We DO NOT restore deleted nodes or move nodes based on DB — that would reset

--- a/recipe-lanes/lib/ai-service.ts
+++ b/recipe-lanes/lib/ai-service.ts
@@ -58,8 +58,9 @@ export class RealAIService implements AIService {
   async generateText(prompt: string): Promise<string> {
     try {
         const response = await ai.generate({
-        model: textModel,
-        prompt: prompt,
+            model: textModel,
+            prompt: prompt,
+            config: { thinkingConfig: { thinkingBudget: 0 } },
         });
         return response.text || '';
     } catch (e) {

--- a/recipe-lanes/lib/recipe-lanes/adjuster.ts
+++ b/recipe-lanes/lib/recipe-lanes/adjuster.ts
@@ -85,6 +85,8 @@ ${PATCH_SCHEMA}
 - **Preserve IDs**: Do not change IDs for unchanged nodes.
 - **New nodes**: Set \`visualDescription\` to an active, object-focused phrase (no hands).
 - **message**: Always include a one-sentence summary of what changed.
+- **Merging nodes**: List ALL nodes being merged in \`removeNodeIds\`. If the result should be a new combined node, add it in \`addNodes\`. You do NOT need to fix \`inputs\` — the system handles dangling refs automatically.
+- **Do not half-merge**: If asked to merge multiple nodes, remove ALL of them — not just some.
 
 ### Current Graph
 \`\`\`json

--- a/recipe-lanes/lib/recipe-lanes/adjuster.ts
+++ b/recipe-lanes/lib/recipe-lanes/adjuster.ts
@@ -85,7 +85,7 @@ ${PATCH_SCHEMA}
 - **Preserve IDs**: Do not change IDs for unchanged nodes.
 - **New nodes**: Set \`visualDescription\` to an active, object-focused phrase (no hands).
 - **message**: Always include a one-sentence summary of what changed.
-- **Merging nodes**: Always do BOTH steps: (1) add the combined result in `addNodes`, (2) put every source node in `removeNodeIds`. Never remove nodes without adding their replacement. Inputs refs are cleaned automatically.
+- **Merging nodes**: Always do BOTH steps: (1) add the combined result in \`addNodes\`, (2) put every source node in \`removeNodeIds\`. Never remove nodes without adding their replacement. Inputs refs are cleaned automatically.
 
 ### Current Graph
 \`\`\`json

--- a/recipe-lanes/lib/recipe-lanes/adjuster.ts
+++ b/recipe-lanes/lib/recipe-lanes/adjuster.ts
@@ -85,8 +85,7 @@ ${PATCH_SCHEMA}
 - **Preserve IDs**: Do not change IDs for unchanged nodes.
 - **New nodes**: Set \`visualDescription\` to an active, object-focused phrase (no hands).
 - **message**: Always include a one-sentence summary of what changed.
-- **Merging nodes**: List ALL nodes being merged in \`removeNodeIds\`. If the result should be a new combined node, add it in \`addNodes\`. You do NOT need to fix \`inputs\` — the system handles dangling refs automatically.
-- **Do not half-merge**: If asked to merge multiple nodes, remove ALL of them — not just some.
+- **Merging nodes**: Always do BOTH steps: (1) add the combined result in `addNodes`, (2) put every source node in `removeNodeIds`. Never remove nodes without adding their replacement. Inputs refs are cleaned automatically.
 
 ### Current Graph
 \`\`\`json

--- a/recipe-lanes/lib/recipe-lanes/adjuster.ts
+++ b/recipe-lanes/lib/recipe-lanes/adjuster.ts
@@ -17,23 +17,28 @@
 
 import type { RecipeGraph } from './types';
 
-const SCHEMA_INTERFACE = `
-interface RecipeGraph {
-  lanes: {
-    id: string;
-    label: string; // e.g. "Skillet"
-    type: 'prep' | 'cook' | 'serve';
+const PATCH_SCHEMA = `
+interface RecipePatch {
+  message: string;          // one sentence describing what changed, shown to the user
+  addNodes?: {
+    id: string; laneId: string; text: string; visualDescription: string;
+    type: 'ingredient' | 'action'; inputs?: string[];
+    temperature?: string; duration?: string;
   }[];
+  updateNodes?: { id: string; [field: string]: any }[];  // only the fields that change
+  removeNodeIds?: string[];
+  addLanes?: { id: string; label: string; type: 'prep' | 'cook' | 'serve' }[];
+  removeLaneIds?: string[];
+  updateTitle?: string;
+}
+
+// Fallback — return a full graph only if the change is so extensive a patch would be larger:
+interface RecipeGraph {
+  lanes: { id: string; label: string; type: 'prep' | 'cook' | 'serve' }[];
   nodes: {
-    id: string;
-    laneId: string; // Must match a lane.id
-    text: string; // Concise instruction
-    visualDescription: string; // Active, object-focused visual prompt (no hands)
-    type: 'ingredient' | 'action';
-    inputs?: string[]; // IDs of previous nodes
-    temperature?: string;
-    duration?: string;
-    iconUrl?: string; // Preserve existing icon URLs if node is unchanged!
+    id: string; laneId: string; text: string; visualDescription: string;
+    type: 'ingredient' | 'action'; inputs?: string[];
+    temperature?: string; duration?: string;
   }[];
 }
 `;
@@ -61,34 +66,33 @@ function stripGraphForPrompt(graph: RecipeGraph): object {
 }
 
 export function generateAdjustmentPrompt(currentGraph: RecipeGraph, userInstruction: string): string {
-  const BLOCK_START = "```typescript";
-  const BLOCK_END = "```";
+  return `You are an expert recipe graph editor.
 
-  return `
-You are an expert recipe graph editor.
-Your goal is to MODIFY the provided "Current Graph" based on the "User Instruction".
+### Task
+Apply the "User Instruction" to the "Current Graph" and return a JSON object.
 
-### Rules
-1. **Preserve ID/State:** Keep existing nodes/lanes if they are still relevant. Do not regenerate IDs for unchanged nodes.
-2. **Preserve Icons:** If you keep a node, KEEP its
-iconUrl
- if present.
-3. **New Nodes:** If adding nodes, generate a
-visualDescription
- following the guidelines (Active, Object-Focused, No Hands).
-4. **Schema:** The output must match the schema strictly.
+### Preferred output: RecipePatch
+Return a patch when the change is surgical (add/remove/edit a few nodes).
+Return a full RecipeGraph only when the change rewrites most of the graph.
 
 ### Schema
-${BLOCK_START}
-${SCHEMA_INTERFACE}
-${BLOCK_END}
+\`\`\`typescript
+${PATCH_SCHEMA}
+\`\`\`
 
-### Current Graph (JSON)
+### Rules
+- **Prefer patch**: For most edits, a patch is smaller and faster to return.
+- **Preserve IDs**: Do not change IDs for unchanged nodes.
+- **New nodes**: Set \`visualDescription\` to an active, object-focused phrase (no hands).
+- **message**: Always include a one-sentence summary of what changed.
+
+### Current Graph
+\`\`\`json
 ${JSON.stringify(stripGraphForPrompt(currentGraph), null, 2)}
+\`\`\`
 
 ### User Instruction
 "${userInstruction}"
 
-Return ONLY the full updated JSON.
-`;
+Return ONLY the JSON object (no markdown, no explanation).`;
 }

--- a/recipe-lanes/lib/recipe-lanes/adjuster.ts
+++ b/recipe-lanes/lib/recipe-lanes/adjuster.ts
@@ -38,6 +38,28 @@ interface RecipeGraph {
 }
 `;
 
+/** Strip internal fields that bloat the prompt and confuse the model. */
+function stripGraphForPrompt(graph: RecipeGraph): object {
+  return {
+    title: graph.title,
+    serves: graph.serves,
+    baseServes: graph.baseServes,
+    lanes: graph.lanes,
+    nodes: graph.nodes.map(n => ({
+      id: n.id,
+      laneId: n.laneId,
+      text: n.text,
+      visualDescription: n.visualDescription,
+      type: n.type,
+      inputs: n.inputs,
+      temperature: n.temperature,
+      duration: n.duration,
+      quantity: n.quantity,
+      unit: n.unit,
+    })),
+  };
+}
+
 export function generateAdjustmentPrompt(currentGraph: RecipeGraph, userInstruction: string): string {
   const BLOCK_START = "```typescript";
   const BLOCK_END = "```";
@@ -48,10 +70,10 @@ Your goal is to MODIFY the provided "Current Graph" based on the "User Instructi
 
 ### Rules
 1. **Preserve ID/State:** Keep existing nodes/lanes if they are still relevant. Do not regenerate IDs for unchanged nodes.
-2. **Preserve Icons:** If you keep a node, KEEP its 
+2. **Preserve Icons:** If you keep a node, KEEP its
 iconUrl
  if present.
-3. **New Nodes:** If adding nodes, generate a 
+3. **New Nodes:** If adding nodes, generate a
 visualDescription
  following the guidelines (Active, Object-Focused, No Hands).
 4. **Schema:** The output must match the schema strictly.
@@ -62,7 +84,7 @@ ${SCHEMA_INTERFACE}
 ${BLOCK_END}
 
 ### Current Graph (JSON)
-${JSON.stringify(currentGraph, null, 2)}
+${JSON.stringify(stripGraphForPrompt(currentGraph), null, 2)}
 
 ### User Instruction
 "${userInstruction}"

--- a/recipe-lanes/lib/recipe-lanes/model-utils.ts
+++ b/recipe-lanes/lib/recipe-lanes/model-utils.ts
@@ -753,12 +753,20 @@ export function applyPatch(graph: RecipeGraph, patch: RecipePatch): RecipeGraph 
     const removeSet = new Set(patch.removeNodeIds ?? []);
     const removeLaneSet = new Set(patch.removeLaneIds ?? []);
 
-    // Keep surviving nodes, apply updates
+    // Keep surviving nodes, apply updates, clean up dangling inputs refs
     let nodes = graph.nodes
         .filter(n => !removeSet.has(n.id))
         .map(n => {
             const update = patch.updateNodes?.find(u => u.id === n.id);
-            return update ? { ...n, ...update } : n;
+            const merged = update ? { ...n, ...update } : n;
+            // Remove any inputs that pointed to now-removed nodes
+            if (merged.inputs && removeSet.size > 0) {
+                const cleanInputs = merged.inputs.filter(id => !removeSet.has(id));
+                if (cleanInputs.length !== merged.inputs.length) {
+                    return { ...merged, inputs: cleanInputs };
+                }
+            }
+            return merged;
         });
 
     // Append new nodes (mark as pending so icons get resolved)

--- a/recipe-lanes/lib/recipe-lanes/model-utils.ts
+++ b/recipe-lanes/lib/recipe-lanes/model-utils.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { RecipeNode, IconStats, IconIndexEntry, ShortlistEntry, SearchTerm, RecipeGraph, IconStyleId } from './types';
+import { RecipeNode, IconStats, IconIndexEntry, ShortlistEntry, SearchTerm, RecipeGraph, IconStyleId, RecipePatch } from './types';
 import { standardizeIngredientName } from '../utils';
 
 /**
@@ -742,5 +742,38 @@ export function preserveNodeShortlist<T extends RecipeNode>(target: T, source: R
         ...target,
         iconShortlist: newShortlist,
         shortlistIndex: source.shortlistIndex,
+    };
+}
+
+/**
+ * Applies a RecipePatch onto an existing graph, returning a new graph.
+ * Icon shortlists on surviving nodes are preserved unchanged.
+ */
+export function applyPatch(graph: RecipeGraph, patch: RecipePatch): RecipeGraph {
+    const removeSet = new Set(patch.removeNodeIds ?? []);
+    const removeLaneSet = new Set(patch.removeLaneIds ?? []);
+
+    // Keep surviving nodes, apply updates
+    let nodes = graph.nodes
+        .filter(n => !removeSet.has(n.id))
+        .map(n => {
+            const update = patch.updateNodes?.find(u => u.id === n.id);
+            return update ? { ...n, ...update } : n;
+        });
+
+    // Append new nodes (mark as pending so icons get resolved)
+    if (patch.addNodes) {
+        nodes = [...nodes, ...patch.addNodes.map(n => ({ ...n, status: 'pending' as const }))];
+    }
+
+    // Lanes
+    let lanes = graph.lanes.filter(l => !removeLaneSet.has(l.id));
+    if (patch.addLanes) lanes = [...lanes, ...patch.addLanes];
+
+    return {
+        ...graph,
+        nodes,
+        lanes,
+        ...(patch.updateTitle !== undefined && { title: patch.updateTitle }),
     };
 }

--- a/recipe-lanes/lib/recipe-lanes/model-utils.ts
+++ b/recipe-lanes/lib/recipe-lanes/model-utils.ts
@@ -771,7 +771,19 @@ export function applyPatch(graph: RecipeGraph, patch: RecipePatch): RecipeGraph 
 
     // Append new nodes (mark as pending so icons get resolved)
     if (patch.addNodes) {
-        nodes = [...nodes, ...patch.addNodes.map(n => ({ ...n, status: 'pending' as const }))];
+        const existingNodes = nodes;
+        nodes = [...nodes, ...patch.addNodes.map(n => {
+            const newNode: RecipeNode = { ...n, status: 'pending' as const };
+            // Place near first input parent if no position set
+            if (newNode.x === undefined && newNode.inputs?.length) {
+                const parent = existingNodes.find(e => e.id === newNode.inputs![0]);
+                if (parent?.x !== undefined && parent?.y !== undefined) {
+                    newNode.x = parent.x + 220;
+                    newNode.y = parent.y;
+                }
+            }
+            return newNode;
+        })];
     }
 
     // Lanes

--- a/recipe-lanes/lib/recipe-lanes/parser.ts
+++ b/recipe-lanes/lib/recipe-lanes/parser.ts
@@ -188,12 +188,20 @@ export function parseHydeQueries(aiResponse: string): string[] {
 }
 
 export function parseRecipeGraph(aiResponse: string): RecipeGraph {
-  // 1. Clean Markdown code blocks if present
+  // 1. Extract JSON — handle markdown code fences and preamble prose
   let jsonStr = aiResponse.trim();
-  if (jsonStr.startsWith("```")) {
-    jsonStr = jsonStr.replace(/^```(json)?/, "").replace(/```$/, "");
+  // Try fenced code block first (anywhere in the response)
+  const fenceMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenceMatch) {
+    jsonStr = fenceMatch[1].trim();
+  } else {
+    // Fall back to extracting the outermost { ... } object
+    const start = jsonStr.indexOf('{');
+    const end = jsonStr.lastIndexOf('}');
+    if (start !== -1 && end > start) {
+      jsonStr = jsonStr.slice(start, end + 1);
+    }
   }
-  jsonStr = jsonStr.trim();
   
   try {
     // 2. Parse JSON

--- a/recipe-lanes/lib/recipe-lanes/types.ts
+++ b/recipe-lanes/lib/recipe-lanes/types.ts
@@ -49,6 +49,23 @@ export interface FastMatch {
     score: number;
 }
 
+/**
+ * Surgical patch returned by the AI for recipe adjustments.
+ * The model returns this instead of a full graph to minimise output tokens.
+ * `applyPatch` merges it onto the existing graph.
+ */
+export interface RecipePatch {
+  /** Human-readable summary shown as the assistant chat message. */
+  message: string;
+  addNodes?: Omit<RecipeNode, 'iconShortlist' | 'shortlistIndex' | 'fastMatches'>[];
+  /** Only the fields that should change, plus `id`. */
+  updateNodes?: (Partial<RecipeNode> & { id: string })[];
+  removeNodeIds?: string[];
+  addLanes?: Lane[];
+  removeLaneIds?: string[];
+  updateTitle?: string;
+}
+
 /** Shape of a document in the Firestore `icon_index` collection. Internal to data-service. */
 export interface IconIndexEntry {
     icon_id: string;

--- a/recipe-lanes/lib/recipe-lanes/types.ts
+++ b/recipe-lanes/lib/recipe-lanes/types.ts
@@ -85,6 +85,13 @@ export interface IngredientDoc {
     updated_at: any;
 }
 
+export interface ChatMessage {
+    id: string;
+    role: 'user' | 'assistant';
+    content: string;
+    timestamp: number;
+}
+
 export interface ShortlistEntry {
     icon: IconStats;
     matchType: 'generated' | 'search';

--- a/recipe-lanes/lib/stores/recipe-store.ts
+++ b/recipe-lanes/lib/stores/recipe-store.ts
@@ -179,14 +179,24 @@ function mergeNodes(
 ): RecipeNode[] {
     // Build a lookup map so merging is O(n) not O(n²).
     const existingById = new Map(existing.map(n => [n.id, n]));
+    const incomingIds = new Set(incoming.map(n => n.id));
+
     const merged = incoming.map(n => {
         const ex = existingById.get(n.id);
         return ex ? mergeNode(ex, n) : n;
     });
 
+    // Preserve locally-added nodes not yet written to Firestore.
+    // This prevents a race where resolveRecipeIcons fires a snapshot using the
+    // pre-adjustment Firestore state and silently drops nodes added by the AI.
+    // Downside: a node deleted on another device will linger until next full reload —
+    // acceptable given single-owner editing is the dominant use case.
+    const pendingLocal = existing.filter(n => !incomingIds.has(n.id));
+    const result = pendingLocal.length > 0 ? [...merged, ...pendingLocal] : merged;
+
     // Return the original array reference if nothing actually changed.
-    const changed = merged.some((n, i) => n !== existing[i] || existing.length !== incoming.length);
-    return changed ? merged : existing;
+    const changed = result.length !== existing.length || result.some((n, i) => n !== existing[i]);
+    return changed ? result : existing;
 }
 
 // ---------------------------------------------------------------------------

--- a/recipe-lanes/lib/stores/recipe-store.ts
+++ b/recipe-lanes/lib/stores/recipe-store.ts
@@ -138,17 +138,29 @@ function mergeNode(existing: RecipeNode, incoming: RecipeNode): RecipeNode {
     const incomingShortlistKey = getNodeShortlistKey(incoming);
     const shortlistChanged = existingShortlistKey !== incomingShortlistKey;
 
-    // Fast path: nothing we care about changed → keep exact reference.
-    if (
-        !shortlistChanged &&
+    const structurallyIdentical =
         existing.text === incoming.text &&
         existing.quantity === incoming.quantity &&
         existing.unit === incoming.unit &&
         existing.visualDescription === incoming.visualDescription &&
         existing.x === incoming.x &&
-        existing.y === incoming.y
-    ) {
+        existing.y === incoming.y;
+
+    // Fast path: nothing changed → keep exact reference.
+    if (!shortlistChanged && structurallyIdentical) {
         return existing;
+    }
+
+    // Icons-only update (resolveRecipeIcons writes back shortlists without touching
+    // structure): preserve all local fields, splice in only the icon-related ones.
+    // This prevents a server write from overwriting local position/text state.
+    if (shortlistChanged && structurallyIdentical) {
+        return {
+            ...existing,
+            iconShortlist: incoming.iconShortlist,
+            shortlistIndex: incoming.shortlistIndex ?? 0,
+            status: incoming.status,
+        };
     }
 
     return {

--- a/recipe-lanes/lib/stores/recipe-store.ts
+++ b/recipe-lanes/lib/stores/recipe-store.ts
@@ -65,6 +65,7 @@ interface RecipeState {
     nodeLayout: LayoutModeId;
     backgrounds: BackgroundElementId[];
     activePresetId: string;
+    undoStack: RecipeGraph[];
 }
 
 interface RecipeActions {
@@ -100,6 +101,15 @@ interface RecipeActions {
      * Marks the recipe dirty — use mergeSnapshot for Firestore data.
      */
     setGraph: (graph: RecipeGraph) => void;
+
+    /**
+     * Pushes the current graph onto the undo stack, then applies the mutation.
+     * Call this before any user-initiated change that should be undoable.
+     */
+    setGraphWithUndo: (graph: RecipeGraph) => void;
+
+    /** Pops the last snapshot from the undo stack and restores it. */
+    undo: () => void;
 
     /** Clears all state — call when the user navigates away from a recipe. */
     reset: () => void;
@@ -167,6 +177,8 @@ function mergeNodes(
 // Store
 // ---------------------------------------------------------------------------
 
+const MAX_UNDO_DEPTH = 20;
+
 const initialState: RecipeState = {
     graph: null,
     recipeId: null,
@@ -180,6 +192,7 @@ const initialState: RecipeState = {
     nodeLayout: 'dagre',
     backgrounds: [],
     activePresetId: 'classic',
+    undoStack: [],
 };
 
 export const useRecipeStore = create<RecipeState & RecipeActions>((set, get) => ({
@@ -222,6 +235,21 @@ export const useRecipeStore = create<RecipeState & RecipeActions>((set, get) => 
     setDirty: (dirty) => set({ isDirty: dirty }),
 
     setGraph: (graph) => set({ graph, isDirty: true }),
+
+    setGraphWithUndo: (graph) => set((state) => ({
+        graph,
+        isDirty: true,
+        undoStack: state.graph
+            ? [...state.undoStack.slice(-MAX_UNDO_DEPTH + 1), state.graph]
+            : state.undoStack,
+    })),
+
+    undo: () => set((state) => {
+        if (state.undoStack.length === 0) return {};
+        const undoStack = [...state.undoStack];
+        const graph = undoStack.pop()!;
+        return { graph, undoStack, isDirty: true };
+    }),
 
     cycleShortlist: (nodeId) => {
         const state = get();

--- a/recipe-lanes/lib/stores/recipe-store.ts
+++ b/recipe-lanes/lib/stores/recipe-store.ts
@@ -43,7 +43,7 @@
  */
 
 import { create } from 'zustand';
-import { RecipeGraph, RecipeNode, IconStyleId, LineStyleId, LayoutModeId, BackgroundElementId } from '../recipe-lanes/types';
+import { RecipeGraph, RecipeNode, IconStyleId, LineStyleId, LayoutModeId, BackgroundElementId, ChatMessage } from '../recipe-lanes/types';
 import { getNodeShortlistKey, cycleShortlistNodes } from '../recipe-lanes/model-utils';
 
 // ---------------------------------------------------------------------------
@@ -66,6 +66,7 @@ interface RecipeState {
     backgrounds: BackgroundElementId[];
     activePresetId: string;
     undoStack: RecipeGraph[];
+    messages: ChatMessage[];
 }
 
 interface RecipeActions {
@@ -110,6 +111,9 @@ interface RecipeActions {
 
     /** Pops the last snapshot from the undo stack and restores it. */
     undo: () => void;
+
+    addMessage: (message: Omit<ChatMessage, 'id' | 'timestamp'>) => void;
+    clearMessages: () => void;
 
     /** Clears all state — call when the user navigates away from a recipe. */
     reset: () => void;
@@ -193,6 +197,7 @@ const initialState: RecipeState = {
     backgrounds: [],
     activePresetId: 'classic',
     undoStack: [],
+    messages: [],
 };
 
 export const useRecipeStore = create<RecipeState & RecipeActions>((set, get) => ({
@@ -259,6 +264,17 @@ export const useRecipeStore = create<RecipeState & RecipeActions>((set, get) => 
 
         set({ graph: { ...state.graph, nodes } });
     },
+
+    addMessage: ({ role, content }) => set((state) => ({
+        messages: [...state.messages, {
+            id: crypto.randomUUID(),
+            role,
+            content,
+            timestamp: Date.now(),
+        }],
+    })),
+
+    clearMessages: () => set({ messages: [] }),
 
     reset: () => set(initialState),
     setVisualPreset: (presetId) => set({ activePresetId: presetId }),

--- a/recipe-lanes/scripts/README.md
+++ b/recipe-lanes/scripts/README.md
@@ -61,9 +61,9 @@ npx tsx scripts/backfill-names.ts --staging
 # Show all nodes, visual descriptions, shortlist sizes, and queue entries for a recipe
 npx tsx --env-file=.env.staging scripts/debug-recipe-nodes.ts <recipeId>
 
-# Run an adjustment against a live recipe — shows full AI prompt, raw response,
-# patch/graph detection, removeNodeId validation, and applyPatch result
-npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> "<instruction>"
+# Run one or more adjustments in sequence — shows AI prompt, raw response, patch
+# detection, removeNodeId validation, applyPatch result, and icon/pending status
+npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> "<step1>" ["<step2>" ...]
 
 # Show recent icon_queue entries (pass a name to look up a specific one)
 npx tsx --env-file=.env.staging scripts/check-queue.ts [<ingredient name>]

--- a/recipe-lanes/scripts/README.md
+++ b/recipe-lanes/scripts/README.md
@@ -55,6 +55,20 @@ npx tsx scripts/backfill-search-terms.ts --staging
 npx tsx scripts/backfill-names.ts --staging
 ```
 
+## Recipe / Adjust debugging
+
+```bash
+# Show all nodes, visual descriptions, shortlist sizes, and queue entries for a recipe
+npx tsx --env-file=.env.staging scripts/debug-recipe-nodes.ts <recipeId>
+
+# Run an adjustment against a live recipe — shows full AI prompt, raw response,
+# patch/graph detection, removeNodeId validation, and applyPatch result
+npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> "<instruction>"
+
+# Show recent icon_queue entries (pass a name to look up a specific one)
+npx tsx --env-file=.env.staging scripts/check-queue.ts [<ingredient name>]
+```
+
 ## DB / Admin
 
 ```bash

--- a/recipe-lanes/scripts/check-queue.ts
+++ b/recipe-lanes/scripts/check-queue.ts
@@ -1,0 +1,27 @@
+import 'dotenv/config';
+import { db } from '../lib/firebase-admin';
+import { standardizeIngredientName } from '../lib/utils';
+
+async function main() {
+  const name = process.argv[2];
+
+  if (name) {
+    const stdName = standardizeIngredientName(name);
+    console.log(`Looking up queue entry: "${stdName}"`);
+    const q = await db.collection('icon_queue').doc(stdName).get();
+    console.log('exists:', q.exists);
+    if (q.exists) console.log(JSON.stringify(q.data(), null, 2));
+  }
+
+  // List 10 most recent queue entries
+  console.log('\n--- Recent queue entries ---');
+  const recent = await db.collection('icon_queue').orderBy('created_at', 'desc').limit(10).get();
+  if (recent.empty) { console.log('(empty)'); return; }
+  recent.forEach(d => {
+    const data = d.data();
+    const created = data.created_at?.toDate ? data.created_at.toDate().toISOString() : 'unknown';
+    console.log(`  [${data.status}] "${d.id}" created=${created}`);
+  });
+}
+
+main().catch(console.error);

--- a/recipe-lanes/scripts/debug-adjust.ts
+++ b/recipe-lanes/scripts/debug-adjust.ts
@@ -1,83 +1,114 @@
 /**
- * Debug script: run an adjustment against a live recipe and show the full AI
- * request/response, patch/graph detection, and whether applyPatch worked.
+ * Debug script: run one or more adjustments against a live recipe in sequence.
+ * Shows the full AI prompt, raw response, patch/graph detection, and applyPatch result.
  *
  * Usage:
- *   npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> "<instruction>"
+ *   npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> "<step1>" ["<step2>" ...]
+ *
+ * Each instruction is applied to the result of the previous one, simulating a real chat session.
  */
 import 'dotenv/config';
 import { db } from '../lib/firebase-admin';
 import { generateAdjustmentPrompt } from '../lib/recipe-lanes/adjuster';
-import { applyPatch } from '../lib/recipe-lanes/model-utils';
+import { applyPatch, preserveNodeShortlist } from '../lib/recipe-lanes/model-utils';
 import { parseRecipeGraph } from '../lib/recipe-lanes/parser';
 import { getAIService } from '../lib/ai-service';
 import type { RecipeGraph, RecipePatch } from '../lib/recipe-lanes/types';
 
-async function main() {
-    const [recipeId, instruction] = process.argv.slice(2);
-    if (!recipeId || !instruction) {
-        console.error('Usage: npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> "<instruction>"');
-        process.exit(1);
-    }
+function parseJson(raw: string): any {
+    let s = raw.trim();
+    const fence = s.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (fence) s = fence[1].trim();
+    else { const a = s.indexOf('{'), b = s.lastIndexOf('}'); if (a !== -1 && b > a) s = s.slice(a, b + 1); }
+    return JSON.parse(s);
+}
 
-    console.log(`\n=== Recipe: ${recipeId} ===`);
-    const snap = await db.collection('recipes').doc(recipeId).get();
-    if (!snap.exists) { console.error('Recipe not found'); process.exit(1); }
-    const graph = snap.data()!.graph as RecipeGraph;
-    console.log(`Title: ${graph.title}, Nodes: ${graph.nodes.length}`);
-    console.log('Node IDs & texts:');
-    graph.nodes.forEach(n => console.log(`  [${n.id}] "${n.text}" (${n.type}) vd="${n.visualDescription}"`));
+async function runStep(graph: RecipeGraph, instruction: string, stepNum: number): Promise<RecipeGraph> {
+    console.log(`\n${'─'.repeat(60)}`);
+    console.log(`Step ${stepNum}: "${instruction}"`);
+    console.log(`${'─'.repeat(60)}`);
 
-    console.log(`\n=== Instruction: "${instruction}" ===`);
     const prompt = generateAdjustmentPrompt(graph, instruction);
-    console.log(`\n--- Prompt (${prompt.length} chars) ---`);
-    console.log(prompt.slice(0, 1000) + (prompt.length > 1000 ? '\n...(truncated)' : ''));
+    console.log(`Prompt: ${prompt.length} chars`);
 
-    console.log('\n--- Calling AI... ---');
     const t0 = Date.now();
     const raw = await getAIService().generateText(prompt);
     const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
-    console.log(`\n--- AI Response (${elapsed}s, ${raw.length} chars) ---`);
-    console.log(raw);
-
-    // Parse
-    let jsonStr = raw.trim();
-    const fenceMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
-    if (fenceMatch) jsonStr = fenceMatch[1].trim();
-    else { const s = jsonStr.indexOf('{'), e = jsonStr.lastIndexOf('}'); if (s !== -1 && e > s) jsonStr = jsonStr.slice(s, e + 1); }
+    console.log(`\nAI response (${elapsed}s, ${raw.length} chars):\n${raw}`);
 
     let parsed: any;
-    try { parsed = JSON.parse(jsonStr); } catch (e) { console.error('\n❌ JSON parse failed:', e); process.exit(1); }
+    try { parsed = parseJson(raw); }
+    catch (e) { console.error('\n❌ JSON parse failed:', e); return graph; }
 
-    console.log('\n--- Parsed ---');
     if (parsed.lanes && parsed.nodes) {
-        console.log('✅ Full graph returned');
+        console.log('\n✅ Full graph returned');
         try {
-            const newGraph = parseRecipeGraph(jsonStr);
-            console.log(`   Nodes: ${newGraph.nodes.length}, Lanes: ${newGraph.lanes.length}`);
-        } catch (e) { console.error('❌ parseRecipeGraph failed:', e); }
+            const newGraph = parseRecipeGraph(JSON.stringify(parsed));
+            // Restore icons for unchanged nodes
+            newGraph.nodes = newGraph.nodes.map(n => {
+                const old = graph.nodes.find(o => o.id === n.id);
+                return old ? preserveNodeShortlist(n, old) : n;
+            });
+            console.log(`   ${newGraph.nodes.length} nodes, ${newGraph.lanes.length} lanes`);
+            printNodeList(newGraph);
+            return newGraph;
+        } catch (e) { console.error('❌ parseRecipeGraph failed:', e); return graph; }
     } else {
         const patch = parsed as RecipePatch;
-        console.log('✅ Patch returned');
-        console.log(`   message: "${patch.message}"`);
-        console.log(`   addNodes: ${patch.addNodes?.length ?? 0}`);
-        console.log(`   updateNodes: ${patch.updateNodes?.length ?? 0}`);
-        console.log(`   removeNodeIds: ${JSON.stringify(patch.removeNodeIds ?? [])}`);
-        console.log(`   addLanes: ${patch.addLanes?.length ?? 0}`);
-        console.log(`   removeLaneIds: ${JSON.stringify(patch.removeLaneIds ?? [])}`);
-        if (patch.updateTitle) console.log(`   updateTitle: "${patch.updateTitle}"`);
+        console.log('\n✅ Patch returned');
+        console.log(`   message:      "${patch.message}"`);
+        console.log(`   addNodes:     ${patch.addNodes?.length ?? 0} ${(patch.addNodes ?? []).map(n => `"${n.text}"`).join(', ')}`);
+        console.log(`   updateNodes:  ${patch.updateNodes?.length ?? 0} ${(patch.updateNodes ?? []).map(n => n.id).join(', ')}`);
+        console.log(`   removeNodeIds:${JSON.stringify(patch.removeNodeIds ?? [])}`);
 
-        // Validate removeNodeIds actually exist
         const existingIds = new Set(graph.nodes.map(n => n.id));
         const missing = (patch.removeNodeIds ?? []).filter(id => !existingIds.has(id));
-        if (missing.length) console.warn(`\n⚠️  removeNodeIds not found in graph: ${JSON.stringify(missing)}`);
+        if (missing.length) console.warn(`\n⚠️  removeNodeIds not in graph: ${JSON.stringify(missing)}`);
 
         try {
             const result = applyPatch(graph, patch);
-            console.log(`\n   applyPatch result: ${result.nodes.length} nodes (was ${graph.nodes.length})`);
-            result.nodes.forEach(n => console.log(`     [${n.id}] "${n.text}" status=${n.status ?? 'none'}`));
-        } catch (e) { console.error('❌ applyPatch failed:', e); }
+            const delta = result.nodes.length - graph.nodes.length;
+            console.log(`\n   applyPatch: ${result.nodes.length} nodes (${delta >= 0 ? '+' : ''}${delta})`);
+            printNodeList(result);
+            return result;
+        } catch (e) { console.error('❌ applyPatch failed:', e); return graph; }
     }
+}
+
+function printNodeList(graph: RecipeGraph) {
+    graph.nodes.forEach(n => {
+        const icon = n.iconShortlist?.length ? '🖼' : (n.status === 'pending' ? '⏳' : '❌');
+        console.log(`     ${icon} [${n.id}] "${n.text}" (${n.type})`);
+    });
+}
+
+async function main() {
+    const args = process.argv.slice(2);
+    const recipeId = args[0];
+    const instructions = args.slice(1);
+    if (!recipeId || instructions.length === 0) {
+        console.error('Usage: npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> "<step1>" ["<step2>" ...]');
+        process.exit(1);
+    }
+
+    console.log(`\n${'═'.repeat(60)}`);
+    console.log(`Recipe: ${recipeId}`);
+    console.log(`${'═'.repeat(60)}`);
+    const snap = await db.collection('recipes').doc(recipeId).get();
+    if (!snap.exists) { console.error('Recipe not found'); process.exit(1); }
+    let graph = snap.data()!.graph as RecipeGraph;
+    console.log(`Title: ${graph.title}  Nodes: ${graph.nodes.length}  Lanes: ${graph.lanes.length}`);
+    console.log('Initial nodes:');
+    printNodeList(graph);
+
+    for (let i = 0; i < instructions.length; i++) {
+        graph = await runStep(graph, instructions[i], i + 1);
+    }
+
+    console.log(`\n${'═'.repeat(60)}`);
+    console.log('Final graph:');
+    console.log(`  ${graph.nodes.length} nodes, ${graph.lanes.length} lanes`);
+    printNodeList(graph);
 }
 
 main().catch(console.error);

--- a/recipe-lanes/scripts/debug-adjust.ts
+++ b/recipe-lanes/scripts/debug-adjust.ts
@@ -86,8 +86,9 @@ async function main() {
     const args = process.argv.slice(2);
     const recipeId = args[0];
     const instructions = args.slice(1);
-    if (!recipeId || instructions.length === 0) {
-        console.error('Usage: npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> "<step1>" ["<step2>" ...]');
+    if (!recipeId) {
+        console.error('Usage: npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> ["<step1>" "<step2>" ...]');
+        console.error('       (omit steps to just inspect the current recipe + chat history)');
         process.exit(1);
     }
 
@@ -96,11 +97,29 @@ async function main() {
     console.log(`${'═'.repeat(60)}`);
     const snap = await db.collection('recipes').doc(recipeId).get();
     if (!snap.exists) { console.error('Recipe not found'); process.exit(1); }
-    let graph = snap.data()!.graph as RecipeGraph;
+    const data = snap.data()!;
+    let graph = data.graph as RecipeGraph;
     console.log(`Title: ${graph.title}  Nodes: ${graph.nodes.length}  Lanes: ${graph.lanes.length}`);
-    console.log('Initial nodes:');
+    console.log('Current nodes:');
     printNodeList(graph);
 
+    // Show chat history if present
+    const chatHistory: any[] = data.chatHistory ?? [];
+    if (chatHistory.length > 0) {
+        console.log(`\n${'─'.repeat(60)}`);
+        console.log(`Chat history (${chatHistory.length} messages):`);
+        for (const msg of chatHistory) {
+            const ts = msg.timestamp ? new Date(msg.timestamp).toISOString() : '';
+            const label = msg.role === 'user' ? '👤 User' : '🤖 AI  ';
+            console.log(`  ${label} [${ts}] ${msg.content}`);
+        }
+    } else {
+        console.log('\n(No chat history stored)');
+    }
+
+    if (instructions.length === 0) return;
+
+    console.log(`\nRunning ${instructions.length} adjustment step(s)...`);
     for (let i = 0; i < instructions.length; i++) {
         graph = await runStep(graph, instructions[i], i + 1);
     }

--- a/recipe-lanes/scripts/debug-adjust.ts
+++ b/recipe-lanes/scripts/debug-adjust.ts
@@ -1,0 +1,83 @@
+/**
+ * Debug script: run an adjustment against a live recipe and show the full AI
+ * request/response, patch/graph detection, and whether applyPatch worked.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> "<instruction>"
+ */
+import 'dotenv/config';
+import { db } from '../lib/firebase-admin';
+import { generateAdjustmentPrompt } from '../lib/recipe-lanes/adjuster';
+import { applyPatch } from '../lib/recipe-lanes/model-utils';
+import { parseRecipeGraph } from '../lib/recipe-lanes/parser';
+import { getAIService } from '../lib/ai-service';
+import type { RecipeGraph, RecipePatch } from '../lib/recipe-lanes/types';
+
+async function main() {
+    const [recipeId, instruction] = process.argv.slice(2);
+    if (!recipeId || !instruction) {
+        console.error('Usage: npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> "<instruction>"');
+        process.exit(1);
+    }
+
+    console.log(`\n=== Recipe: ${recipeId} ===`);
+    const snap = await db.collection('recipes').doc(recipeId).get();
+    if (!snap.exists) { console.error('Recipe not found'); process.exit(1); }
+    const graph = snap.data()!.graph as RecipeGraph;
+    console.log(`Title: ${graph.title}, Nodes: ${graph.nodes.length}`);
+    console.log('Node IDs & texts:');
+    graph.nodes.forEach(n => console.log(`  [${n.id}] "${n.text}" (${n.type}) vd="${n.visualDescription}"`));
+
+    console.log(`\n=== Instruction: "${instruction}" ===`);
+    const prompt = generateAdjustmentPrompt(graph, instruction);
+    console.log(`\n--- Prompt (${prompt.length} chars) ---`);
+    console.log(prompt.slice(0, 1000) + (prompt.length > 1000 ? '\n...(truncated)' : ''));
+
+    console.log('\n--- Calling AI... ---');
+    const t0 = Date.now();
+    const raw = await getAIService().generateText(prompt);
+    const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+    console.log(`\n--- AI Response (${elapsed}s, ${raw.length} chars) ---`);
+    console.log(raw);
+
+    // Parse
+    let jsonStr = raw.trim();
+    const fenceMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (fenceMatch) jsonStr = fenceMatch[1].trim();
+    else { const s = jsonStr.indexOf('{'), e = jsonStr.lastIndexOf('}'); if (s !== -1 && e > s) jsonStr = jsonStr.slice(s, e + 1); }
+
+    let parsed: any;
+    try { parsed = JSON.parse(jsonStr); } catch (e) { console.error('\n❌ JSON parse failed:', e); process.exit(1); }
+
+    console.log('\n--- Parsed ---');
+    if (parsed.lanes && parsed.nodes) {
+        console.log('✅ Full graph returned');
+        try {
+            const newGraph = parseRecipeGraph(jsonStr);
+            console.log(`   Nodes: ${newGraph.nodes.length}, Lanes: ${newGraph.lanes.length}`);
+        } catch (e) { console.error('❌ parseRecipeGraph failed:', e); }
+    } else {
+        const patch = parsed as RecipePatch;
+        console.log('✅ Patch returned');
+        console.log(`   message: "${patch.message}"`);
+        console.log(`   addNodes: ${patch.addNodes?.length ?? 0}`);
+        console.log(`   updateNodes: ${patch.updateNodes?.length ?? 0}`);
+        console.log(`   removeNodeIds: ${JSON.stringify(patch.removeNodeIds ?? [])}`);
+        console.log(`   addLanes: ${patch.addLanes?.length ?? 0}`);
+        console.log(`   removeLaneIds: ${JSON.stringify(patch.removeLaneIds ?? [])}`);
+        if (patch.updateTitle) console.log(`   updateTitle: "${patch.updateTitle}"`);
+
+        // Validate removeNodeIds actually exist
+        const existingIds = new Set(graph.nodes.map(n => n.id));
+        const missing = (patch.removeNodeIds ?? []).filter(id => !existingIds.has(id));
+        if (missing.length) console.warn(`\n⚠️  removeNodeIds not found in graph: ${JSON.stringify(missing)}`);
+
+        try {
+            const result = applyPatch(graph, patch);
+            console.log(`\n   applyPatch result: ${result.nodes.length} nodes (was ${graph.nodes.length})`);
+            result.nodes.forEach(n => console.log(`     [${n.id}] "${n.text}" status=${n.status ?? 'none'}`));
+        } catch (e) { console.error('❌ applyPatch failed:', e); }
+    }
+}
+
+main().catch(console.error);

--- a/recipe-lanes/scripts/debug-adjust.ts
+++ b/recipe-lanes/scripts/debug-adjust.ts
@@ -1,11 +1,12 @@
 /**
- * Debug script: run one or more adjustments against a live recipe in sequence.
- * Shows the full AI prompt, raw response, patch/graph detection, and applyPatch result.
+ * Debug script: inspect a recipe's state + chat history, and optionally run adjustments.
  *
  * Usage:
- *   npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> "<step1>" ["<step2>" ...]
+ *   npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> [--verbose] ["<step1>" ...]
  *
- * Each instruction is applied to the result of the previous one, simulating a real chat session.
+ * Without steps: shows current recipe state and stored chat history.
+ * With steps: runs each instruction in sequence against the live recipe.
+ * --verbose / -v: also prints the full raw AI response for each step.
  */
 import 'dotenv/config';
 import { db } from '../lib/firebase-admin';
@@ -23,7 +24,7 @@ function parseJson(raw: string): any {
     return JSON.parse(s);
 }
 
-async function runStep(graph: RecipeGraph, instruction: string, stepNum: number): Promise<RecipeGraph> {
+async function runStep(graph: RecipeGraph, instruction: string, stepNum: number, verbose: boolean): Promise<RecipeGraph> {
     console.log(`\n${'─'.repeat(60)}`);
     console.log(`Step ${stepNum}: "${instruction}"`);
     console.log(`${'─'.repeat(60)}`);
@@ -34,7 +35,12 @@ async function runStep(graph: RecipeGraph, instruction: string, stepNum: number)
     const t0 = Date.now();
     const raw = await getAIService().generateText(prompt);
     const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
-    console.log(`\nAI response (${elapsed}s, ${raw.length} chars):\n${raw}`);
+
+    if (verbose) {
+        console.log(`\nRaw AI response (${elapsed}s, ${raw.length} chars):\n${raw}`);
+    } else {
+        console.log(`AI: ${elapsed}s, ${raw.length} chars`);
+    }
 
     let parsed: any;
     try { parsed = parseJson(raw); }
@@ -44,7 +50,6 @@ async function runStep(graph: RecipeGraph, instruction: string, stepNum: number)
         console.log('\n✅ Full graph returned');
         try {
             const newGraph = parseRecipeGraph(JSON.stringify(parsed));
-            // Restore icons for unchanged nodes
             newGraph.nodes = newGraph.nodes.map(n => {
                 const old = graph.nodes.find(o => o.id === n.id);
                 return old ? preserveNodeShortlist(n, old) : n;
@@ -56,14 +61,22 @@ async function runStep(graph: RecipeGraph, instruction: string, stepNum: number)
     } else {
         const patch = parsed as RecipePatch;
         console.log('\n✅ Patch returned');
-        console.log(`   message:      "${patch.message}"`);
-        console.log(`   addNodes:     ${patch.addNodes?.length ?? 0} ${(patch.addNodes ?? []).map(n => `"${n.text}"`).join(', ')}`);
-        console.log(`   updateNodes:  ${patch.updateNodes?.length ?? 0} ${(patch.updateNodes ?? []).map(n => n.id).join(', ')}`);
-        console.log(`   removeNodeIds:${JSON.stringify(patch.removeNodeIds ?? [])}`);
+        console.log(`   message:       "${patch.message}"`);
+        console.log(`   addNodes:      ${patch.addNodes?.length ?? 0}  ${(patch.addNodes ?? []).map(n => `"${n.text}"`).join(', ')}`);
+        console.log(`   updateNodes:   ${patch.updateNodes?.length ?? 0}  ${(patch.updateNodes ?? []).map(n => n.id).join(', ')}`);
+        console.log(`   removeNodeIds: ${JSON.stringify(patch.removeNodeIds ?? [])}`);
+        if (verbose) {
+            console.log('\n   Full patch JSON:');
+            console.log(JSON.stringify(patch, null, 2).split('\n').map(l => '   ' + l).join('\n'));
+        }
 
         const existingIds = new Set(graph.nodes.map(n => n.id));
         const missing = (patch.removeNodeIds ?? []).filter(id => !existingIds.has(id));
         if (missing.length) console.warn(`\n⚠️  removeNodeIds not in graph: ${JSON.stringify(missing)}`);
+
+        const hasRemovals = (patch.removeNodeIds?.length ?? 0) > 0;
+        const hasAdditions = (patch.addNodes?.length ?? 0) > 0;
+        if (hasRemovals && !hasAdditions) console.warn(`⚠️  Nodes removed but no addNodes — likely a bad merge response`);
 
         try {
             const result = applyPatch(graph, patch);
@@ -83,11 +96,14 @@ function printNodeList(graph: RecipeGraph) {
 }
 
 async function main() {
-    const args = process.argv.slice(2);
+    const rawArgs = process.argv.slice(2);
+    const verbose = rawArgs.includes('--verbose') || rawArgs.includes('-v');
+    const args = rawArgs.filter(a => a !== '--verbose' && a !== '-v');
+
     const recipeId = args[0];
     const instructions = args.slice(1);
     if (!recipeId) {
-        console.error('Usage: npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> ["<step1>" "<step2>" ...]');
+        console.error('Usage: npx tsx --env-file=.env.staging scripts/debug-adjust.ts <recipeId> [-v] ["<step1>" ...]');
         console.error('       (omit steps to just inspect the current recipe + chat history)');
         process.exit(1);
     }
@@ -103,7 +119,6 @@ async function main() {
     console.log('Current nodes:');
     printNodeList(graph);
 
-    // Show chat history if present
     const chatHistory: any[] = data.chatHistory ?? [];
     if (chatHistory.length > 0) {
         console.log(`\n${'─'.repeat(60)}`);
@@ -119,9 +134,9 @@ async function main() {
 
     if (instructions.length === 0) return;
 
-    console.log(`\nRunning ${instructions.length} adjustment step(s)...`);
+    console.log(`\nRunning ${instructions.length} adjustment step(s)...${verbose ? ' (verbose)' : ''}`);
     for (let i = 0; i < instructions.length; i++) {
-        graph = await runStep(graph, instructions[i], i + 1);
+        graph = await runStep(graph, instructions[i], i + 1, verbose);
     }
 
     console.log(`\n${'═'.repeat(60)}`);

--- a/recipe-lanes/scripts/debug-recipe-nodes.ts
+++ b/recipe-lanes/scripts/debug-recipe-nodes.ts
@@ -1,0 +1,40 @@
+import 'dotenv/config';
+import { db } from '../lib/firebase-admin';
+import { standardizeIngredientName } from '../lib/utils';
+
+async function main() {
+  const recipeId = process.argv[2];
+  if (!recipeId) { console.error('Usage: npx tsx scripts/debug-recipe-nodes.ts <recipeId>'); process.exit(1); }
+
+  const doc = await db.collection('recipes').doc(recipeId).get();
+  if (!doc.exists) { console.log('NOT FOUND'); process.exit(1); }
+  const data = doc.data()!;
+  const nodes = data.graph?.nodes || [];
+  console.log(`Title: ${data.title || data.graph?.title}`);
+  console.log(`Nodes: ${nodes.length}\n`);
+
+  for (const n of nodes) {
+    const shortlistLen = n.iconShortlist?.length ?? 0;
+    const stdName = standardizeIngredientName(n.visualDescription || n.text || '');
+    console.log(`[${n.type}] "${n.text}"`);
+    console.log(`  vd:       "${n.visualDescription}"`);
+    console.log(`  stdName:  "${stdName}"`);
+    console.log(`  status:   ${n.status ?? 'none'}`);
+    console.log(`  shortlist: ${shortlistLen} entries`);
+    console.log(`  inputs:   ${JSON.stringify(n.inputs ?? [])}`);
+    console.log('');
+  }
+
+  // Also check queue entries for all nodes
+  console.log('--- Queue entries ---');
+  for (const n of nodes) {
+    const stdName = standardizeIngredientName(n.visualDescription || n.text || '');
+    const q = await db.collection('icon_queue').doc(stdName).get();
+    if (q.exists) {
+      const qd = q.data()!;
+      console.log(`  "${stdName}": status=${qd.status} error=${qd.error ?? 'none'}`);
+    }
+  }
+}
+
+main().catch(console.error);

--- a/recipe-lanes/tests/icon-pipeline.test.ts
+++ b/recipe-lanes/tests/icon-pipeline.test.ts
@@ -24,16 +24,17 @@ const makeIcon = (id: string): IconStats => ({
     score: 0.9,
 });
 
-/** Stub batch search fn that returns a fixed vector and fast matches and records how many times it was called. */
+type BatchSearchFn = (ingredients: { name: string, queries: string[] }[], limit: number) => Promise<{ name: string; icons: IconStats[]; matchScores: Record<string, number> }[]>;
+
+/** Stub batch search fn that returns an empty result and records how many times it was called. */
 function makeEmbedSpy() {
     let callCount = 0;
-    const searchFn = async (ingredients: { name: string, queries: string[] }[], _limit: number): Promise<{ name: string, embedding: number[], fast_matches: any[] }[]> => {
+    const searchFn: BatchSearchFn = async (ingredients, _limit) => {
         callCount++;
-        return ingredients.map(ing => ({ name: ing.name, embedding: [0.1, 0.2, 0.3], fast_matches: [] }));
+        return ingredients.map(ing => ({ name: ing.name, icons: [], matchScores: {} }));
     };
     return { searchFn, getCallCount: () => callCount };
 }
-type BatchSearchFn = (ingredients: { name: string, queries: string[] }[], limit: number) => Promise<{ name: string, embedding: number[], fast_matches: any[] }[]>;
 
 /** A MemoryDataService subclass that tracks resolveRecipeIcons calls, including batchSearchFn. */
 class SpyMemoryDataService extends MemoryDataService {


### PR DESCRIPTION
BatchSearchFn in icon-pipeline.test.ts was using a stale return shape ({embedding, fast_matches}) that diverged from the DataService interface ({icons, matchScores}); updated both.