### PR TITLE
fix(icons): skip missing/deleted recipes during batch icon processing (#128)

### DIFF
--- a/recipe-lanes/functions/src/index.ts
+++ b/recipe-lanes/functions/src/index.ts
@@ -108,9 +108,17 @@ export const processIconTaskHandler = async (data: { ingredientName: string }, r
             console.log(`[Queue-${ingredientName}] ✅ Success. Icon ID: ${icon.id}`);
 
             const recipeDataObj: Record<string, any> = {};
+            const processedRecipeIds: string[] = [];
             for (const rId of latestRecipeIds) {
-                const data = await dataService.imagineRecipeWithIcon(rId, ingredientName, iconWithTerms, transaction);
-                recipeDataObj[rId] = data;
+                try {
+                    const data = await dataService.imagineRecipeWithIcon(rId, ingredientName, iconWithTerms, transaction);
+                    recipeDataObj[rId] = data;
+                    processedRecipeIds.push(rId);
+                } catch (e) {
+                    // A single missing/deleted recipe must not crash the whole batch.
+                    // Skip it and continue processing the remaining recipes.
+                    console.warn(`[Queue-${ingredientName}] Skipping recipe ${rId} during icon processing (likely missing/deleted):`, e);
+                }
             }
 
             // End READS. Now commit all changes together.
@@ -124,14 +132,14 @@ export const processIconTaskHandler = async (data: { ingredientName: string }, r
             await dataService.setIngredientWithIcon(ingredientData, transaction);
 
             // Update all linked recipes using the atomic helper
-            console.log(`[Queue-${ingredientName}] Updating ${latestRecipeIds.length} recipes...`);
-            for (const rId of latestRecipeIds) {
+            console.log(`[Queue-${ingredientName}] Updating ${processedRecipeIds.length} recipes...`);
+            for (const rId of processedRecipeIds) {
                 await dataService.setRecipeWithIcon(recipeDataObj[rId], transaction);
             }
 
             // Delete the queue item
             transaction.delete(docRef);
-            console.log(`[Queue-${ingredientName}] Successfully updated ${latestRecipeIds.length} recipes and deleted queue item.`);
+            console.log(`[Queue-${ingredientName}] Successfully updated ${processedRecipeIds.length} of ${latestRecipeIds.length} recipes and deleted queue item.`);
         });
 
         // Record one impression per recipe this icon was shown in (non-fatal)

--- a/recipe-lanes/tests/icon-pipeline.test.ts
+++ b/recipe-lanes/tests/icon-pipeline.test.ts
@@ -330,3 +330,54 @@ describe('shortlist wrapping via advanceShortlistIndex', () => {
         assert.strictEqual(step.wrappedIdx, 0);
     });
 });
+
+// ---------------------------------------------------------------------------
+// Batch icon processing — missing/deleted recipes must not crash the batch
+// (regression for issue #128). The cloud function processIconTaskHandler loops
+// over queued recipe IDs calling imagineRecipeWithIcon and must skip a single
+// missing recipe instead of failing the whole batch. We exercise the same
+// loop semantics against MemoryDataService here.
+// ---------------------------------------------------------------------------
+
+describe('batch icon processing skips missing recipes (issue #128)', () => {
+    let service: MemoryDataService;
+
+    beforeEach(() => {
+        memoryStore.clear();
+        setDataService(new MemoryDataService());
+        setAIService(new MockAIService());
+        setAuthService(new MockAuthService());
+        service = getDataService() as MemoryDataService;
+    });
+
+    it('imagineRecipeWithIcon throws for a missing recipe', async () => {
+        await assert.rejects(
+            () => service.imagineRecipeWithIcon('does-not-exist', 'Carrot', makeIcon('i1')),
+            /Recipe not found/,
+        );
+    });
+
+    it('processing a list with one missing recipe still processes the valid ones', async () => {
+        const validId = await makeRecipe(service);
+        await service.addNodeToRecipe(validId, 'Carrot');
+
+        const recipeIds = [validId, 'missing-recipe-id'];
+        const icon = makeIcon('icon-1');
+
+        // Mirror the handler loop: skip recipes that throw instead of aborting.
+        const processed: string[] = [];
+        const skipped: string[] = [];
+        for (const rId of recipeIds) {
+            try {
+                const data = await service.imagineRecipeWithIcon(rId, 'Carrot', icon);
+                await service.setRecipeWithIcon(data);
+                processed.push(rId);
+            } catch {
+                skipped.push(rId);
+            }
+        }
+
+        assert.deepStrictEqual(processed, [validId], 'valid recipe should be processed');
+        assert.deepStrictEqual(skipped, ['missing-recipe-id'], 'missing recipe should be skipped');
+    });
+});


### PR DESCRIPTION
## The bug
`processIconTaskHandler` (recipe-lanes/functions/src/index.ts) loops over the queued recipe IDs and calls `dataService.imagineRecipeWithIcon(rId, ...)` for each. That method throws `Recipe not found` when the recipe doc is missing/deleted. Because the loop ran inside a Firestore transaction with no guard, a single orphaned recipe crashed the whole transaction and failed icon generation for every other valid recipe in the batch. (Forensics: 29 icons failed on Mar 15 due to one missing recipe `6DVpQpqF7NXuA47m7bZO`.)

## The fix
Wrap the per-recipe `imagineRecipeWithIcon` call in a try/catch: on failure, log a warning and skip that recipe, continuing with the rest. Only successfully-processed recipes are written and counted. The normal (all-recipes-present) path is behavior-preserving.

## How verified
- `npm run typecheck` — passes (tsconfig includes `functions/`).
- `npm run test:unit:pure` — 252 pass / 0 fail, including new regression tests in `tests/icon-pipeline.test.ts` covering: (a) `imagineRecipeWithIcon` throws for a missing recipe, and (b) a batch loop with one missing recipe still processes the valid ones and skips the missing one.
- `eslint` on the changed files — 0 errors.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)