### PR TITLE
feat(icons): preheat icon vector-search CF when recipe parse kicks off (#186)

### DIFF
--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -42,6 +42,7 @@ import { LoadingScreen, LoadingPhase } from '@/components/recipe-lanes/ui/loadin
 import { doc, onSnapshot } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
 import { db, functions } from '@/lib/firebase-client';
+import { preheatIconSearch } from '@/lib/icon-search-strategy';
 import { FeedbackModal } from '@/components/feedback-modal';
 
 function RecipeLanesContent() {
@@ -589,7 +590,11 @@ const handleVisualize = async () => {
     setStatus('parsing');
     setError(null);
     setGuestBannerDismissed(false);
-    
+
+    // Warm the icon vector-search CF now so its model is loaded by the time the
+    // LLM finishes parsing and we run the real icon lookup. Fire-and-forget.
+    preheatIconSearch();
+
     try {
         // Use New Fast Path Action
         const currentId = searchParams.get('id');

--- a/recipe-lanes/functions/src/vector-search/index.ts
+++ b/recipe-lanes/functions/src/vector-search/index.ts
@@ -108,6 +108,14 @@ export const searchIconVector = onCall({
   const limit = request.data.limit || 12;
   await initialize();
 
+  // Preheat mode: a recipe parse has kicked off and wants this instance warm
+  // (model loaded) by the time the real lookup runs. initialize() above has
+  // already done the expensive work, so just acknowledge.
+  if (request.data.preheat) {
+    console.log("[VectorSearch] preheat");
+    return { preheated: true, snapshot_timestamp: snapshotTimestamp };
+  }
+
   // Batch mode: ingredients[{name, queries[]}] → results[{name, embedding, fast_matches}]
   if (Array.isArray(request.data.ingredients)) {
     const ingredients: { name: string; queries: string[] }[] = request.data.ingredients;

--- a/recipe-lanes/lib/icon-search-strategy.ts
+++ b/recipe-lanes/lib/icon-search-strategy.ts
@@ -71,6 +71,31 @@ export async function getFastPass(queryInput: string | string[], limit: number =
 }
 
 /**
+ * Fire-and-forget warm-up for the icon vector-search cloud function.
+ *
+ * `vectorSearch-searchIconVector` loads an ONNX embedding model into a 2GiB
+ * instance on cold start, which can take several seconds. Calling this when a
+ * recipe parse kicks off spins the instance up in parallel with the LLM parse,
+ * so the model is warm by the time we run the real icon lookup. The call is
+ * intentionally not awaited and swallows errors — it is a best-effort hint.
+ */
+export function preheatIconSearch(): void {
+  if (getActiveSearchMode() !== 'node_cf') return;
+
+  try {
+    const searchIconVector = httpsCallable<{ preheat: boolean }, unknown>(
+      functions,
+      'vectorSearch-searchIconVector',
+    );
+    void searchIconVector({ preheat: true }).catch(() => {
+      // Best-effort only; the real lookup will cold-start if this fails.
+    });
+  } catch {
+    // Never let warm-up surface to the caller.
+  }
+}
+
+/**
  * Batch fast pass — one CF call for multiple ingredients.
  * Returns per-ingredient results in the same order as the input.
  */


### PR DESCRIPTION
Closes #186.

## What
When a recipe parse kicks off, fire a best-effort **preheat** call to the icon vector-search cloud function so its instance is warm by the time the LLM finishes and we run the real icon lookup.

## Why
`vectorSearch-searchIconVector` loads an ONNX embedding model into a 2GiB instance on cold start (several seconds). Previously that cold start landed serially *after* the LLM parse, on the critical path of the icon lookup. Now it warms in parallel with the LLM call, hiding the latency.

## Changes
- `lib/icon-search-strategy.ts` — new fire-and-forget `preheatIconSearch()` helper (no-op unless `node_cf` mode; swallows errors).
- `app/lanes/page.tsx` — calls `preheatIconSearch()` the moment parsing starts in `handleVisualize`.
- `functions/src/vector-search/index.ts` — handles a `{ preheat: true }` payload: runs `initialize()` then returns early, avoiding a noisy `invalid-argument` error.

## Verification
- Typecheck (app + functions) clean, lint clean (0 errors).
- Pre-commit hook (build + tests) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)