### PR TITLE
fix(icon_overview): public view, login-gated forge, admin-gated controls (#172)

### DIFF
--- a/recipe-lanes/app/actions.ts
+++ b/recipe-lanes/app/actions.ts
@@ -89,6 +89,12 @@ export async function createDebugRecipeAction() {
 }
 // icon_overview and tests only.
 export async function addIngredientNodeAction(recipeId: string, ingredientName: string) {
+    // Forging requires a logged-in session. Anonymous visitors can VIEW
+    // /icon_overview but must sign in to forge. (A future PR may add an
+    // `allowAnonForge` config flag; do not assume it here.)
+    const session = await getAuthService().verifyAuth();
+    if (!session) return { success: false, error: 'Login required' };
+
     // Generate HyDE queries so the icon_index entry gets rich search terms
     let hydeQueries: string[] = [];
     try {

--- a/recipe-lanes/app/icon_overview/page.tsx
+++ b/recipe-lanes/app/icon_overview/page.tsx
@@ -39,7 +39,7 @@ import { iconSearchProviders } from '@/lib/icon-search-providers';
 import { SearchProviderPanel } from '@/components/search-provider-panel';
 
 export default function Home() {
-  const { user, loading: authLoading, signIn } = useAuth();
+  const { user, isAdmin, loading: authLoading, signIn } = useAuth();
   const [nodes, setNodes] = useState<RecipeNode[]>([]);
   const [recipeId, setRecipeId] = useState<string | null>(null);
   const [initializing, setInitializing] = useState(true);
@@ -125,6 +125,14 @@ export default function Home() {
     event.preventDefault();
     if (!recipeId) {
         setError("Session not initialized.");
+        return;
+    }
+
+    // Forging requires a login. Anonymous visitors can view the page but
+    // must sign in to forge; prompt them instead of attempting the action.
+    if (!user) {
+        setError("Please log in to forge icons.");
+        signIn();
         return;
     }
 
@@ -302,7 +310,7 @@ export default function Home() {
             </div>
           )}
 
-          {mode === 'forge' && <QueueMonitor />}
+          {mode === 'forge' && <QueueMonitor isAdmin={isAdmin} />}
 
           {mode === 'forge' && (
             <IconDisplay

--- a/recipe-lanes/components/queue-monitor.tsx
+++ b/recipe-lanes/components/queue-monitor.tsx
@@ -33,7 +33,7 @@ interface QueueItem {
   created_at?: any;
 }
 
-export function QueueMonitor() {
+export function QueueMonitor({ isAdmin = false }: { isAdmin?: boolean }) {
   const [items, setItems] = useState<QueueItem[]>([]);
   const [totalCount, setTotalCount] = useState<number>(0);
   const [page, setPage] = useState(1);
@@ -115,13 +115,15 @@ export function QueueMonitor() {
           <span className="text-[10px] font-mono text-zinc-600 bg-zinc-800 px-1.5 rounded">
             {items.length === totalCount ? `${items.length} ACTIVE` : `${items.length} / ${totalCount} ACTIVE`}
           </span>
-          <button
-            onClick={handleClearQueue}
-            className="p-1 hover:bg-zinc-800 rounded text-zinc-600 hover:text-red-400 transition-colors"
-            title="Clear entire queue"
-          >
-            <Trash2 className="w-3 h-3" />
-          </button>
+          {isAdmin && (
+            <button
+              onClick={handleClearQueue}
+              className="p-1 hover:bg-zinc-800 rounded text-zinc-600 hover:text-red-400 transition-colors"
+              title="Clear entire queue"
+            >
+              <Trash2 className="w-3 h-3" />
+            </button>
+          )}
         </div>
       </div>
       <div className="divide-y divide-zinc-900">
@@ -160,14 +162,16 @@ export function QueueMonitor() {
                       <XCircle className="w-3 h-3" />
                       <span className="text-[10px] font-bold uppercase">Failed</span>
                     </div>
-                    <button 
-                        onClick={() => handleRetry(item.ingredientName)}
-                        className="p-1 hover:bg-zinc-800 rounded text-zinc-400 hover:text-white transition-colors"
-                        title="Retry"
-                        aria-label="Retry"
-                    >
-                        <RotateCw className="w-3 h-3" />
-                    </button>
+                    {isAdmin && (
+                      <button
+                          onClick={() => handleRetry(item.ingredientName)}
+                          className="p-1 hover:bg-zinc-800 rounded text-zinc-400 hover:text-white transition-colors"
+                          title="Retry"
+                          aria-label="Retry"
+                      >
+                          <RotateCw className="w-3 h-3" />
+                      </button>
+                    )}
                 </div>
               )}
             </div>

--- a/recipe-lanes/e2e/icons.spec.ts
+++ b/recipe-lanes/e2e/icons.spec.ts
@@ -87,8 +87,13 @@ test.describe('Icon Systems (Consolidated)', () => {
     // 2. Backlog Management
     await page.goto('/icon_overview');
     await login('backlog-user');
+    // QueueMonitor's Retry/Clear controls are admin-only (Bug 172); promote this
+    // user so the admin controls render, then let the client auth pick up admin.
+    const { promoteToAdmin } = await import('./utils/admin-utils');
+    await promoteToAdmin('backlog-user');
+    await page.waitForTimeout(1000);
     const failItem = `Fail Egg ${Date.now()}`;
-    
+
     await page.waitForFunction(() => (window as any)._firebaseDb && (window as any)._firebaseFirestore);
     // Clear existing queue items so our test item sorts to page 1 of QueueMonitor
     await page.evaluate(async () => {

--- a/recipe-lanes/tests/admin-security.test.ts
+++ b/recipe-lanes/tests/admin-security.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { deleteIconByIdAction } from '../app/actions';
+import { deleteIconByIdAction, addIngredientNodeAction } from '../app/actions';
 import { setAuthService, AuthSession } from '../lib/auth-service';
 import { db } from '../lib/firebase-admin';
 
@@ -34,6 +34,23 @@ describe('Admin Security', () => {
         const res = await deleteIconByIdAction('fake-id');
         // We expect it NOT to fail with auth error, though it might fail because ID is fake
         assert.notStrictEqual(res.error, 'Admin required');
+        assert.notStrictEqual(res.error, 'Login required');
+    });
+});
+
+describe('Forge Auth Scoping (Bug 172)', () => {
+    it('should block anonymous (logged-out) user from forging', async () => {
+        setAuthService(new MockAuth(null));
+        const res = await addIngredientNodeAction('any-recipe', 'Carrot');
+        assert.strictEqual(res.success, false);
+        assert.strictEqual(res.error, 'Login required');
+    });
+
+    it('should let a logged-in (non-admin) user past the forge auth gate', async () => {
+        setAuthService(new MockAuth({ uid: 'forger', isAdmin: false }));
+        const res = await addIngredientNodeAction('missing-recipe', 'Carrot');
+        // A logged-in user is NOT blocked by auth. The action may still fail for
+        // other reasons (e.g. the recipe does not exist) but never with 'Login required'.
         assert.notStrictEqual(res.error, 'Login required');
     });
 });


### PR DESCRIPTION
## Bug 172 — rescope auth on `/icon_overview`

**Note:** the bug title says "hide behind auth", but there was no real view-gate — the page already rendered for logged-out users. The actual defect was that the **forge action had no auth check at all**. This PR fixes the real problem and matches the agreed product spec.

### Behavior
- **Anyone can VIEW** `/icon_overview` (including logged-out visitors).
- **Forging is gated** server-side in `addIngredientNodeAction`.
- **Admin management controls** (Clear Queue, Retry) are hidden from non-admins in the UI, matching the existing server-side `isAdmin` checks.

### Tests
- New "Forge Auth Scoping" cases in `tests/admin-security.test.ts`.

First in a stack of 3 (→ abuse controls → alerting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)