### PR TITLE
feat(icons): emit icon_forged signal for pure-GCP rate alerting (#171)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,3 +70,4 @@ Scoped single test: `npm run test:one -- tests/my.test.ts`
 - `docs/git_workflow.md` — disposable feature branch protocol
 - `recipe-lanes/TESTING.md` — full testing guide including Pi-specific pre-commit warm-up sequence and known flaky tests
 - `docs/architecture-review-2026-06.md` — prioritized technical roadmap (June 2026 review)
+- `docs/alerting-icon-forge.md` — pure-GCP alerting on icon-generation rate (Bug 171): the `icon_forged` log signal + Cloud Monitoring metric/policy runbook

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -77,3 +77,11 @@ npx firebase deploy --only firestore,storage,functions
 ## 7. Firestore Indexes
 
 Indexes are tracked in `firestore.indexes.json` and deployed with `firebase deploy --only firestore`. Do not create indexes manually in the console — they won't be tracked and will cause drift between environments.
+
+## 8. Monitoring & Alerting
+
+Icon-generation-rate alerting (Bug 171) is configured entirely in GCP Cloud
+Monitoring — the app only emits an `icon_forged` structured log on each successful
+generation. See `docs/alerting-icon-forge.md` for the exact `gcloud` commands to
+create the log-based metric and alert policy, and to tune thresholds with no app
+redeploy.

--- a/docs/alerting-icon-forge.md
+++ b/docs/alerting-icon-forge.md
@@ -1,0 +1,142 @@
+# Icon-forge alerting (Bug 171) — pure-GCP runbook
+
+Alert when **more than N icons are generated in X minutes**.
+
+## Design: why pure-GCP
+
+The app's only job is to emit a clean, structured log signal on each successful
+icon generation. **All counting, thresholds, and notification delivery live in
+GCP Cloud Monitoring — never in the app.** Rationale:
+
+- **No app config/UI for thresholds.** Tuning N and X is an ops concern; baking it
+  into the app would mean a redeploy for every threshold tweak.
+- **Delivery is GCP's job.** Email/Slack/PagerDuty routing is configured once as a
+  notification channel and reused; the app never touches it.
+- **Survives app bugs.** Because the alert counts log entries in GCP, it keeps
+  working even if app-side counting logic regressed — there is no app-side counting
+  logic to regress.
+- **Tune with zero redeploy.** Changing N or X is a `gcloud`/console edit of the
+  alert policy. That is the entire point of this approach.
+
+## The app signal
+
+On each **successful** icon generation, `processIconTaskHandler`
+(`recipe-lanes/functions/src/index.ts`) emits exactly one structured JSON log line
+*after the publish transaction commits* (genuine success only — never on
+retry/failure paths):
+
+```json
+{ "event": "icon_forged", "ingredient": "<standardized name>", "queueDocId": "<id>", "recipeCount": 3, "ts": "2026-06-13T..." }
+```
+
+Because it is JSON written to stdout, Cloud Logging parses it into `jsonPayload`,
+so the alert can match on the stable field `jsonPayload.event="icon_forged"`.
+
+## Resource type
+
+The icon function is a **Firebase Functions v2** function
+(`firebase-functions/v2/tasks` → `onTaskDispatched`). v2 functions run on Cloud
+Run, so logs carry the resource type **`cloud_run_revision`**, and the function
+name appears as the Cloud Run service label `resource.labels.service_name`.
+
+> No explicit region is set in the code, so the default region is `us-central1`.
+> Project ids: `recipe-lanes` (prod), `recipe-lanes-staging` (staging).
+
+## 1. Create the log-based counter metric
+
+Run once per project (swap `--project` for staging vs prod).
+
+```bash
+gcloud logging metrics create icon_forged_count \
+  --project=recipe-lanes \
+  --description="Count of successful icon generations (Bug 171 alerting)" \
+  --log-filter='resource.type="cloud_run_revision"
+resource.labels.service_name="processicontask"
+jsonPayload.event="icon_forged"'
+```
+
+Notes:
+- Cloud Run lowercases the service name, so the function `processIconTask` appears
+  as `processicontask`. Verify with:
+  `gcloud logging read 'jsonPayload.event="icon_forged"' --project=recipe-lanes --limit=1 --format=json`
+  and copy the exact `resource.labels.service_name`.
+- This is a **counter** metric (one increment per matching log entry). No value
+  extractor is needed.
+
+## 2. Create the Cloud Monitoring alert policy
+
+Fires when the metric's count exceeds **N** within an **X-minute** alignment
+window. Example below: **N = 50** icons in **X = 10** minutes. Tune freely later.
+
+First create (or reuse) a notification channel. Email example:
+
+```bash
+gcloud beta monitoring channels create \
+  --project=recipe-lanes \
+  --display-name="Icon-forge alerts (email)" \
+  --type=email \
+  --channel-labels=email_address=binghelpdesk@gmail.com
+# Note the returned channel id: projects/recipe-lanes/notificationChannels/XXXX
+```
+
+(For Slack: `--type=slack` with a configured Slack channel, or wire a PagerDuty/
+webhook channel — same `channels create` flow.)
+
+Then create the policy from a YAML condition file:
+
+```bash
+cat > /tmp/icon-forge-policy.yaml <<'YAML'
+displayName: "Icon forge rate too high (Bug 171)"
+combiner: OR
+conditions:
+  - displayName: "icon_forged > 50 in 10 min"
+    conditionThreshold:
+      filter: 'metric.type="logging.googleapis.com/user/icon_forged_count" resource.type="cloud_run_revision"'
+      comparison: COMPARISON_GT
+      thresholdValue: 50          # <-- N
+      duration: 0s
+      aggregations:
+        - alignmentPeriod: 600s   # <-- X (10 min)
+          perSeriesAligner: ALIGN_COUNT
+      trigger:
+        count: 1
+notificationChannels:
+  - projects/recipe-lanes/notificationChannels/XXXX
+YAML
+
+gcloud alpha monitoring policies create \
+  --project=recipe-lanes \
+  --policy-from-file=/tmp/icon-forge-policy.yaml
+```
+
+How it reads: each `alignmentPeriod` (X = 600s) the aligner counts matching log
+entries; if that count is greater than `thresholdValue` (N = 50) the policy fires
+and notifies the attached channel(s).
+
+## 3. Tuning N and X — no app redeploy
+
+To change the threshold or window, edit the alert policy only:
+
+```bash
+# List policies to get the policy id
+gcloud alpha monitoring policies list --project=recipe-lanes \
+  --filter='displayName="Icon forge rate too high (Bug 171)"'
+
+# Update from an edited YAML (change thresholdValue / alignmentPeriod)
+gcloud alpha monitoring policies update POLICY_ID \
+  --project=recipe-lanes \
+  --policy-from-file=/tmp/icon-forge-policy.yaml
+```
+
+Or adjust the same two fields in the Cloud Monitoring console
+(Alerting → the policy → Edit condition). **No app build or deploy is involved** —
+that is the whole point of the pure-GCP design.
+
+## Verifying end to end
+
+1. Generate an icon in staging.
+2. Confirm the log entry:
+   `gcloud logging read 'jsonPayload.event="icon_forged"' --project=recipe-lanes-staging --limit=5`
+3. Confirm the metric increments in Monitoring → Metrics explorer
+   (`logging.googleapis.com/user/icon_forged_count`).
+4. Temporarily lower N to force the alert and confirm the notification arrives.

--- a/recipe-lanes/functions/src/index.ts
+++ b/recipe-lanes/functions/src/index.ts
@@ -119,6 +119,7 @@ export const processIconTaskHandler = async (data: { ingredientName: string }, r
         console.log(`[Queue-${ingredientName}] Publishing to Firestore...`);
         let ingredientDocId;
         let rawHydeQueries: string[] = [];
+        let publishedRecipeCount = 0;
         const dataService = getDataService();
 
         // Find or Create Ingredient Group.
@@ -137,6 +138,7 @@ export const processIconTaskHandler = async (data: { ingredientName: string }, r
             }
             const queueDocData = queueDoc.data();
             const latestRecipeIds: string[] = queueDocData?.recipes || [];
+            publishedRecipeCount = latestRecipeIds.length;
             console.log(`[Queue-${ingredientName}] in transaction Publishing to Firestore...`);
 
             rawHydeQueries = queueDocData?.hydeQueries || [];
@@ -178,6 +180,19 @@ export const processIconTaskHandler = async (data: { ingredientName: string }, r
             transaction.delete(docRef);
             console.log(`[Queue-${ingredientName}] Successfully updated ${processedRecipeIds.length} of ${latestRecipeIds.length} recipes and deleted queue item.`);
         });
+
+        // Structured success marker for GCP log-based metrics / alerting (Bug 171).
+        // Pure-GCP design: the app only emits this signal; counting, thresholds and
+        // delivery live in Cloud Monitoring. See docs/alerting-icon-forge.md.
+        // Emitted ONLY here, after the publish transaction commits — i.e. genuine
+        // success, never on retry/failure paths.
+        console.log(JSON.stringify({
+            event: 'icon_forged',
+            ingredient: ingredientName,
+            queueDocId: docRef.id,
+            recipeCount: publishedRecipeCount,
+            ts: new Date().toISOString(),
+        }));
 
         // Record one impression per recipe this icon was shown in (non-fatal)
         dataService.recordImpression(icon.id, ingredientDocId).catch(e =>


### PR DESCRIPTION
## Bug 171 — alert when more than N icons generated in X time (pure-GCP)

Thresholds and delivery live in **GCP Cloud Monitoring**, not the app.

### App change (tiny)
- One structured `console.log(JSON.stringify({ event: 'icon_forged', ... }))` emitted only on genuine generation success in `processIconTask` (`functions/src/index.ts`). Not emitted on retry/failure paths.

### GCP side (runbook)
- `docs/alerting-icon-forge.md`: `gcloud` commands for a log-based counter metric on `jsonPayload.event="icon_forged"`, a Cloud Monitoring alert policy ("> N forges in X min"), notification channel setup, and the no-redeploy tuning note. Resource type `cloud_run_revision`.

(Recreated from #178, which auto-closed when its stacked base branch was deleted after merge. Now correctly based on `main` with just the alerting commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)