### PR TITLE
fix(feedback): drop full graph JSON, rely on recipe URL (#184)

### DIFF
--- a/recipe-lanes/app/actions.ts
+++ b/recipe-lanes/app/actions.ts
@@ -821,7 +821,7 @@ export async function deleteIconByIdAction(iconId: string, ingredientName?: stri
 //     }
 // }
 
-export async function submitFeedbackAction(data: { message: string, url: string, email?: string, graphJson?: string }) {
+export async function submitFeedbackAction(data: { message: string, url: string, email?: string }) {
     try {
         const session = await getAuthService().verifyAuth();
         const userId = session?.uid;

--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -1304,8 +1304,7 @@ const handleVisualize = async () => {
         
         <FeedbackModal 
             isOpen={showFeedback} 
-            onClose={() => setShowFeedback(false)} 
-            graphJson={jsonText}
+            onClose={() => setShowFeedback(false)}
         />
     </div>
   );

--- a/recipe-lanes/components/feedback-modal.tsx
+++ b/recipe-lanes/components/feedback-modal.tsx
@@ -24,10 +24,9 @@ import { submitFeedbackAction } from '@/app/actions';
 interface FeedbackModalProps {
     isOpen: boolean;
     onClose: () => void;
-    graphJson?: string;
 }
 
-export function FeedbackModal({ isOpen, onClose, graphJson }: FeedbackModalProps) {
+export function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
     const [message, setMessage] = useState('');
     const [email, setEmail] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
@@ -47,8 +46,7 @@ export function FeedbackModal({ isOpen, onClose, graphJson }: FeedbackModalProps
             const result = await submitFeedbackAction({
                 message,
                 email,
-                url: window.location.href,
-                graphJson
+                url: window.location.href
             });
 
             if (result.error) {

--- a/recipe-lanes/lib/data-service.ts
+++ b/recipe-lanes/lib/data-service.ts
@@ -85,7 +85,7 @@ export interface DataService {
   imagineIngredientWithIcon(ingredientId: string, ingredientName: string, icon: IconStats, transaction?: any): Promise<any>;
   setIngredientWithIcon(data: any, transaction?: any): Promise<void>;
   
-  submitFeedback(data: { message: string, url: string, email?: string, graphJson?: string, userId?: string }): Promise<void>;
+  submitFeedback(data: { message: string, url: string, email?: string, userId?: string }): Promise<void>;
   
   vetRecipe(recipeId: string, isVetted: boolean): Promise<void>;
   getUnvettedRecipes(limit: number): Promise<any[]>;
@@ -189,7 +189,7 @@ export class FirebaseDataService implements DataService {
       return this.mapRecipes(snapshot);
   }
 
-  async submitFeedback(data: { message: string, url: string, email?: string, graphJson?: string, userId?: string }): Promise<void> {
+  async submitFeedback(data: { message: string, url: string, email?: string, userId?: string }): Promise<void> {
       try {
           // Use DB_COLLECTION_FEEDBACK if imported, else string literal 'feedback'
           // Since I updated config.ts but not the import in this file yet (wait, I should check imports)
@@ -1752,7 +1752,7 @@ export class MemoryDataService implements DataService {
         console.log(`[MemoryDataService] Fail icon requested for ${ingredientName}: ${errorMsg}`);
     }
 
-    async submitFeedback(data: { message: string, url: string, email?: string, graphJson?: string, userId?: string }): Promise<void> {
+    async submitFeedback(data: { message: string, url: string, email?: string, userId?: string }): Promise<void> {
         console.log('[MemoryDataService] Feedback submitted:', data);
     }
 


### PR DESCRIPTION
Closes #184.

## What
Feedback submissions previously bundled the entire recipe graph as `graphJson`. The submitted `url` (`window.location.href`) already links straight to the recipe, so the full graph payload is redundant.

## Changes
- Remove `graphJson` prop from `FeedbackModal`
- Drop `graphJson` from `submitFeedbackAction` and the `submitFeedback` data-service signatures (Firestore + memory impls)
- Stop passing `jsonText` into the modal from the lanes page

The recipe link is preserved via the existing `url` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)