### PR TITLE
UI: Warn when recipe input is just a URL (#130)

### DIFF
--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -36,6 +36,7 @@ import { useRecipeStore } from '@/lib/stores/recipe-store';
 import { LayoutMode } from '@/lib/recipe-lanes/layout';
 import { Wand2, ChefHat, ArrowRight, Code, MessageSquare, Send, LayoutDashboard, Kanban, GitGraph, Columns, AlignCenter, Network, Sparkles, CircleDot, Share2, Sprout, Move, RotateCw, Orbit, Type, Play, Pause, Pencil, RotateCcw, Globe, Lock, Plus, LayoutGrid, Star, User, ShoppingBasket, HelpCircle, Github } from 'lucide-react';
 import { Banner } from '@/components/ui/banner';
+import { looksLikeUrl } from '@/lib/recipe-lanes/input-utils';
 import { LoadingScreen, LoadingPhase } from '@/components/recipe-lanes/ui/loading-screen';
 import { doc, onSnapshot } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
@@ -885,6 +886,11 @@ const handleVisualize = async () => {
                     </button>
                 )}
              </div>
+             {looksLikeUrl(recipeText) && (
+                <div className="px-2 pb-2 text-[10px] text-yellow-400">
+                    That looks like a link. Direct links aren&apos;t supported yet — please copy and paste the recipe text itself into the box.
+                </div>
+             )}
              {error && (
                 <div className="px-2 pb-2 text-[10px] text-red-400">
                     {error}

--- a/recipe-lanes/lib/recipe-lanes/input-utils.ts
+++ b/recipe-lanes/lib/recipe-lanes/input-utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Pure helpers for validating recipe text input on the client.
+ */
+
+/**
+ * Returns true when the trimmed input looks like nothing but a URL — i.e. the
+ * user pasted a link to a recipe instead of the recipe text itself.
+ *
+ * We only flag inputs that are essentially a single bare URL so we don't warn
+ * on real recipes that happen to mention a link somewhere in the body.
+ */
+export function looksLikeUrl(input: string): boolean {
+  const trimmed = input.trim();
+  if (!trimmed) return false;
+  // A single token (no internal whitespace) starting with http(s):// or www.
+  if (/\s/.test(trimmed)) return false;
+  return /^(https?:\/\/|www\.)\S+$/i.test(trimmed);
+}

--- a/recipe-lanes/tests/data.test.ts
+++ b/recipe-lanes/tests/data.test.ts
@@ -6,6 +6,7 @@ import { setAIService, MockAIService } from '../lib/ai-service';
 import { setAuthService, MockAuthService } from '../lib/auth-service';
 import { createVisualRecipeAction } from '../app/actions';
 import { getNodeIconUrl } from '../lib/recipe-lanes/model-utils';
+import { looksLikeUrl } from '../lib/recipe-lanes/input-utils';
 
 // Mock Graph
 const mockGraph: any = {
@@ -64,5 +65,22 @@ describe('Data Service & Actions', () => {
             const iconUrl = getNodeIconUrl(carrotNode);
             assert.ok(typeof iconUrl === 'string' && iconUrl.length > 0, 'carrot node should have a derived icon URL');
         });
+    });
+});
+
+describe('looksLikeUrl', () => {
+    it('flags bare URLs', () => {
+        assert.equal(looksLikeUrl('https://example.com/recipe'), true);
+        assert.equal(looksLikeUrl('http://foo.com'), true);
+        assert.equal(looksLikeUrl('  https://example.com/recipe  '), true);
+        assert.equal(looksLikeUrl('www.example.com/recipe'), true);
+    });
+
+    it('does not flag real recipe text', () => {
+        assert.equal(looksLikeUrl(''), false);
+        assert.equal(looksLikeUrl('   '), false);
+        assert.equal(looksLikeUrl('1 cup flour\n2 eggs'), false);
+        assert.equal(looksLikeUrl('See more at https://example.com for tips'), false);
+        assert.equal(looksLikeUrl('Carrot soup'), false);
     });
 });


### PR DESCRIPTION
## What it does
Adds a client-side check to the recipe input on `app/lanes/page.tsx`. When the input is a single bare URL (e.g. `https://…` or `www.…`), a non-blocking inline yellow warning appears beneath the input box telling the user to copy and paste the recipe text itself instead of submitting a link. The warning is non-blocking and matches the existing inline error styling next to the input.

The URL-detection logic is extracted into a pure helper `looksLikeUrl()` in `lib/recipe-lanes/input-utils.ts`. It only flags inputs that are a single URL token, so real recipes that merely mention a link are not flagged.

## How verified
- `npm run typecheck` — passes
- `npm run test:unit:pure` — 252/252 pass, including new `looksLikeUrl` tests
- `npx eslint` on changed files — 0 errors

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)