### PR TITLE
feat(limits): cap recipe input size and graph node count (#181)

### DIFF
--- a/recipe-lanes/app/actions.ts
+++ b/recipe-lanes/app/actions.ts
@@ -24,6 +24,7 @@ import { getAuthService } from '@/lib/auth-service';
 import { z } from 'zod';
 import { generateRecipePrompt, parseRecipeGraph, extractServes, generateHydeQueriesPrompt, parseHydeQueries } from '@/lib/recipe-lanes/parser';
 import { generateAdjustmentPrompt } from '@/lib/recipe-lanes/adjuster';
+import { assertInputWithinLimit, assertGraphWithinLimit, MAX_RECIPE_INPUT_CHARS, MAX_ADJUST_INSTRUCTION_CHARS } from '@/lib/recipe-lanes/limits';
 import type { RecipeGraph, IconStats, FastMatch, RecipePatch } from '@/lib/recipe-lanes/types';
 import { standardizeIngredientName } from '@/lib/utils';
 import { cosineSimilarity, getIconThumbUrl, getNodeIconUrl, getShortlistIconAt, preserveNodeShortlist, buildShortlistEntry, mutateNodesByIngredient, markEntryImpressedAtIndex, getEntryIcon, extractBatchIngredients, getNodeIngredientName, applyPatch, assignNodeShortlist } from '@/lib/recipe-lanes/model-utils';
@@ -183,12 +184,17 @@ export async function addIngredientNodeAction(recipeId: string, ingredientName: 
 export async function createVisualRecipeAction(recipeText: string, currentId?: string): Promise<{ id?: string; error?: string }> {
     try {
         console.log('[createVisualRecipeAction] 🚀 Starting...');
-        
+
+        // Guardrail (issue #181): cap input size before spending tokens.
+        assertInputWithinLimit(recipeText, MAX_RECIPE_INPUT_CHARS, 'Recipe text');
+
         // 1. Parse Text
         const prompt = generateRecipePrompt(recipeText);
         // TODO move this to a cloud function.
         const text = await getAIService().generateText(prompt);
         const graph = parseRecipeGraph(text);
+        // Guardrail (issue #181): reject a runaway graph before it hits Firestore / the icon queue.
+        assertGraphWithinLimit(graph);
         graph.originalText = recipeText;
         
         const serves = extractServes(recipeText);
@@ -428,6 +434,8 @@ export async function getAllStorageFilesAction() {
 
 export async function adjustRecipeAction(currentGraph: RecipeGraph, prompt: string) {
   try {
+    // Guardrail (issue #181): cap the chatbot instruction length sent to the model.
+    assertInputWithinLimit(prompt, MAX_ADJUST_INSTRUCTION_CHARS, 'Instruction');
     const fullPrompt = generateAdjustmentPrompt(currentGraph, prompt);
     const text = await getAIService().generateText(fullPrompt);
 
@@ -460,6 +468,11 @@ export async function adjustRecipeAction(currentGraph: RecipeGraph, prompt: stri
       newGraph = applyPatch(currentGraph, patch);
       message = patch.message;
     }
+
+    // Guardrail (issue #181): stop the graph growing without bound (e.g. a chatbot
+    // coaxed into repeatedly adding nodes). Reject the adjustment, keeping the
+    // current graph intact.
+    assertGraphWithinLimit(newGraph);
 
     return { graph: newGraph, message };
   } catch (e: any) {

--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -26,6 +26,7 @@ import ReactFlowDiagram, { ReactFlowDiagramHandle } from '@/components/recipe-la
 import { ReactFlowProvider } from 'reactflow';
 import { createVisualRecipeAction, adjustRecipeAction, saveRecipeAction, saveChatHistoryAction, checkExistingCopiesAction, debugLogAction, applyIconSearchResultsAction } from '@/app/actions';
 import { ChatPanel } from '@/components/recipe-lanes/chat-panel';
+import { MAX_RECIPE_INPUT_CHARS, MAX_ADJUST_INSTRUCTION_CHARS } from '@/lib/recipe-lanes/limits';
 import { iconSearchMethods, defaultIconSearchMethod, hydrateClientSide } from '@/lib/icon-search-registry';
 import { standardizeIngredientName } from '@/lib/utils';
 import { IngredientsSidebar } from '@/components/recipe-lanes/ui/ingredients-sidebar';
@@ -850,6 +851,7 @@ const handleVisualize = async () => {
                     ref={textareaRef}
                     className={`flex-1 bg-zinc-950 border border-zinc-800 rounded-lg p-2 text-xs text-zinc-300 focus:ring-1 focus:ring-yellow-500/50 outline-none resize-y transition-all duration-300 ${inputExpanded ? 'h-[50vh]' : 'h-10'}`}
                     placeholder="Paste recipe here..."
+                    maxLength={MAX_RECIPE_INPUT_CHARS}
                     value={recipeText}
                     onChange={(e) => {
                         setRecipeText(e.target.value);
@@ -1188,6 +1190,7 @@ const handleVisualize = async () => {
                             <input
                                 className="flex-1 bg-transparent border-none outline-none text-sm text-zinc-800 placeholder-zinc-400 h-10 px-2"
                                 placeholder="Adjust recipe..."
+                                maxLength={MAX_ADJUST_INSTRUCTION_CHARS}
                                 value={chatInput}
                                 onChange={(e) => setChatInput(e.target.value)}
                                 onKeyDown={(e) => e.key === 'Enter' && handleAdjust()}
@@ -1216,6 +1219,7 @@ const handleVisualize = async () => {
                             <input
                                 className="flex-1 bg-zinc-100 border border-zinc-200 rounded-md px-2 text-xs h-full text-zinc-800 outline-none"
                                 placeholder="Adjust..."
+                                maxLength={MAX_ADJUST_INSTRUCTION_CHARS}
                                 value={chatInput}
                                 onChange={(e) => setChatInput(e.target.value)}
                                 onKeyDown={(e) => e.key === 'Enter' && handleAdjust()}

--- a/recipe-lanes/lib/recipe-lanes/limits.ts
+++ b/recipe-lanes/lib/recipe-lanes/limits.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Abuse / cost guardrails for the LLM recipe pipeline (issue #181).
+ *
+ * Two distinct dangers these caps defend against:
+ *  1. Oversized *input* — large pasted text or a chatbot instruction that
+ *     inflates the prompt token count (cost) sent TO the model.
+ *  2. Oversized *output* — a graph that keeps growing (e.g. asking the
+ *     chatbot to "keep adding nodes"), which bloats Firestore docs, the
+ *     icon queue, and every subsequent adjustment prompt sent back to the
+ *     model.
+ *
+ * These are static, conservative ceilings — a real recipe never approaches
+ * them. They are not user-tunable on purpose; they are a safety floor.
+ */
+
+/** Max characters of raw recipe text accepted for a single parse. */
+export const MAX_RECIPE_INPUT_CHARS = 10_000;
+
+/** Max characters of a single chatbot adjustment instruction. */
+export const MAX_ADJUST_INSTRUCTION_CHARS = 2_000;
+
+/** Max nodes allowed in a recipe graph after a parse or adjustment. */
+export const MAX_GRAPH_NODES = 150;
+
+/** Max lanes allowed in a recipe graph. */
+export const MAX_GRAPH_LANES = 30;
+
+export class RecipeLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RecipeLimitError';
+  }
+}
+
+/** Throws RecipeLimitError if `text` exceeds `max` chars. `label` names the input for the message. */
+export function assertInputWithinLimit(text: string, max: number, label: string): void {
+  const len = text?.length ?? 0;
+  if (len > max) {
+    throw new RecipeLimitError(
+      `${label} is too long (${len.toLocaleString()} characters; limit is ${max.toLocaleString()}). Please shorten it.`,
+    );
+  }
+}
+
+/** Throws RecipeLimitError if the graph exceeds the node or lane ceilings. */
+export function assertGraphWithinLimit(graph: { nodes?: unknown[]; lanes?: unknown[] }): void {
+  const nodeCount = graph.nodes?.length ?? 0;
+  if (nodeCount > MAX_GRAPH_NODES) {
+    throw new RecipeLimitError(
+      `This recipe is too large (${nodeCount} steps; limit is ${MAX_GRAPH_NODES}). Try splitting it into smaller recipes.`,
+    );
+  }
+  const laneCount = graph.lanes?.length ?? 0;
+  if (laneCount > MAX_GRAPH_LANES) {
+    throw new RecipeLimitError(
+      `This recipe has too many lanes (${laneCount}; limit is ${MAX_GRAPH_LANES}).`,
+    );
+  }
+}

--- a/recipe-lanes/tests/limits.test.ts
+++ b/recipe-lanes/tests/limits.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  assertInputWithinLimit,
+  assertGraphWithinLimit,
+  RecipeLimitError,
+  MAX_RECIPE_INPUT_CHARS,
+  MAX_ADJUST_INSTRUCTION_CHARS,
+  MAX_GRAPH_NODES,
+  MAX_GRAPH_LANES,
+} from '../lib/recipe-lanes/limits';
+
+describe('recipe limits (issue #181)', () => {
+  describe('assertInputWithinLimit', () => {
+    it('accepts input at the limit', () => {
+      assert.doesNotThrow(() =>
+        assertInputWithinLimit('x'.repeat(MAX_RECIPE_INPUT_CHARS), MAX_RECIPE_INPUT_CHARS, 'Recipe text'),
+      );
+    });
+
+    it('rejects input over the limit with a RecipeLimitError', () => {
+      assert.throws(
+        () => assertInputWithinLimit('x'.repeat(MAX_RECIPE_INPUT_CHARS + 1), MAX_RECIPE_INPUT_CHARS, 'Recipe text'),
+        RecipeLimitError,
+      );
+    });
+
+    it('handles empty / nullish input', () => {
+      assert.doesNotThrow(() => assertInputWithinLimit('', MAX_ADJUST_INSTRUCTION_CHARS, 'Instruction'));
+      assert.doesNotThrow(() =>
+        assertInputWithinLimit(undefined as unknown as string, MAX_ADJUST_INSTRUCTION_CHARS, 'Instruction'),
+      );
+    });
+  });
+
+  describe('assertGraphWithinLimit', () => {
+    const nodes = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `n${i}` }));
+    const lanes = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `l${i}` }));
+
+    it('accepts a graph at the node limit', () => {
+      assert.doesNotThrow(() => assertGraphWithinLimit({ nodes: nodes(MAX_GRAPH_NODES), lanes: lanes(1) }));
+    });
+
+    it('rejects a graph over the node limit', () => {
+      assert.throws(
+        () => assertGraphWithinLimit({ nodes: nodes(MAX_GRAPH_NODES + 1), lanes: lanes(1) }),
+        RecipeLimitError,
+      );
+    });
+
+    it('rejects a graph over the lane limit', () => {
+      assert.throws(
+        () => assertGraphWithinLimit({ nodes: nodes(1), lanes: lanes(MAX_GRAPH_LANES + 1) }),
+        RecipeLimitError,
+      );
+    });
+
+    it('tolerates a graph missing nodes/lanes arrays', () => {
+      assert.doesNotThrow(() => assertGraphWithinLimit({}));
+    });
+  });
+});


### PR DESCRIPTION
Fixes #181.

## Problem
Two LLM abuse/cost vectors: an oversized pasted recipe (large prompt sent **to** the model) and an unbounded graph — e.g. coaxing the chatbot to "keep adding nodes" — which bloats Firestore docs, the icon queue, and every subsequent adjustment prompt sent **back** to the model.

## Change
New `lib/recipe-lanes/limits.ts` with static, conservative ceilings (intentionally not runtime-tunable — a safety floor, not an abuse-control knob):
- `MAX_RECIPE_INPUT_CHARS = 10,000`, `MAX_ADJUST_INSTRUCTION_CHARS = 2,000`
- `MAX_GRAPH_NODES = 150`, `MAX_GRAPH_LANES = 30`
- `assertInputWithinLimit` / `assertGraphWithinLimit` + `RecipeLimitError`

Enforcement (server is the real boundary):
- `createVisualRecipeAction` — caps input before spending tokens; caps the parsed graph before it reaches Firestore / the icon queue.
- `adjustRecipeAction` — caps the instruction and the resulting graph (both full-graph and patch paths); a runaway adjustment is rejected and the current graph stays intact.
- `lanes/page.tsx` — `maxLength` on the recipe + adjust inputs (defense-in-depth; server still enforces).

## Tests
`tests/limits.test.ts` — 7 cases (boundary, over-limit, empty/nullish, missing arrays), all passing. Typecheck + lint clean (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)