### PR TITLE
fix(utils): fold accents in standardizeIngredientName for icon lookups

### DIFF
--- a/recipe-lanes/lib/utils.ts
+++ b/recipe-lanes/lib/utils.ts
@@ -24,6 +24,8 @@ export function cn(...inputs: ClassValue[]) {
 
 export function standardizeIngredientName(name: string) {
     return name
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
     .trim()
     .split(' ')
     .map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())

--- a/recipe-lanes/tests/data.test.ts
+++ b/recipe-lanes/tests/data.test.ts
@@ -6,6 +6,19 @@ import { setAIService, MockAIService } from '../lib/ai-service';
 import { setAuthService, MockAuthService } from '../lib/auth-service';
 import { createVisualRecipeAction } from '../app/actions';
 import { getNodeIconUrl } from '../lib/recipe-lanes/model-utils';
+import { standardizeIngredientName } from '../lib/utils';
+
+describe('standardizeIngredientName', () => {
+    it('folds accents/diacritics to ASCII', () => {
+        assert.strictEqual(standardizeIngredientName('jalapeño'), 'Jalapeno');
+        assert.strictEqual(standardizeIngredientName('Sautéed Crème'), 'Sauteed Creme');
+        // Accented and unaccented forms produce the same key
+        assert.strictEqual(
+            standardizeIngredientName('purée'),
+            standardizeIngredientName('puree')
+        );
+    });
+});
 
 // Mock Graph
 const mockGraph: any = {


### PR DESCRIPTION
## Bug
Accented/non-ASCII ingredient names (e.g. "jalapeño", "Sautéed") produced inconsistent keys in `standardizeIngredientName`, which is used to build Firestore doc IDs. This broke icon/ingredient lookups since the accented form didn't match the unaccented one.

## Fix
Normalize via NFD and strip combining diacritical marks (U+0300–U+036F) before existing trim/case-folding, so "jalapeño" → "Jalapeno". Minimal, no other behavior changed.

## Verification
- `npm run typecheck` — pass
- `npm run test:unit:pure` — 251 pass, 0 fail (incl. new accent test cases)
- eslint on changed files — clean

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)