### PR TITLE
fix(ai): fail-safe mock-mode guard so prod never serves placeholder icons

### DIFF
--- a/recipe-lanes/lib/ai-service.ts
+++ b/recipe-lanes/lib/ai-service.ts
@@ -308,26 +308,49 @@ export class MockAIService implements AIService {
 
 // Default to Real or Mock based on env.
 // Tests can swap this out using setAIService.
-const isMockMode = 
-  process.env.MOCK_AI === 'true' || 
-  process.env.FUNCTIONS_EMULATOR === 'true' || 
-  process.env.NEXT_PUBLIC_USE_FIREBASE_EMULATOR === 'true';
+//
+// Selection is a pure function of env so it can be unit-tested directly
+// (the live `currentService` is resolved once at module-load time below).
+export function selectAIService(env: Record<string, string | undefined> = process.env): AIService {
+    const mockFlagSet =
+        env.MOCK_AI === 'true' ||
+        env.FUNCTIONS_EMULATOR === 'true' ||
+        env.NEXT_PUBLIC_USE_FIREBASE_EMULATOR === 'true';
 
-const useNodeCF = process.env.NEXT_PUBLIC_ICON_SEARCH_MODE === 'node_cf';
+    // Fail-safe production guard: mock mode must NEVER be active on a real
+    // production server. NODE_ENV === 'production' is the prod signal used
+    // consistently across this codebase (firebase-admin, prebuild, auth) and
+    // is set by Next.js / Firebase App Hosting at runtime. Emulators and tests
+    // do not run with NODE_ENV=production, so dev/test behavior is unchanged.
+    const isProduction = env.NODE_ENV === 'production';
 
-let currentService: AIService;
-if (isMockMode) {
-    currentService = new MockAIService();
-    // Loud server-side warning so MOCK_AI can never be silently active.
-    // This fires at module load time (server startup / cold start).
-    if (typeof process !== 'undefined' && process.env.MOCK_AI === 'true') {
-        console.warn('[ai-service] WARNING: MOCK_AI=true — AI responses are MOCKED. Do NOT use in production.');
+    if (mockFlagSet && isProduction) {
+        // A mock flag leaked into a production runtime — this is a config bug.
+        // Log loudly and force the real service rather than serving placeholders.
+        console.error(
+            '[ai-service] FATAL CONFIG LEAK: a mock-AI flag (MOCK_AI / FUNCTIONS_EMULATOR / ' +
+            'NEXT_PUBLIC_USE_FIREBASE_EMULATOR) is set while NODE_ENV=production. ' +
+            'Forcing RealAIService so prod never serves placeholder icons. Fix the deploy config.'
+        );
+        return new RealAIService();
     }
-} else if (useNodeCF) {
-    currentService = new NodeCFAIService();
-} else {
-    currentService = new RealAIService();
+
+    if (mockFlagSet) {
+        // Loud server-side warning so MOCK_AI can never be silently active.
+        if (env.MOCK_AI === 'true') {
+            console.warn('[ai-service] WARNING: MOCK_AI=true — AI responses are MOCKED. Do NOT use in production.');
+        }
+        return new MockAIService();
+    }
+
+    if (env.NEXT_PUBLIC_ICON_SEARCH_MODE === 'node_cf') {
+        return new NodeCFAIService();
+    }
+
+    return new RealAIService();
 }
+
+let currentService: AIService = selectAIService();
 
 export function getAIService(): AIService {
   return currentService;

--- a/recipe-lanes/package.json
+++ b/recipe-lanes/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "npm run test:unit:pure && npm run test:unit:integration",
-    "test:unit:pure": "npx env-cmd -f .env.test node --import tsx --test tests/data.test.ts tests/gallery-view.test.ts tests/graph-logic.test.ts tests/graph.test.ts tests/hybrid-plumbing.test.ts tests/icon-pipeline.test.ts tests/icon-search.test.ts tests/icon-shortlist.test.ts tests/image-processing.test.ts tests/layout-saving.test.ts tests/model-utils.test.ts tests/optimistic-flow.test.ts tests/parser.test.ts tests/patch.test.ts tests/recipe-store.test.ts tests/shortlist-delta.test.ts tests/social-features.test.ts tests/timeline-layout.test.ts tests/timeline-save.test.ts tests/title-persistence.test.ts tests/undo-complex.test.ts tests/verify-production-logic.test.ts",
+    "test:unit:pure": "npx env-cmd -f .env.test node --import tsx --test tests/ai-service-selection.test.ts tests/data.test.ts tests/gallery-view.test.ts tests/graph-logic.test.ts tests/graph.test.ts tests/hybrid-plumbing.test.ts tests/icon-pipeline.test.ts tests/icon-search.test.ts tests/icon-shortlist.test.ts tests/image-processing.test.ts tests/layout-saving.test.ts tests/model-utils.test.ts tests/optimistic-flow.test.ts tests/parser.test.ts tests/patch.test.ts tests/recipe-store.test.ts tests/shortlist-delta.test.ts tests/social-features.test.ts tests/timeline-layout.test.ts tests/timeline-save.test.ts tests/title-persistence.test.ts tests/undo-complex.test.ts tests/verify-production-logic.test.ts",
     "test:unit:integration": "./scripts/test-unit-integration.sh",
     "test:one": "npx env-cmd -f .env.test node --import tsx --test",
     "test:watch": "node --import tsx --test --watch tests/*.test.ts",

--- a/recipe-lanes/tests/ai-service-selection.test.ts
+++ b/recipe-lanes/tests/ai-service-selection.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser
+ */
+
+import { describe, it, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { selectAIService, RealAIService, MockAIService, NodeCFAIService } from '../lib/ai-service';
+
+// Silence the loud guard logging during assertions.
+let errorMock: ReturnType<typeof mock.method>;
+
+describe('selectAIService production guard', () => {
+    beforeEach(() => {
+        mock.method(console, 'warn', () => {});
+        errorMock = mock.method(console, 'error', () => {});
+    });
+    afterEach(() => {
+        mock.restoreAll();
+    });
+
+    it('mock flag + prod signal → RealAIService (fail-safe, never placeholders)', () => {
+        const svc = selectAIService({ MOCK_AI: 'true', NODE_ENV: 'production' });
+        assert.ok(svc instanceof RealAIService);
+        // Loud config-leak error must fire.
+        assert.equal(errorMock.mock.calls.length, 1);
+    });
+
+    it('emulator flag + prod signal → RealAIService', () => {
+        const svc = selectAIService({ FUNCTIONS_EMULATOR: 'true', NODE_ENV: 'production' });
+        assert.ok(svc instanceof RealAIService);
+    });
+
+    it('mock flag + non-prod → MockAIService (dev/test unchanged)', () => {
+        const svc = selectAIService({ MOCK_AI: 'true', NODE_ENV: 'development' });
+        assert.ok(svc instanceof MockAIService);
+    });
+
+    it('emulator flag + no NODE_ENV → MockAIService', () => {
+        const svc = selectAIService({ NEXT_PUBLIC_USE_FIREBASE_EMULATOR: 'true' });
+        assert.ok(svc instanceof MockAIService);
+    });
+
+    it('no mock flag, node_cf mode → NodeCFAIService', () => {
+        const svc = selectAIService({ NEXT_PUBLIC_ICON_SEARCH_MODE: 'node_cf' });
+        assert.ok(svc instanceof NodeCFAIService);
+    });
+
+    it('no flags → RealAIService', () => {
+        const svc = selectAIService({});
+        assert.ok(svc instanceof RealAIService);
+    });
+});


### PR DESCRIPTION
## Root cause (#19)
`lib/ai-service.ts` selected `MockAIService` (which returns `placehold.co` URLs) purely from env flags — `MOCK_AI`, `FUNCTIONS_EMULATOR`, or `NEXT_PUBLIC_USE_FIREBASE_EMULATOR` — with **no production safety guard**. If any of those leaked into a prod runtime (this has happened before), the backend silently served mock icons.

## The guard
Refactored the module-load selection into a pure, testable `selectAIService(env)`. New fail-safe rule: when a mock flag is set **AND** the prod signal is detected, log a loud config-leak error and force `RealAIService` instead of mocks. All other paths (dev, test, emulators, node_cf, real) are byte-for-byte unchanged.

## Prod signal chosen: `NODE_ENV === 'production'`
This is the signal already used consistently across the codebase for prod detection: `lib/firebase-admin.ts`, `app/api/auth/login/route.ts` (secure cookies), and `scripts/prebuild.js`. Next.js production builds and Firebase App Hosting set `NODE_ENV=production` at runtime, while emulators and tests do not — so the guard fires exactly in prod and never disturbs local/test mock usage.

## Prebuild-guard discrepancy note
Memory suggested the MOCK_AI prebuild guard was *absent*; investigation found it **is present** in `scripts/prebuild.js` (lines 8–39) and fails a prod build when `MOCK_AI=true`. However, that is build-time only, keys on `MOCK_AI` alone (not the emulator flags), and does not protect the runtime/cold-start path — so the runtime guard added here is still the real fix. No change made to prebuild.js.

## Verification
- `npm run typecheck` — pass
- `npm run test:unit:pure` — 256 pass / 0 fail (added 6 selection tests, incl. mock+prod→Real and mock+non-prod→Mock)
- eslint on changed files — clean

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)