### PR TITLE
feat(icon-queue): runtime config doc + abuse controls

### DIFF
--- a/recipe-lanes/app/actions.ts
+++ b/recipe-lanes/app/actions.ts
@@ -59,6 +59,11 @@ export async function forgeIconAction(recipeId: string, ingredientName: string, 
     try {
         const session = await getAuthService().verifyAuth();
         const userId = session?.uid;
+        const forgeBlock = await checkForgeAllowed(userId);
+        if (forgeBlock) return { success: false, error: forgeBlock };
+        if (userId) incrementUserForgeCount(userId).catch(e =>
+            console.warn('[forgeIconAction] forge count increment failed (non-fatal):', e)
+        );
         // Forge: reject current and queue brand-new generation (no index search — skip embedFn)
         return getDataService().rejectRecipeIcon(recipeId, ingredientName, currentIconId, userId);
     } catch (e: any) {
@@ -283,15 +288,26 @@ export async function createVisualRecipeAction(recipeText: string, currentId?: s
         // icon shortlists as resolveRecipeIcons writes them to Firestore.
         // Falls back to awaiting directly when outside a Next.js request context (tests).
         const embedFn = getAIService().embedTexts.bind(getAIService());
-        try {
-            if (process.env.NODE_ENV === 'test') {
+        // Gate AI icon forging (allowAnonForge / per-user daily cap). The recipe is
+        // still saved and existing-icon search pre-population above still runs; only
+        // the expensive new-icon generation is skipped when blocked.
+        const forgeBlock = await checkForgeAllowed(userId);
+        if (forgeBlock) {
+            console.log(`[createVisualRecipeAction] forge gated (${forgeBlock}); recipe ${id} saved without icon resolution.`);
+        } else {
+            if (userId) incrementUserForgeCount(userId).catch(e =>
+                console.warn('[createVisualRecipeAction] forge count increment failed (non-fatal):', e)
+            );
+            try {
+                if (process.env.NODE_ENV === 'test') {
+                    await getDataService().resolveRecipeIcons(id, serverBatchSearchAction);
+                } else {
+                    after(() => getDataService().resolveRecipeIcons(id, serverBatchSearchAction));
+                }
+            } catch (e) {
+                console.log("[createVisualRecipeAction] 'after' not supported or outside request scope, running sync", e);
                 await getDataService().resolveRecipeIcons(id, serverBatchSearchAction);
-            } else {
-                after(() => getDataService().resolveRecipeIcons(id, serverBatchSearchAction));
             }
-        } catch (e) {
-            console.log("[createVisualRecipeAction] 'after' not supported or outside request scope, running sync", e);
-            await getDataService().resolveRecipeIcons(id, serverBatchSearchAction);
         }
 
         console.log(`[createVisualRecipeAction] ✅ Saved. ID: ${id} (icons resolving in background)`);
@@ -463,7 +479,15 @@ export async function saveRecipeAction(graph: RecipeGraph, existingId?: string, 
     // Resolve icons for any pending nodes (e.g. added via AI adjustment)
     const hasPending = graph.nodes.some(n => n.status === 'pending');
     if (hasPending) {
-      after(() => dataService.resolveRecipeIcons(id, serverBatchSearchAction));
+      const forgeBlock = await checkForgeAllowed(userId);
+      if (forgeBlock) {
+        console.log(`[saveRecipeAction] forge gated (${forgeBlock}); recipe ${id} saved without icon resolution.`);
+      } else {
+        if (userId) incrementUserForgeCount(userId).catch(e =>
+          console.warn('[saveRecipeAction] forge count increment failed (non-fatal):', e)
+        );
+        after(() => dataService.resolveRecipeIcons(id, serverBatchSearchAction));
+      }
     }
     return { id };
   } catch (e: any) {

--- a/recipe-lanes/app/actions.ts
+++ b/recipe-lanes/app/actions.ts
@@ -30,6 +30,8 @@ import { cosineSimilarity, getIconThumbUrl, getNodeIconUrl, getShortlistIconAt, 
 import { db } from '@/lib/firebase-admin';
 import { DB_COLLECTION_RECIPES, DB_COLLECTION_QUEUE } from '@/lib/config';
 import { unifiedIconSearch, serverBatchIconSearch } from '@/lib/search-orchestrator';
+import { getIconQueueConfig, setIconQueueConfig, getUserForgeCountToday, incrementUserForgeCount } from '@/lib/icon-queue-config';
+import type { IconQueueConfig } from '@/lib/config';
 
 // Input Validation Schemas
 const IngredientSchema = z.string().min(1).max(100);
@@ -87,13 +89,43 @@ export async function createDebugRecipeAction() {
         return { error: e.message };
     }
 }
+// --- icon-queue abuse controls (feat/icon-queue-abuse-controls) ---
+// Runtime-configurable gate consulted before any forge is enqueued. Reads the
+// single `config/icon_queue` doc via the typed accessor. Returns an error string
+// (suitable for the UI to turn into a login/limit prompt) when the forge should
+// be rejected, or null to allow.
+async function checkForgeAllowed(uid: string | undefined): Promise<string | null> {
+    const cfg = await getIconQueueConfig();
+
+    // Anonymous-forge gate.
+    if (!uid) {
+        if (!cfg.allowAnonForge) {
+            return 'Please log in to forge new icons.';
+        }
+        // No per-user counting possible for anonymous users; allow (subject to pause).
+        return null;
+    }
+
+    // Per-user daily cap.
+    const used = await getUserForgeCountToday(uid);
+    if (used >= cfg.perUserDailyCap) {
+        return `Daily forge limit reached (${cfg.perUserDailyCap}/day). Try again tomorrow.`;
+    }
+    return null;
+}
+
 // icon_overview and tests only.
 export async function addIngredientNodeAction(recipeId: string, ingredientName: string) {
-    // Forging requires a logged-in session. Anonymous visitors can VIEW
-    // /icon_overview but must sign in to forge. (A future PR may add an
-    // `allowAnonForge` config flag; do not assume it here.)
-    const session = await getAuthService().verifyAuth();
-    if (!session) return { success: false, error: 'Login required' };
+    // --- abuse controls: gate the forge before doing any work ---
+    // Anonymous visitors can VIEW /icon_overview; forging is gated by config:
+    // checkForgeAllowed enforces the allowAnonForge flag and the per-user daily cap.
+    const forgeSession = await getAuthService().verifyAuth();
+    const forgeUid = forgeSession?.uid;
+    const forgeBlock = await checkForgeAllowed(forgeUid);
+    if (forgeBlock) {
+        return { success: false, error: forgeBlock };
+    }
+    // --- end abuse controls ---
 
     // Generate HyDE queries so the icon_index entry gets rich search terms
     let hydeQueries: string[] = [];
@@ -105,6 +137,12 @@ export async function addIngredientNodeAction(recipeId: string, ingredientName: 
     }
     const result = await getDataService().addNodeToRecipe(recipeId, ingredientName, undefined, hydeQueries);
     if (result.success) {
+        // Count this forge against the user's daily quota (non-fatal).
+        if (forgeUid) {
+            incrementUserForgeCount(forgeUid).catch(e =>
+                console.warn('[addIngredientNodeAction] forge count increment failed (non-fatal):', e)
+            );
+        }
         // 5. Trigger icon resolution in background (or foreground if preferred)
         try {
             if (process.env.NODE_ENV === 'test') {
@@ -623,6 +661,40 @@ export async function clearIconQueueAction(): Promise<{ success: boolean; delete
         return { success: true, deleted };
     } catch (e: any) {
         return { success: false, deleted: 0, error: e.message };
+    }
+}
+
+// --- icon-queue runtime config (admin only) ---
+
+// Read the current icon-queue config for the admin panel. Admin-gated server-side.
+export async function getIconQueueConfigAction(): Promise<{ config?: IconQueueConfig; error?: string }> {
+    const session = await getAuthService().verifyAuth();
+    if (!session) return { error: 'Login required' };
+    const userDoc = await db.collection('users').doc(session.uid).get();
+    if (!userDoc.data()?.isAdmin) return { error: 'Admin required' };
+
+    try {
+        const config = await getIconQueueConfig();
+        return { config };
+    } catch (e: any) {
+        return { error: e.message };
+    }
+}
+
+// Update the icon-queue config from the admin panel. Admin-gated server-side.
+export async function setIconQueueConfigAction(
+    patch: Partial<IconQueueConfig>,
+): Promise<{ config?: IconQueueConfig; error?: string }> {
+    const session = await getAuthService().verifyAuth();
+    if (!session) return { error: 'Login required' };
+    const userDoc = await db.collection('users').doc(session.uid).get();
+    if (!userDoc.data()?.isAdmin) return { error: 'Admin required' };
+
+    try {
+        const config = await setIconQueueConfig(patch);
+        return { config };
+    } catch (e: any) {
+        return { error: e.message };
     }
 }
 

--- a/recipe-lanes/app/icon_overview/page.tsx
+++ b/recipe-lanes/app/icon_overview/page.tsx
@@ -22,6 +22,7 @@ import { IngredientForm } from '@/components/ingredient-form';
 import { IconDisplay } from '@/components/icon-display';
 import { SharedGallery } from '@/components/shared-gallery';
 import { QueueMonitor } from '@/components/queue-monitor';
+import { QueueConfigPanel } from '@/components/queue-config-panel';
 import { LogoutButton } from '@/components/logout-button';
 import { useAuth } from '@/components/auth-provider';
 import { createDebugRecipeAction, addIngredientNodeAction, rejectIcon, deleteRecipeAction } from '@/app/actions';
@@ -128,14 +129,6 @@ export default function Home() {
         return;
     }
 
-    // Forging requires a login. Anonymous visitors can view the page but
-    // must sign in to forge; prompt them instead of attempting the action.
-    if (!user) {
-        setError("Please log in to forge icons.");
-        signIn();
-        return;
-    }
-
     const formData = new FormData(event.currentTarget);
     const rawIngredient = formData.get('ingredient') as string;
     
@@ -151,7 +144,13 @@ export default function Home() {
     // and safer for consistency. But we can set a loading state if we want.
     
     try {
-        await addIngredientNodeAction(recipeId, newIngredient);
+        // Forging is gated server-side by config (allowAnonForge + per-user daily
+        // cap). Surface any rejection; if the server requires a login, prompt it.
+        const result = await addIngredientNodeAction(recipeId, newIngredient);
+        if (result && !result.success && result.error) {
+            setError(result.error);
+            if (!user) signIn();
+        }
     } catch (e: any) {
         console.error(e);
         setError("Failed to add item.");
@@ -311,6 +310,8 @@ export default function Home() {
           )}
 
           {mode === 'forge' && <QueueMonitor isAdmin={isAdmin} />}
+
+          {mode === 'forge' && <QueueConfigPanel isAdmin={isAdmin} />}
 
           {mode === 'forge' && (
             <IconDisplay

--- a/recipe-lanes/components/queue-config-panel.tsx
+++ b/recipe-lanes/components/queue-config-panel.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Loader2, ShieldAlert, Save } from 'lucide-react';
+import { getIconQueueConfigAction, setIconQueueConfigAction } from '@/app/actions';
+import type { IconQueueConfig } from '@/lib/config';
+
+/**
+ * Admin-only panel for editing the runtime icon-queue config (`config/icon_queue`).
+ * Visibility is gated by `isAdmin` here AND every action is re-checked server-side.
+ * Render nothing for non-admins.
+ */
+export function QueueConfigPanel({ isAdmin }: { isAdmin: boolean }) {
+  const [config, setConfig] = useState<IconQueueConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    let cancelled = false;
+    (async () => {
+      const res = await getIconQueueConfigAction();
+      if (cancelled) return;
+      if (res.error) setError(res.error);
+      else if (res.config) setConfig(res.config);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAdmin]);
+
+  if (!isAdmin) return null;
+
+  const update = (patch: Partial<IconQueueConfig>) =>
+    setConfig(prev => (prev ? { ...prev, ...patch } : prev));
+
+  const handleSave = async () => {
+    if (!config) return;
+    setSaving(true);
+    setError(null);
+    const res = await setIconQueueConfigAction(config);
+    if (res.error) setError(res.error);
+    else if (res.config) {
+      setConfig(res.config);
+      setSavedAt(Date.now());
+    }
+    setSaving(false);
+  };
+
+  return (
+    <section className="w-full rounded-lg border border-amber-700/50 bg-zinc-950/60 p-4 font-mono text-sm">
+      <div className="mb-3 flex items-center gap-2 text-amber-500">
+        <ShieldAlert className="h-4 w-4" />
+        <span className="font-bold uppercase tracking-wider">Queue Config (Admin)</span>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-zinc-400">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading config…
+        </div>
+      ) : config ? (
+        <div className="space-y-3">
+          <label className="flex items-center justify-between gap-4">
+            <span className="text-zinc-300">Paused (hard stop)</span>
+            <input
+              type="checkbox"
+              checked={config.paused}
+              onChange={e => update({ paused: e.target.checked })}
+              className="h-4 w-4 accent-amber-500"
+            />
+          </label>
+
+          <label className="flex items-center justify-between gap-4">
+            <span className="text-zinc-300">Allow anonymous forge</span>
+            <input
+              type="checkbox"
+              checked={config.allowAnonForge}
+              onChange={e => update({ allowAnonForge: e.target.checked })}
+              className="h-4 w-4 accent-amber-500"
+            />
+          </label>
+
+          <label className="flex items-center justify-between gap-4">
+            <span className="text-zinc-300">Per-user daily cap</span>
+            <input
+              type="number"
+              min={0}
+              value={config.perUserDailyCap}
+              onChange={e => update({ perUserDailyCap: Number(e.target.value) })}
+              className="w-24 rounded bg-zinc-800 px-2 py-1 text-right text-zinc-100"
+            />
+          </label>
+
+          <div className="flex items-center gap-3 pt-1">
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="flex items-center gap-1.5 rounded bg-amber-600 px-3 py-1.5 text-xs font-bold uppercase tracking-wider text-black hover:bg-amber-500 disabled:opacity-50"
+            >
+              {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+              Save
+            </button>
+            {savedAt && !saving && <span className="text-xs text-green-500">Saved.</span>}
+          </div>
+        </div>
+      ) : null}
+
+      {error && <p className="mt-3 text-xs text-red-400">{error}</p>}
+    </section>
+  );
+}

--- a/recipe-lanes/functions/src/index.ts
+++ b/recipe-lanes/functions/src/index.ts
@@ -17,7 +17,7 @@
 
 
 import { generateIconData } from './icon-generator';
-import { DB_COLLECTION_QUEUE, DB_COLLECTION_RECIPES } from "../../lib/config";
+import { DB_COLLECTION_QUEUE, DB_COLLECTION_RECIPES, DB_COLLECTION_CONFIG, ICON_QUEUE_CONFIG_DOC, withIconQueueConfigDefaults } from "../../lib/config";
 import { getDataService } from '../../lib/data-service';
 import { getAIService } from '../../lib/ai-service';
 import { db } from '../../lib/firebase-admin';
@@ -50,6 +50,24 @@ export const processIconTask = onTaskDispatched({
     await processIconTaskHandler(req.data, req.retryCount ?? 0);
 });
 
+// How long to wait before retrying a task that was deferred because the queue
+// is paused. Re-enqueue (rather than fail/drop) so work resumes automatically
+// once an admin un-pauses via the runtime config doc.
+const PAUSE_BACKOFF_SECONDS = 300;
+
+// Functions-side read of the runtime config doc. The functions package shares
+// lib/ with the app; we read the doc directly with the admin SDK here and reuse
+// the shared `withIconQueueConfigDefaults` so defaults live in one place.
+const readIconQueueConfig = async () => {
+    try {
+        const snap = await db.collection(DB_COLLECTION_CONFIG).doc(ICON_QUEUE_CONFIG_DOC).get();
+        return withIconQueueConfigDefaults(snap.exists ? snap.data() : null);
+    } catch (e) {
+        console.warn('[processIconTask] config read failed, using defaults:', e);
+        return withIconQueueConfigDefaults(null);
+    }
+};
+
 export const processIconTaskHandler = async (data: { ingredientName: string }, retryCount: number = 0) => {
     const { ingredientName } = data;
     console.log(`[Task-${ingredientName}] 🚀 Started`);
@@ -60,6 +78,25 @@ export const processIconTaskHandler = async (data: { ingredientName: string }, r
     }
 
     const docRef = db.collection(DB_COLLECTION_QUEUE).doc(ingredientName);
+
+    // HARD PAUSE: checked FIRST. When paused, do not generate — re-enqueue the
+    // task with a backoff delay so it resumes when an admin un-pauses, rather
+    // than dropping or failing it.
+    const cfg = await readIconQueueConfig();
+    if (cfg.paused) {
+        console.log(`[Task-${ingredientName}] ⏸ Queue paused — re-enqueueing in ${PAUSE_BACKOFF_SECONDS}s.`);
+        try {
+            const { getFunctions } = require('firebase-admin/functions');
+            const queue = getFunctions().taskQueue('processIconTask');
+            await queue.enqueue(
+                { ingredientName },
+                { scheduleDelaySeconds: PAUSE_BACKOFF_SECONDS },
+            );
+        } catch (e) {
+            console.error(`[Task-${ingredientName}] Failed to re-enqueue paused task:`, e);
+        }
+        return; // ACK this dispatch; the delayed copy will retry.
+    }
 
     try {
         // 1. Check doc exists (may have been cleared by admin) before proceeding

--- a/recipe-lanes/lib/config.ts
+++ b/recipe-lanes/lib/config.ts
@@ -24,3 +24,48 @@ export const DB_COLLECTION_QUEUE = 'icon_queue';
 export const DB_COLLECTION_RECIPES = 'recipes';
 export const DB_COLLECTION_FEEDBACK = 'feedback';
 export const DB_COLLECTION_ICON_INDEX = 'icon_index';
+export const DB_COLLECTION_CONFIG = 'config';
+
+// Runtime config document for the icon-generation queue. Both the server actions
+// and the Cloud Function read this so abuse controls are adjustable without a redeploy.
+export const ICON_QUEUE_CONFIG_DOC = 'icon_queue';
+
+export interface IconQueueConfig {
+  /** Hard pause: when true the Cloud Task handler re-enqueues with backoff instead of generating. */
+  paused: boolean;
+  /** Whether logged-out/anonymous users may forge icons. */
+  allowAnonForge: boolean;
+  /** Max forges a single user may enqueue per calendar (UTC) day. */
+  perUserDailyCap: number;
+}
+
+export const DEFAULT_ICON_QUEUE_CONFIG: IconQueueConfig = {
+  paused: false,
+  allowAnonForge: true,
+  perUserDailyCap: 100,
+};
+
+/**
+ * Apply safe defaults to a (possibly partial / undefined) raw config doc.
+ * Defaults live in exactly one place so the typed accessor
+ * (lib/icon-queue-config.ts) and the functions-side reader agree.
+ */
+export function withIconQueueConfigDefaults(raw: any): IconQueueConfig {
+  const data = raw || {};
+  return {
+    paused: typeof data.paused === 'boolean' ? data.paused : DEFAULT_ICON_QUEUE_CONFIG.paused,
+    allowAnonForge:
+      typeof data.allowAnonForge === 'boolean'
+        ? data.allowAnonForge
+        : DEFAULT_ICON_QUEUE_CONFIG.allowAnonForge,
+    perUserDailyCap:
+      typeof data.perUserDailyCap === 'number' && Number.isFinite(data.perUserDailyCap)
+        ? data.perUserDailyCap
+        : DEFAULT_ICON_QUEUE_CONFIG.perUserDailyCap,
+  };
+}
+
+/** UTC day key (YYYY-MM-DD) used for per-user daily forge counting. */
+export function dayKey(d: Date = new Date()): string {
+  return d.toISOString().slice(0, 10);
+}

--- a/recipe-lanes/lib/icon-queue-config.ts
+++ b/recipe-lanes/lib/icon-queue-config.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Typed accessor for the runtime icon-queue config document (`config/icon_queue`).
+// This is the single source of truth used by server actions and the data layer.
+// The Cloud Function package mirrors this read with the admin SDK directly
+// (see functions/src/index.ts) but shares the defaults from ./config.
+
+import { FieldValue } from 'firebase-admin/firestore';
+import { db } from './firebase-admin';
+import {
+  DB_COLLECTION_CONFIG,
+  ICON_QUEUE_CONFIG_DOC,
+  IconQueueConfig,
+  dayKey,
+  withIconQueueConfigDefaults,
+} from './config';
+
+// Per-user daily forge usage counters.
+// Strategy: a tiny counter doc keyed by `${uid}_${utcDay}` that we atomically
+// increment at enqueue time. This is chosen over counting queue docs because
+// queue docs are DELETED once processed (so a count would undercount real
+// usage), and a collection-group count query would be O(queue size) on every
+// forge. The counter is a single point read + one atomic increment, and the
+// day-key in the doc id makes it self-expiring/cheap to reason about.
+const DB_COLLECTION_FORGE_USAGE = 'icon_forge_usage';
+
+function usageDocRef(uid: string, day: string = dayKey()) {
+  return db.collection(DB_COLLECTION_FORGE_USAGE).doc(`${uid}_${day}`);
+}
+
+/** How many forges has this user enqueued so far today (UTC)? */
+export async function getUserForgeCountToday(uid: string): Promise<number> {
+  try {
+    const snap = await usageDocRef(uid).get();
+    const c = snap.data()?.count;
+    return typeof c === 'number' ? c : 0;
+  } catch (e) {
+    console.warn('[icon-queue-config] usage read failed, assuming 0:', e);
+    return 0;
+  }
+}
+
+/** Atomically record one forge for this user today. */
+export async function incrementUserForgeCount(uid: string, by: number = 1): Promise<void> {
+  const day = dayKey();
+  await usageDocRef(uid, day).set(
+    { count: FieldValue.increment(by), uid, day, updated_at: FieldValue.serverTimestamp() },
+    { merge: true },
+  );
+}
+
+function configDocRef() {
+  return db.collection(DB_COLLECTION_CONFIG).doc(ICON_QUEUE_CONFIG_DOC);
+}
+
+/** Read the icon-queue config, applying safe defaults for a missing doc/field. */
+export async function getIconQueueConfig(): Promise<IconQueueConfig> {
+  try {
+    const snap = await configDocRef().get();
+    return withIconQueueConfigDefaults(snap.exists ? snap.data() : null);
+  } catch (e) {
+    console.warn('[icon-queue-config] read failed, using defaults:', e);
+    return withIconQueueConfigDefaults(null);
+  }
+}
+
+/**
+ * Merge-write a partial update to the icon-queue config.
+ * Only the provided fields are written; validation/clamping is applied so an
+ * admin cannot persist a nonsensical value.
+ */
+export async function setIconQueueConfig(
+  patch: Partial<IconQueueConfig>,
+): Promise<IconQueueConfig> {
+  const update: Partial<IconQueueConfig> = {};
+  if (typeof patch.paused === 'boolean') update.paused = patch.paused;
+  if (typeof patch.allowAnonForge === 'boolean') update.allowAnonForge = patch.allowAnonForge;
+  if (typeof patch.perUserDailyCap === 'number' && Number.isFinite(patch.perUserDailyCap)) {
+    // Clamp to a sane non-negative integer.
+    update.perUserDailyCap = Math.max(0, Math.floor(patch.perUserDailyCap));
+  }
+  await configDocRef().set(update, { merge: true });
+  return getIconQueueConfig();
+}

--- a/recipe-lanes/scripts/test-unit-integration.sh
+++ b/recipe-lanes/scripts/test-unit-integration.sh
@@ -7,7 +7,7 @@ if [ -d "/usr/lib/jvm/java-21-openjdk-amd64" ]; then
     export PATH=$JAVA_HOME/bin:$PATH
 fi
 
-INTEGRATION_TESTS="tests/admin-security.test.ts tests/data-helpers.test.ts tests/functions-metadata.test.ts tests/hybrid-integration.test.ts tests/icon-index.test.ts tests/impression-rejection.test.ts tests/lifecycle.test.ts"
+INTEGRATION_TESTS="tests/admin-security.test.ts tests/data-helpers.test.ts tests/functions-metadata.test.ts tests/hybrid-integration.test.ts tests/icon-index.test.ts tests/icon-queue-config.test.ts tests/forge-gate-regression.test.ts tests/impression-rejection.test.ts tests/lifecycle.test.ts"
 # Note: these tests import firebase-admin and require Firestore/Auth emulators to be available.
 
 echo "----------------------------------------------------------------"
@@ -17,12 +17,12 @@ echo "----------------------------------------------------------------"
 # Check if Emulators are already running (Firestore on 8080)
 if curl -s --connect-timeout 1 http://127.0.0.1:8080 > /dev/null 2>&1; then
     echo "Emulators detected on port 8080. Running against EXISTING emulators."
-    npx env-cmd -f .env.test node --import tsx --test $INTEGRATION_TESTS
+    npx env-cmd -f .env.test node --import tsx --test --test-concurrency=1 $INTEGRATION_TESTS
 else
     echo "No emulators detected. Starting NEW emulators for tests."
     # Build Functions (Required for 'functions' emulator)
     npm install --prefix functions --quiet
     npm run build --prefix functions
 
-    npx env-cmd -f .env.test firebase emulators:exec --only auth,firestore,storage,functions,tasks --project local-project-id "node --import tsx --test $INTEGRATION_TESTS"
+    npx env-cmd -f .env.test firebase emulators:exec --only auth,firestore,storage,functions,tasks --project local-project-id "node --import tsx --test --test-concurrency=1 $INTEGRATION_TESTS"
 fi

--- a/recipe-lanes/tests/admin-security.test.ts
+++ b/recipe-lanes/tests/admin-security.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { deleteIconByIdAction, addIngredientNodeAction } from '../app/actions';
 import { setAuthService, AuthSession } from '../lib/auth-service';
+import { setIconQueueConfig } from '../lib/icon-queue-config';
 import { db } from '../lib/firebase-admin';
 
 class MockAuth {
@@ -38,19 +39,31 @@ describe('Admin Security', () => {
     });
 });
 
-describe('Forge Auth Scoping (Bug 172)', () => {
-    it('should block anonymous (logged-out) user from forging', async () => {
+describe('Forge Auth Scoping (Bug 172) + abuse controls', () => {
+    const ANON_BLOCKED = 'Please log in to forge new icons.';
+
+    it('should allow anonymous forging when allowAnonForge is true (default)', async () => {
         setAuthService(new MockAuth(null));
-        const res = await addIngredientNodeAction('any-recipe', 'Carrot');
-        assert.strictEqual(res.success, false);
-        assert.strictEqual(res.error, 'Login required');
+        await setIconQueueConfig({ allowAnonForge: true });
+        const res = await addIngredientNodeAction('missing-recipe', 'Carrot');
+        // Anon is permitted by default; the action may still fail for other
+        // reasons (e.g. missing recipe) but never with the anon-gate message.
+        assert.notStrictEqual(res.error, ANON_BLOCKED);
     });
 
-    it('should let a logged-in (non-admin) user past the forge auth gate', async () => {
+    it('should block anonymous forging when allowAnonForge is false', async () => {
+        setAuthService(new MockAuth(null));
+        await setIconQueueConfig({ allowAnonForge: false });
+        const res = await addIngredientNodeAction('any-recipe', 'Carrot');
+        assert.strictEqual(res.success, false);
+        assert.strictEqual(res.error, ANON_BLOCKED);
+    });
+
+    it('should let a logged-in (non-admin) user past the anon gate', async () => {
         setAuthService(new MockAuth({ uid: 'forger', isAdmin: false }));
+        await setIconQueueConfig({ allowAnonForge: false });
         const res = await addIngredientNodeAction('missing-recipe', 'Carrot');
-        // A logged-in user is NOT blocked by auth. The action may still fail for
-        // other reasons (e.g. the recipe does not exist) but never with 'Login required'.
-        assert.notStrictEqual(res.error, 'Login required');
+        // A logged-in user is not subject to the anon gate.
+        assert.notStrictEqual(res.error, ANON_BLOCKED);
     });
 });

--- a/recipe-lanes/tests/forge-gate-regression.test.ts
+++ b/recipe-lanes/tests/forge-gate-regression.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { setAIService, MockAIService } from '../lib/ai-service';
+import { setDataService, MemoryDataService, getDataService } from '../lib/data-service';
+import { setAuthService, AuthSession } from '../lib/auth-service';
+import { setIconQueueConfig } from '../lib/icon-queue-config';
+import { createVisualRecipeAction } from '../app/actions';
+import { db } from '../lib/firebase-admin';
+import { DB_COLLECTION_CONFIG, ICON_QUEUE_CONFIG_DOC } from '../lib/config';
+
+// Regression: the anon-forge gate must cover recipe CREATION, not just the
+// manual "add ingredient" action. Previously an anonymous user could create a
+// recipe and have every ingredient's icon FORGED even with allowAnonForge=false,
+// because createVisualRecipeAction triggered resolveRecipeIcons ungated.
+//
+// Note: existing-icon search pre-population is intentionally NOT gated (it is a
+// cheap reuse of already-generated icons, not the AI-generation abuse vector).
+// So we assert on whether *forging* (resolveRecipeIcons) was triggered, not on
+// whether the node ended up with an icon URL.
+// Reads config from Firestore -> emulator-backed test.
+
+class MockAuth {
+    constructor(private user: AuthSession | null) {}
+    async verifyAuth() { return this.user; }
+}
+
+class RecipeMockAI extends MockAIService {
+    async generateText(): Promise<string> {
+        return JSON.stringify({
+            title: 'Gate Test',
+            lanes: [{ id: 'lane1', label: 'Board', type: 'prep' }],
+            nodes: [
+                { id: 'n1', laneId: 'lane1', text: '1 Rutabaga', visualDescription: 'Rutabaga', type: 'ingredient' },
+            ],
+        });
+    }
+}
+
+// MemoryDataService that records whether forging (resolveRecipeIcons) was triggered.
+class SpyDataService extends MemoryDataService {
+    forgeTriggered = false;
+    async resolveRecipeIcons(id: string, fn?: any): Promise<void> {
+        this.forgeTriggered = true;
+        return super.resolveRecipeIcons(id, fn);
+    }
+}
+
+describe('Anon forge gate covers recipe creation (regression)', () => {
+    let spy: SpyDataService;
+
+    beforeEach(async () => {
+        await db.collection(DB_COLLECTION_CONFIG).doc(ICON_QUEUE_CONFIG_DOC).delete().catch(() => {});
+        spy = new SpyDataService();
+        setDataService(spy);
+        setAIService(new RecipeMockAI());
+    });
+
+    afterEach(async () => {
+        await db.collection(DB_COLLECTION_CONFIG).doc(ICON_QUEUE_CONFIG_DOC).delete().catch(() => {});
+    });
+
+    it('does not forge on anon recipe creation when allowAnonForge is false (recipe still saved)', async () => {
+        setAuthService(new MockAuth(null));
+        await setIconQueueConfig({ allowAnonForge: false });
+
+        const res = await createVisualRecipeAction('1 Rutabaga');
+        assert.ok(res.id, 'recipe should still be created even when forging is blocked');
+        assert.strictEqual(spy.forgeTriggered, false, 'forging must NOT run for anon when allowAnonForge is false');
+    });
+
+    it('forges on anon recipe creation when allowAnonForge is true', async () => {
+        setAuthService(new MockAuth(null));
+        await setIconQueueConfig({ allowAnonForge: true });
+
+        const res = await createVisualRecipeAction('1 Rutabaga');
+        assert.ok(res.id, 'recipe should be created');
+        assert.strictEqual(spy.forgeTriggered, true, 'forging should run for anon when allowAnonForge is true');
+    });
+});

--- a/recipe-lanes/tests/icon-queue-config.test.ts
+++ b/recipe-lanes/tests/icon-queue-config.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { getIconQueueConfigAction, setIconQueueConfigAction, addIngredientNodeAction } from '../app/actions';
+import { setAuthService, AuthSession } from '../lib/auth-service';
+import {
+    getIconQueueConfig,
+    setIconQueueConfig,
+    getUserForgeCountToday,
+    incrementUserForgeCount,
+} from '../lib/icon-queue-config';
+import { DEFAULT_ICON_QUEUE_CONFIG, DB_COLLECTION_CONFIG, ICON_QUEUE_CONFIG_DOC } from '../lib/config';
+import { db } from '../lib/firebase-admin';
+
+class MockAuth {
+    constructor(private user: AuthSession | null) {}
+    async verifyAuth() { return this.user; }
+}
+
+const configRef = () => db.collection(DB_COLLECTION_CONFIG).doc(ICON_QUEUE_CONFIG_DOC);
+
+describe('Icon Queue Config — accessor', () => {
+    beforeEach(async () => {
+        await configRef().delete().catch(() => {});
+    });
+
+    it('returns safe defaults when the doc is missing', async () => {
+        const cfg = await getIconQueueConfig();
+        assert.deepStrictEqual(cfg, DEFAULT_ICON_QUEUE_CONFIG);
+    });
+
+    it('fills in defaults for missing fields', async () => {
+        await configRef().set({ paused: true });
+        const cfg = await getIconQueueConfig();
+        assert.strictEqual(cfg.paused, true);
+        assert.strictEqual(cfg.allowAnonForge, DEFAULT_ICON_QUEUE_CONFIG.allowAnonForge);
+        assert.strictEqual(cfg.perUserDailyCap, DEFAULT_ICON_QUEUE_CONFIG.perUserDailyCap);
+    });
+
+    it('clamps perUserDailyCap to a non-negative integer on write', async () => {
+        const cfg = await setIconQueueConfig({ perUserDailyCap: -5 });
+        assert.strictEqual(cfg.perUserDailyCap, 0);
+        const cfg2 = await setIconQueueConfig({ perUserDailyCap: 42.9 });
+        assert.strictEqual(cfg2.perUserDailyCap, 42);
+    });
+});
+
+describe('Icon Queue Config — admin actions auth', () => {
+    it('blocks guests and non-admins from reading config', async () => {
+        setAuthService(new MockAuth(null));
+        assert.strictEqual((await getIconQueueConfigAction()).error, 'Login required');
+
+        setAuthService(new MockAuth({ uid: 'u1', isAdmin: false }));
+        await db.collection('users').doc('u1').set({ isAdmin: false });
+        assert.strictEqual((await getIconQueueConfigAction()).error, 'Admin required');
+    });
+
+    it('allows admins to read & write config', async () => {
+        setAuthService(new MockAuth({ uid: 'admin', isAdmin: true }));
+        await db.collection('users').doc('admin').set({ isAdmin: true });
+
+        const setRes = await setIconQueueConfigAction({ paused: true, perUserDailyCap: 7 });
+        assert.strictEqual(setRes.error, undefined);
+        assert.strictEqual(setRes.config?.paused, true);
+        assert.strictEqual(setRes.config?.perUserDailyCap, 7);
+
+        const getRes = await getIconQueueConfigAction();
+        assert.strictEqual(getRes.config?.paused, true);
+    });
+});
+
+describe('Icon Queue Config — per-user daily counter', () => {
+    it('counts and increments per user', async () => {
+        const uid = 'counter-user-' + Date.now();
+        assert.strictEqual(await getUserForgeCountToday(uid), 0);
+        await incrementUserForgeCount(uid);
+        await incrementUserForgeCount(uid);
+        assert.strictEqual(await getUserForgeCountToday(uid), 2);
+    });
+});
+
+describe('Icon Queue Config — enqueue gating', () => {
+    beforeEach(async () => {
+        await configRef().delete().catch(() => {});
+    });
+
+    it('rejects anonymous forge when allowAnonForge is false', async () => {
+        await setIconQueueConfig({ allowAnonForge: false });
+        setAuthService(new MockAuth(null));
+        const res = await addIngredientNodeAction('any-recipe', 'Carrot');
+        assert.strictEqual(res.success, false);
+        assert.match(res.error || '', /log in/i);
+    });
+
+    it('rejects a user at or over the daily cap', async () => {
+        const uid = 'capped-user-' + Date.now();
+        await setIconQueueConfig({ perUserDailyCap: 1 });
+        await incrementUserForgeCount(uid); // now at cap
+        setAuthService(new MockAuth({ uid, isAdmin: false }));
+        const res = await addIngredientNodeAction('any-recipe', 'Carrot');
+        assert.strictEqual(res.success, false);
+        assert.match(res.error || '', /limit reached/i);
+    });
+});

--- a/recipe-lanes/tests/icon-queue-config.test.ts
+++ b/recipe-lanes/tests/icon-queue-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { getIconQueueConfigAction, setIconQueueConfigAction, addIngredientNodeAction } from '../app/actions';
 import { setAuthService, AuthSession } from '../lib/auth-service';
@@ -20,6 +20,11 @@ const configRef = () => db.collection(DB_COLLECTION_CONFIG).doc(ICON_QUEUE_CONFI
 
 describe('Icon Queue Config — accessor', () => {
     beforeEach(async () => {
+        await configRef().delete().catch(() => {});
+    });
+    // Reset shared emulator config so leaked non-default values can't poison
+    // other integration test files (they share one Firestore config doc).
+    afterEach(async () => {
         await configRef().delete().catch(() => {});
     });
 
@@ -45,6 +50,10 @@ describe('Icon Queue Config — accessor', () => {
 });
 
 describe('Icon Queue Config — admin actions auth', () => {
+    afterEach(async () => {
+        await configRef().delete().catch(() => {});
+    });
+
     it('blocks guests and non-admins from reading config', async () => {
         setAuthService(new MockAuth(null));
         assert.strictEqual((await getIconQueueConfigAction()).error, 'Login required');
@@ -80,6 +89,9 @@ describe('Icon Queue Config — per-user daily counter', () => {
 
 describe('Icon Queue Config — enqueue gating', () => {
     beforeEach(async () => {
+        await configRef().delete().catch(() => {});
+    });
+    afterEach(async () => {
         await configRef().delete().catch(() => {});
     });
 

--- a/recipe-lanes/tests/lifecycle.test.ts
+++ b/recipe-lanes/tests/lifecycle.test.ts
@@ -15,12 +15,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { describe, it } from 'node:test';
+import { describe, it, before } from 'node:test';
 import assert from 'node:assert';
 import { createDebugRecipeAction, addIngredientNodeAction, forgeIconAction } from '../app/actions';
 import { setAIService, MockAIService } from '../lib/ai-service';
 import { getDataService } from '../lib/data-service';
 import { setAuthService, MockAuthService } from '../lib/auth-service';
+import { setIconQueueConfig } from '../lib/icon-queue-config';
 import { getNodeIconId } from '../lib/recipe-lanes/model-utils';
 
 setAIService(new MockAIService());
@@ -45,6 +46,12 @@ async function pollForIcon(
 }
 
 describe('Recipe & Icon Lifecycle', () => {
+    // Ensure forging isn't blocked by config leaked from earlier integration
+    // files sharing the emulator (allowAnonForge / a low perUserDailyCap).
+    before(async () => {
+        await setIconQueueConfig({ paused: false, allowAnonForge: true, perUserDailyCap: 1000 });
+    });
+
     it('should follow the full creation and shortlist-cycle reroll flow', async () => {
         const ingredient = 'Integration-Egg-' + Date.now();
 


### PR DESCRIPTION
## Runtime queue config + abuse controls

Adds a single Firestore `config/icon_queue` doc read by both the Cloud Function and the admin UI, so abuse controls are adjustable **at runtime with no redeploy**.

### Controls
- **`paused`** (default false) — `processIconTask` checks it first; when paused, re-enqueues with backoff so work auto-resumes on un-pause (no dropped/failed tasks).
- **`allowAnonForge`** (default true) — when false, anonymous forge attempts are rejected with a login-prompt-friendly error.
- **`perUserDailyCap`** (default 100) — per-user daily forge ceiling, counted via `icon_forge_usage/{uid}_{utcDay}` (one read + atomic increment; queue docs are deleted on processing so they can't be counted).
- **Admin-only config panel** on `/icon_overview`, gated server-side and in the UI.

Cloud Tasks concurrency (`maxConcurrentDispatches`/`maxDispatchesPerSecond`) intentionally **stays in GCP**, not the app.

### Tests
- New `tests/icon-queue-config.test.ts` + extended forge auth cases. Verified 14/14 against emulators.

**Stacked on #172** — review/merge that first. Base will retarget to `main` once #172 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)