### PR TITLE
fix(ci): provision functions embedding model before integration tests

### DIFF
--- a/recipe-lanes/scripts/test-unit-integration.sh
+++ b/recipe-lanes/scripts/test-unit-integration.sh
@@ -22,6 +22,15 @@ else
     echo "No emulators detected. Starting NEW emulators for tests."
     # Build Functions (Required for 'functions' emulator)
     npm install --prefix functions --quiet
+    # The functions vector-search loads Xenova/all-MiniLM-L6-v2 from a bundled,
+    # gitignored model-cache with allowRemoteModels=false. Provision it before the
+    # build's copy step — otherwise the copy silently no-ops (|| true) and the
+    # emulator fails at runtime with `local_files_only=true ... not found locally`.
+    # Skipped when already present (local dev) so it only pays the download in CI.
+    if [ ! -d functions/src/vector-search/model-cache ]; then
+        echo "Downloading functions embedding model (Xenova/all-MiniLM-L6-v2)..."
+        npm run download-model --prefix functions
+    fi
     npm run build --prefix functions
 
     npx env-cmd -f .env.test firebase emulators:exec --only auth,firestore,storage,functions,tasks --project local-project-id "node --import tsx --test --test-concurrency=1 $INTEGRATION_TESTS"


### PR DESCRIPTION
## Problem
The `integration` CI job has been failing on `tests/lifecycle.test.ts` (`addIngredientNodeAction should return a nodeId`; `forge produces a new icon distinct from the original`). Root cause is **not** a test/logic bug:

- `functions/src/vector-search/index.ts` loads `Xenova/all-MiniLM-L6-v2` from a bundled `model-cache` with `env.allowRemoteModels = false`.
- That cache is gitignored and provisioned by `npm run download-model --prefix functions`.
- The integration runner (`scripts/test-unit-integration.sh`) ran `npm install` + `npm run build` for functions but **never** `download-model`. The build's copy step is guarded by `|| true`, so a missing cache silently no-ops and the build "succeeds" with no model bundled.
- At runtime the functions emulator then fails: `local_files_only=true ... file was not found locally at .../@huggingface/transformers/models/Xenova/all-MiniLM-L6-v2/config.json`, surfacing as `[FirebaseDataService] batch search failed: INTERNAL` and breaking the lifecycle assertions.

Pre-existing and unrelated to any feature work (reproduces on `55e8e46`).

## Fix
Run `download-model` before the functions build in the integration runner, guarded so it only downloads when the cache is absent (CI) and is skipped where devs already have it locally.

## Verification
Path-checked: `download-model.js` targets `functions/src/vector-search/model-cache`, matching the guard and the `cp -rL` source in the functions `build` script. Couldn't run the full emulator integration tier locally (arm64 Pi / slow); relying on this PR's own `integration` job to confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)