### PR TITLE
feat(lanes): explicit "Save a copy" button for shared recipes

### DIFF
--- a/recipe-lanes/components/recipe-lanes/hooks/useSaveAndFork.ts
+++ b/recipe-lanes/components/recipe-lanes/hooks/useSaveAndFork.ts
@@ -48,6 +48,37 @@ export function buildGraphForSave(
     return { ...graph, nodes: nodesWithPos, layouts, layoutMode: mode };
 }
 
+/**
+ * Pure helper: decides how the Save button should behave for the current
+ * viewer. A logged-in non-owner can always "Save a copy" of a shared recipe
+ * (issue #46) without first making an edit. Owners keep the original
+ * dirty/saved gating.
+ */
+export function getSaveButtonState(params: {
+    isLoggedIn: boolean;
+    isOwner: boolean;
+    isDirty: boolean;
+    saved: boolean;
+}): { enabled: boolean; label: string; isCopy: boolean } {
+    const { isLoggedIn, isOwner, isDirty, saved } = params;
+
+    // Logged-in viewer looking at someone else's recipe: explicit "Save a copy".
+    if (isLoggedIn && !isOwner) {
+        return {
+            enabled: true,
+            label: saved ? 'Saved a copy!' : 'Save a copy',
+            isCopy: true,
+        };
+    }
+
+    // Owner (or not-yet-saved new recipe): original behaviour.
+    return {
+        enabled: isDirty || saved,
+        label: saved ? 'Saved!' : isDirty ? 'Save Changes' : 'No Changes',
+        isCopy: false,
+    };
+}
+
 interface UseSaveAndForkParams {
     graph: RecipeGraph;
     mode: any;

--- a/recipe-lanes/components/recipe-lanes/react-flow-diagram.tsx
+++ b/recipe-lanes/components/recipe-lanes/react-flow-diagram.tsx
@@ -47,7 +47,7 @@ import TimelineBackground, { type TimelineData } from './timeline-background';
 import { toPng } from 'html-to-image';
 import { Download, Share2, Undo, Redo, Check, Save } from 'lucide-react';
 import { useHistoryManager } from './hooks/useHistoryManager';
-import { useSaveAndFork } from './hooks/useSaveAndFork';
+import { useSaveAndFork, getSaveButtonState } from './hooks/useSaveAndFork';
 import { useAutosave } from './hooks/useAutosave';
 import { useRecipeStore } from '../../lib/stores/recipe-store';
 
@@ -132,6 +132,8 @@ const DiagramInner = memo(forwardRef<ReactFlowDiagramHandle, ReactFlowDiagramPro
         onSave,
         onNotify,
     });
