### PR TITLE
chore(lint): encapsulate RecipeNode store-internal access, flip model rule to error

### DIFF
--- a/recipe-lanes/app/actions.ts
+++ b/recipe-lanes/app/actions.ts
@@ -26,7 +26,7 @@ import { generateRecipePrompt, parseRecipeGraph, extractServes, generateHydeQuer
 import { generateAdjustmentPrompt } from '@/lib/recipe-lanes/adjuster';
 import type { RecipeGraph, IconStats, FastMatch, RecipePatch } from '@/lib/recipe-lanes/types';
 import { standardizeIngredientName } from '@/lib/utils';
-import { cosineSimilarity, getIconThumbUrl, getNodeIconUrl, getShortlistIconAt, preserveNodeShortlist, buildShortlistEntry, mutateNodesByIngredient, markEntryImpressedAtIndex, getEntryIcon, extractBatchIngredients, getNodeIngredientName, applyPatch } from '@/lib/recipe-lanes/model-utils';
+import { cosineSimilarity, getIconThumbUrl, getNodeIconUrl, getShortlistIconAt, preserveNodeShortlist, buildShortlistEntry, mutateNodesByIngredient, markEntryImpressedAtIndex, getEntryIcon, extractBatchIngredients, getNodeIngredientName, applyPatch, assignNodeShortlist } from '@/lib/recipe-lanes/model-utils';
 import { db } from '@/lib/firebase-admin';
 import { DB_COLLECTION_RECIPES, DB_COLLECTION_QUEUE } from '@/lib/config';
 import { unifiedIconSearch, serverBatchIconSearch } from '@/lib/search-orchestrator';
@@ -176,11 +176,10 @@ export async function createVisualRecipeAction(recipeText: string, currentId?: s
                         const result = hydratedResults.find(r => r.name === stdName);
                         if (result && result.icons.length > 0) {
                             const icon = result.icons[0];
-                            node.iconShortlist = markEntryImpressedAtIndex(
+                            assignNodeShortlist(node, markEntryImpressedAtIndex(
                                 [buildShortlistEntry(icon, 'search', result.matchScores[icon.id] ?? 0)],
                                 0,
-                            );
-                            node.shortlistIndex = 0;
+                            ), 0);
                         }
                         const allMatches = allMatchesByName.get(stdName);
                         if (allMatches && allMatches.length > 0) node.fastMatches = allMatches;
@@ -584,8 +583,7 @@ export async function applyIconSearchResultsAction(
             const nodes: any[] = snap.data()?.graph?.nodes || [];
             for (const { name, entries } of shortlists) {
                 const changed = mutateNodesByIngredient(nodes, name, (n: any) => {
-                    n.iconShortlist = entries;
-                    n.shortlistIndex = 0;
+                    assignNodeShortlist(n, entries, 0);
                     delete n.status;
                 });
                 if (changed) applied++;

--- a/recipe-lanes/components/recipe-lanes/timeline-view.tsx
+++ b/recipe-lanes/components/recipe-lanes/timeline-view.tsx
@@ -27,7 +27,7 @@ import {
   type TLNode, type TLEdge, type TLLane,
 } from '@/lib/recipe-lanes/timeline-layout';
 import {
-  getNodeIconUrlAt, getNodeIngredientName, getNodeIconId, getNodeShortlistKey,
+  getNodeIconUrlAt, getNodeIngredientName, getNodeIconId, getNodeShortlistKey, currentShortlistIndex,
 } from '@/lib/recipe-lanes/model-utils';
 import { useRecipeStore } from '@/lib/stores/recipe-store';
 import { forgeIconAction } from '@/app/actions';
@@ -118,7 +118,7 @@ interface NodeProps {
 function ActionNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSelected, isForging,
   onMouseDown, onMouseEnter, onMouseLeave, onReroll, onForge, onDelete }: NodeProps) {
   const { data } = node;
-  const iconUrl = getNodeIconUrlAt(data, Math.max(0, data.shortlistIndex ?? 0));
+  const iconUrl = getNodeIconUrlAt(data, Math.max(0, currentShortlistIndex(data)));
   const clipId  = `tl-a-${node.id.replace(/\W/g, '')}`;
   const innerR  = TL.NODE_R - 3;
 
@@ -172,7 +172,7 @@ function ActionNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSelecte
 function IngredientNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSelected, isForging,
   onMouseDown, onMouseEnter, onMouseLeave, onReroll, onForge, onDelete }: NodeProps) {
   const { data } = node;
-  const iconUrl = getNodeIconUrlAt(data, Math.max(0, data.shortlistIndex ?? 0));
+  const iconUrl = getNodeIconUrlAt(data, Math.max(0, currentShortlistIndex(data)));
   const clipId  = `tl-i-${node.id.replace(/\W/g, '')}`;
   const innerR  = TL.NODE_R - 3;
   const ring = isSelected ? '#6366f1' : lineColor;

--- a/recipe-lanes/eslint.config.mjs
+++ b/recipe-lanes/eslint.config.mjs
@@ -78,7 +78,7 @@ const eslintConfig = defineConfig([
     ],
     rules: {
       "no-restricted-syntax": [
-        "warn",
+        "error",
         {
           selector: "MemberExpression[property.name='iconShortlist']",
           message: "Access RecipeNode.iconShortlist via model-utils (getNodeShortlistLength, getShortlistIconAt, getNodeShortlistKey, …).",

--- a/recipe-lanes/lib/data-service.ts
+++ b/recipe-lanes/lib/data-service.ts
@@ -25,7 +25,7 @@ import type { RecipeGraph, IconStats, ShortlistEntry } from './recipe-lanes/type
 import { DB_COLLECTION_INGREDIENTS, DB_COLLECTION_ICON_INDEX, DB_COLLECTION_QUEUE, DB_COLLECTION_RECIPES } from './config';
 import { standardizeIngredientName, removeUndefined } from './utils';
 // import { calculateWilsonLCB } from './utils';
-import { applyIconToNode, buildShortlistEntry, clearNodeShortlist, computeShortlistDelta, getEntryIcon, getIconPath, getIconStoragePaths, getIconThumbPath, getIconUrl, getNodeHydeQueries, getNodeIconId, getNodeIconUrl, getNodeIngredientName, getPendingImpressionIds, getPendingRejectionIds, getPendingImpressionTargets, getPendingRejectionTargets, getSeenIconIds, hasNodeIcon, iconIndexEntryToStats, markEntryImpressedAtIndex, markSeenEntriesImpressed, markSeenEntriesRejected, mutateNodesByIngredient, prependToShortlist, rankIconsByEmbedding, toRecipeIcon, setNodeStatusByIngredient, extractBatchIngredients } from './recipe-lanes/model-utils';
+import { applyIconToNode, assignNodeShortlist, buildShortlistEntry, clearNodeShortlist, computeShortlistDelta, getEntryIcon, getIconPath, getIconStoragePaths, getIconThumbPath, getIconUrl, getNodeHydeQueries, getNodeIconId, getNodeIconUrl, getNodeIngredientName, getNodeShortlist, getNodeShortlistLength, getPendingImpressionIds, getPendingRejectionIds, getPendingImpressionTargets, getPendingRejectionTargets, getSeenIconIds, hasNodeIcon, iconIndexEntryToStats, markEntryImpressedAtIndex, markSeenEntriesImpressed, markSeenEntriesRejected, mutateNodesByIngredient, prependToShortlist, rankIconsByEmbedding, toRecipeIcon, setNodeStatusByIngredient, extractBatchIngredients } from './recipe-lanes/model-utils';
 
 export interface DataService {
   getIngredientByName(name: string): Promise<{ id: string; data: any } | null>;
@@ -228,8 +228,7 @@ export class FirebaseDataService implements DataService {
 
       const generatedEntry: ShortlistEntry = buildShortlistEntry(icon, 'generated');
       recipeChanged = mutateNodesByIngredient(nodes, stdName, (n) => {
-          n.iconShortlist = prependToShortlist(n.iconShortlist || [], generatedEntry);
-          n.shortlistIndex = 0;
+          assignNodeShortlist(n, prependToShortlist(getNodeShortlist(n), generatedEntry), 0);
           delete n.status;
       });
 
@@ -269,7 +268,7 @@ export class FirebaseDataService implements DataService {
     private nodeNeedsProcessing(node: any): boolean {
         if (!node.visualDescription) return false;
         if (node.status === 'pending' || node.status === 'processing') return true;
-        if (!node.iconShortlist || node.iconShortlist.length === 0) return true;
+        if (getNodeShortlistLength(node) === 0) return true;
         return false;
     }
 
@@ -336,6 +335,7 @@ export class FirebaseDataService implements DataService {
                     recipeCount: 1
                 };
                 if (hydeQueries && hydeQueries.length > 0) {
+                    // eslint-disable-next-line no-restricted-syntax -- payload object, not a RecipeNode field access
                     newQueueDoc.hydeQueries = hydeQueries;
                 }
                 transaction.set(queueRef, newQueueDoc);
@@ -354,6 +354,7 @@ export class FirebaseDataService implements DataService {
                     console.log(`[Transaction] Added recipe ${recipeId} to existing queue for "${stdName}"`);
                 }
                 if (hydeQueries && hydeQueries.length > 0) {
+                    // eslint-disable-next-line no-restricted-syntax -- payload object, not a RecipeNode field access
                     updatePayload.hydeQueries = FieldValue.arrayUnion(...hydeQueries);
                 }
                 if (Object.keys(updatePayload).length > 0) {
@@ -494,8 +495,7 @@ export class FirebaseDataService implements DataService {
                         const nodes: any[] = snap.data()?.graph?.nodes || [];
                         for (const { name, entries } of shortlists) {
                             mutateNodesByIngredient(nodes, name, (n: any) => {
-                                n.iconShortlist = entries;
-                                n.shortlistIndex = 0;
+                                assignNodeShortlist(n, entries, 0);
                                 delete n.status;
                             });
                         }
@@ -556,6 +556,7 @@ export class FirebaseDataService implements DataService {
                 x: 0, y: 0
             };
             if (hydeQueries && hydeQueries.length > 0) {
+                // eslint-disable-next-line no-restricted-syntax -- payload object, not a RecipeNode field access
                 newNode.hydeQueries = hydeQueries;
             }
 
@@ -790,13 +791,13 @@ export class FirebaseDataService implements DataService {
           // shortlistCycled are trusted from the client.
           const tasks: Promise<void>[] = [];
           (graph.nodes || []).forEach((n: any) => {
-              if (!n.iconShortlist || !n.visualDescription) return;
+              if (getNodeShortlistLength(n) === 0 || !n.visualDescription) return;
               const oldNode = oldNodesById.get(n.id);
               const delta = computeShortlistDelta(oldNode, n);
               const hasDelta = delta.toImpres.length || delta.toReject.length || delta.toUnreject.length;
             //   console.log(`[saveRecipe] node=${n.id} ingredient="${n.visualDescription}" idx=${n.shortlistIndex} oldIdx=${oldNode?.shortlistIndex ?? 'none'} toImpres=${delta.toImpres.map(t=>t.id)} toReject=${delta.toReject.map(t=>t.id)} toUnreject=${delta.toUnreject.map(t=>t.id)}`);
               if (hasDelta) {
-                  n.iconShortlist = delta.updatedShortlist;
+                  assignNodeShortlist(n, delta.updatedShortlist);
                   delta.toImpres.forEach(({ id, ingredientId }) => tasks.push(this.recordImpression(id, ingredientId)));
                   delta.toReject.forEach(({ id, ingredientId }) => tasks.push(this.recordRejection(id, ingredientId)));
                   delta.toUnreject.forEach(({ id, ingredientId }) => tasks.push(this.decrementRejection(id, ingredientId)));
@@ -1365,8 +1366,7 @@ export class MemoryDataService implements DataService {
                     // todo don't use this broken 
                     applyIconToNode(n, bestIcon);
                     const entry = buildShortlistEntry(bestIcon, 'generated');
-                    n.iconShortlist = prependToShortlist(n.iconShortlist || [], entry);
-                    n.shortlistIndex = 0;
+                    assignNodeShortlist(n, prependToShortlist(getNodeShortlist(n), entry), 0);
                 }
             }
         });
@@ -1722,8 +1722,7 @@ export class MemoryDataService implements DataService {
         let changed = false;
         
         changed = mutateNodesByIngredient(nodes, stdName, (n) => {
-            n.iconShortlist = prependToShortlist((n.iconShortlist as any) || [], buildShortlistEntry(icon, 'generated'));
-            n.shortlistIndex = 0;
+            assignNodeShortlist(n, prependToShortlist(getNodeShortlist(n), buildShortlistEntry(icon, 'generated')), 0);
             delete n.status;
         });
 

--- a/recipe-lanes/lib/recipe-lanes/model-utils.ts
+++ b/recipe-lanes/lib/recipe-lanes/model-utils.ts
@@ -79,6 +79,15 @@ export function setNodeIcon(node: RecipeNode, _icon: IconStats) {
     return node;
 }
 
+/**
+ * Assigns a shortlist (and optionally its index) onto a node in place.
+ * When `index` is omitted the node's existing shortlistIndex is left untouched.
+ */
+export function assignNodeShortlist(node: RecipeNode, entries: ShortlistEntry[], index?: number): void {
+    node.iconShortlist = entries;
+    if (index !== undefined) node.shortlistIndex = index;
+}
+
 /** Clears all shortlist state from the node (shortlist, index, and cycled flag). */
 export function clearNodeShortlist(node: RecipeNode): void {
     node.iconShortlist = undefined;
@@ -360,6 +369,11 @@ export function computeShortlistDelta(
 export function getShortlistIconAt(node: RecipeNode, index: number): IconStats | undefined {
     const entry = node.iconShortlist?.[index];
     return entry ? getEntryIcon(entry) : undefined;
+}
+
+/** Returns the node's shortlist entries, or an empty array when none are present. */
+export function getNodeShortlist(node: RecipeNode): ShortlistEntry[] {
+    return node.iconShortlist ?? [];
 }
 
 /** Returns the number of entries in the node's shortlist. */


### PR DESCRIPTION
## Scope
Routes all out-of-store access to RecipeNode store-internal fields through `model-utils`, then promotes the model-encapsulation lint rule to error.

- **New helpers in `lib/recipe-lanes/model-utils.ts`:** `assignNodeShortlist(node, entries, index?)` (in-place; `index` omitted leaves `shortlistIndex` untouched) and `getNodeShortlist(node)`.
- **Writes routed via `assignNodeShortlist`** in `app/actions.ts` and `lib/data-service.ts`: the `iconShortlist = X; shortlistIndex = 0` reset pairs pass index 0; the `saveRecipe` delta write (which never reset the index) preserves it by omitting the index arg.
- **Reads routed via helpers:** `shortlistIndex ?? 0` → `currentShortlistIndex` (timeline-view.tsx); presence/length checks → `getNodeShortlistLength`; existing-shortlist reads → `getNodeShortlist`.
- **3 justified disables:** targeted `// eslint-disable-next-line no-restricted-syntax` on `hydeQueries` assigned to Firestore payload objects (`newQueueDoc`, `updatePayload`) and a freshly-built node literal (`newNode`) in `data-service.ts` — these are not encapsulated RecipeNode field access. No blanket disable.
- **Rule flipped** `no-restricted-syntax` warn → error in `eslint.config.mjs`.

## Verification
- `npm run lint`: exit 0, 0 model-rule violations
- `npm run typecheck`: exit 0
- `npm run test:unit:pure`: 250 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)