+
+    const saveButton = getSaveButtonState({ isLoggedIn, isOwner, isDirty, saved });
 
     const { scheduleAutosave, flushAutosave } = useAutosave({
         onSave: handleSave,
@@ -834,13 +836,14 @@ const DiagramInner = memo(forwardRef<ReactFlowDiagramHandle, ReactFlowDiagramPro
                         </button>
                     </div>
 
-                     <button 
-                        onClick={handleSave} 
-                        disabled={!isDirty && !saved}
-                        className={`p-2 rounded shadow-md border border-zinc-200 transition-colors ${saved ? 'bg-green-50 text-green-600 border-green-200' : isDirty ? 'bg-blue-50 text-blue-600 border-blue-200 hover:bg-blue-100' : 'bg-white text-zinc-400'}`}
-                        title={saved ? "Saved!" : isDirty ? "Save Changes" : "No Changes"}
+                     <button
+                        onClick={handleSave}
+                        disabled={!saveButton.enabled}
+                        className={`flex items-center gap-1.5 p-2 rounded shadow-md border border-zinc-200 transition-colors ${saved ? 'bg-green-50 text-green-600 border-green-200' : saveButton.enabled ? 'bg-blue-50 text-blue-600 border-blue-200 hover:bg-blue-100' : 'bg-white text-zinc-400'}`}
+                        title={saveButton.label}
                     >
                         {saved ? <Check className="w-4 h-4" /> : <Save className="w-4 h-4" />}
+                        {saveButton.isCopy && <span className="text-xs font-bold hidden sm:inline">{saveButton.label}</span>}
                     </button>
 
                      <button 

--- a/recipe-lanes/package.json
+++ b/recipe-lanes/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "npm run test:unit:pure && npm run test:unit:integration",
-    "test:unit:pure": "npx env-cmd -f .env.test node --import tsx --test tests/data.test.ts tests/gallery-view.test.ts tests/graph-logic.test.ts tests/graph.test.ts tests/hybrid-plumbing.test.ts tests/icon-pipeline.test.ts tests/icon-search.test.ts tests/icon-shortlist.test.ts tests/image-processing.test.ts tests/layout-saving.test.ts tests/model-utils.test.ts tests/optimistic-flow.test.ts tests/parser.test.ts tests/patch.test.ts tests/recipe-store.test.ts tests/shortlist-delta.test.ts tests/social-features.test.ts tests/timeline-layout.test.ts tests/timeline-save.test.ts tests/title-persistence.test.ts tests/undo-complex.test.ts tests/verify-production-logic.test.ts",
+    "test:unit:pure": "npx env-cmd -f .env.test node --import tsx --test tests/data.test.ts tests/gallery-view.test.ts tests/graph-logic.test.ts tests/graph.test.ts tests/hybrid-plumbing.test.ts tests/icon-pipeline.test.ts tests/icon-search.test.ts tests/icon-shortlist.test.ts tests/image-processing.test.ts tests/layout-saving.test.ts tests/model-utils.test.ts tests/optimistic-flow.test.ts tests/parser.test.ts tests/patch.test.ts tests/recipe-store.test.ts tests/save-copy.test.ts tests/shortlist-delta.test.ts tests/social-features.test.ts tests/timeline-layout.test.ts tests/timeline-save.test.ts tests/title-persistence.test.ts tests/undo-complex.test.ts tests/verify-production-logic.test.ts",
     "test:unit:integration": "./scripts/test-unit-integration.sh",
     "test:one": "npx env-cmd -f .env.test node --import tsx --test",
     "test:watch": "node --import tsx --test --watch tests/*.test.ts",

--- a/recipe-lanes/tests/save-copy.test.ts
+++ b/recipe-lanes/tests/save-copy.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for the "Save a copy" button gating (issue #46).
+ *
+ * A logged-in viewer looking at someone else's shared recipe should be able to
+ * explicitly save a copy without first making an edit. Owners keep the original
+ * dirty/saved gating.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getSaveButtonState } from '../components/recipe-lanes/hooks/useSaveAndFork';
+
+describe('getSaveButtonState', () => {
+    it('lets a logged-in non-owner save a copy without editing first', () => {
+        const state = getSaveButtonState({ isLoggedIn: true, isOwner: false, isDirty: false, saved: false });
+        assert.equal(state.enabled, true);
+        assert.equal(state.isCopy, true);
+        assert.equal(state.label, 'Save a copy');
+    });
+
+    it('shows a confirmation label after a non-owner copy is saved', () => {
+        const state = getSaveButtonState({ isLoggedIn: true, isOwner: false, isDirty: false, saved: true });
+        assert.equal(state.enabled, true);
+        assert.equal(state.isCopy, true);
+        assert.equal(state.label, 'Saved a copy!');
+    });
+
+    it('keeps the owner button disabled when there are no changes', () => {
+        const state = getSaveButtonState({ isLoggedIn: true, isOwner: true, isDirty: false, saved: false });
+        assert.equal(state.enabled, false);
+        assert.equal(state.isCopy, false);
+        assert.equal(state.label, 'No Changes');
+    });
+
+    it('enables the owner button when the recipe is dirty', () => {
+        const state = getSaveButtonState({ isLoggedIn: true, isOwner: true, isDirty: true, saved: false });
+        assert.equal(state.enabled, true);
+        assert.equal(state.isCopy, false);
+        assert.equal(state.label, 'Save Changes');
+    });
+
+    it('does not offer copy to a logged-out viewer (handleSave prompts login)', () => {
+        const state = getSaveButtonState({ isLoggedIn: false, isOwner: false, isDirty: false, saved: false });
+        assert.equal(state.isCopy, false);
+        assert.equal(state.enabled, false);
+    });
+});


### PR DESCRIPTION
## What existed
The fork-on-save logic already lived in `useSaveAndFork.performSave`: a logged-in non-owner viewing a recipe with an `?id=` gets a new copy created (new id, `Copy of …` naming, `sourceId` set). But the Save button in `react-flow-diagram.tsx` was `disabled={!isDirty && !saved}`, so a non-owner could only trigger the fork *after* editing — matching the issue ("without requiring an edit first").

## What was added
- Extracted a pure `getSaveButtonState()` helper in `useSaveAndFork.ts`. For a logged-in non-owner it always enables the button and labels it "Save a copy" (owners keep the original dirty/saved gating).
- Wired the Save button to that helper (enabled state + title + visible "Save a copy" label for non-owners). No new save path — reuses existing `handleSave` → `performSave` fork logic.
- Added `tests/save-copy.test.ts` covering the helper and registered it in `test:unit:pure`.

## Verified
- `npm run typecheck` — clean
- `npm run test:unit:pure` — 256 pass, 0 fail (incl. new getSaveButtonState suite)
- eslint on changed files — 0 errors (pre-existing warnings only)

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)