### PR TITLE
feat(ci): per-PR Cloud Run frontend previews with staging-lease detection

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -163,11 +163,20 @@ jobs:
       - name: Deploy to Cloud Run (tagged, no traffic)
         id: deploy
         run: |
+          # --no-traffic is only valid when the service already exists. On the
+          # first-ever deploy of the shared preview service it must be omitted;
+          # the new revision then takes traffic on the main service URL (harmless
+          # — previews are accessed via the tagged pr-N URL). Every later deploy
+          # keeps --no-traffic.
+          NOTRAFFIC="--no-traffic"
+          if ! gcloud run services describe "$SERVICE" --project "$GCP_PROJECT" --region "$REGION" >/dev/null 2>&1; then
+            NOTRAFFIC=""
+          fi
           gcloud run deploy "$SERVICE" \
             --project "$GCP_PROJECT" --region "$REGION" \
             --image "${{ steps.build.outputs.image }}" \
             --tag "pr-${{ github.event.number }}" \
-            --no-traffic \
+            $NOTRAFFIC \
             --allow-unauthenticated \
             --set-env-vars "NEXT_PUBLIC_ENV_NAME=preview,ADMIN_EMAILS=${{ secrets.ADMIN_EMAILS }}"
           URL=$(gcloud run services describe "$SERVICE" \

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -169,7 +169,7 @@ jobs:
             --tag "pr-${{ github.event.number }}" \
             --no-traffic \
             --allow-unauthenticated \
-            --set-env-vars "NEXT_PUBLIC_ENV_NAME=preview,ADMIN_EMAILS=binghelpdesk@gmail.com"
+            --set-env-vars "NEXT_PUBLIC_ENV_NAME=preview,ADMIN_EMAILS=${{ secrets.ADMIN_EMAILS }}"
           URL=$(gcloud run services describe "$SERVICE" \
             --project "$GCP_PROJECT" --region "$REGION" \
             --format="value(status.traffic.url)" \

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,235 @@
+name: PR Cloud Run Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+# One in-flight deploy per PR; cancel superseded builds.
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+  id-token: write
+
+env:
+  GCP_PROJECT: recipe-lanes-staging
+  REGION: us-central1
+  SERVICE: recipe-lanes-preview
+  # Artifact Registry repo (must exist; see docs/agent-isolation-roadmap.md).
+  AR_REPO: preview
+
+jobs:
+  # Backend-touching PRs get NO shared-staging preview: they need an exclusive
+  # staging lease instead (deploying their functions/rules could break every
+  # other open preview that shares the staging backend).
+  detect-backend-changes:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.diff.outputs.backend }}
+    steps:
+      - name: Check PR diff for backend paths
+        id: diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" \
+            --paginate --jq '.[].filename')
+          echo "$FILES"
+          if echo "$FILES" | grep -qE '^recipe-lanes/(functions/|firestore\.rules$|firestore\.indexes\.json$|storage\.rules$)'; then
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+            echo "Backend paths touched -> preview skipped, staging lease required."
+          else
+            echo "backend=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  needs-staging-lease:
+    needs: detect-backend-changes
+    if: github.event.action != 'closed' && needs.detect-backend-changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR needs-staging-lease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create needs-staging-lease \
+            --repo "${{ github.repository }}" \
+            --color D93F0B \
+            --description "Touches backend (functions/rules/indexes); needs exclusive staging validation" \
+            2>/dev/null || true
+          gh pr edit "${{ github.event.number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label needs-staging-lease
+
+      - name: Post sticky skip comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: cloud-run-preview
+          message: |
+            ### Cloud Run preview skipped — staging lease required
+
+            This PR changes backend resources (`recipe-lanes/functions/**`, Firestore/Storage
+            rules, or Firestore indexes). Per-PR previews all share the staging Firebase
+            backend, so backend changes cannot be previewed in parallel.
+
+            Instead, this PR needs **exclusive staging validation**: take the staging
+            lease, deploy the backend changes to `staging`, and verify there before merge.
+            The `needs-staging-lease` label has been added.
+
+            _Commit:_ `${{ github.sha }}`
+
+  deploy:
+    needs: detect-backend-changes
+    if: github.event.action != 'closed' && needs.detect-backend-changes.outputs.backend == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_STAGING }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      # Single source of truth: read the plain NEXT_PUBLIC_* values straight from
+      # the committed apphosting.staging.yaml (same values prod/staging inline).
+      # setup-gcloud provides no yq; use a tiny node parser (no extra deps).
+      - name: Read NEXT_PUBLIC_* build args from apphosting.staging.yaml
+        id: cfg
+        working-directory: recipe-lanes
+        run: |
+          node -e '
+            const fs = require("fs");
+            const txt = fs.readFileSync("apphosting.staging.yaml", "utf8");
+            const want = [
+              "NEXT_PUBLIC_FIREBASE_API_KEY",
+              "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN",
+              "NEXT_PUBLIC_FIREBASE_PROJECT_ID",
+              "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET",
+              "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID",
+              "NEXT_PUBLIC_FIREBASE_APP_ID",
+            ];
+            const out = [];
+            let cur = null;
+            for (const raw of txt.split("\n")) {
+              const v = raw.match(/^\s*-\s*variable:\s*(\S+)/);
+              if (v) { cur = v[1]; continue; }
+              const val = raw.match(/^\s*value:\s*(.*)$/);
+              if (val && cur && want.includes(cur)) {
+                let s = val[1].trim().replace(/^["\x27]|["\x27]$/g, "");
+                out.push(`${cur}=${s}`);
+              }
+            }
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, "args<<EOF\n" + out.join("\n") + "\nEOF\n");
+          '
+
+      # icon_index.json already lives under recipe-lanes/functions/... in the repo,
+      # so it is inside the build context. prebuild.js tolerates its absence anyway.
+
+      - name: Ensure Artifact Registry repo exists
+        run: |
+          gcloud artifacts repositories describe "$AR_REPO" \
+            --project "$GCP_PROJECT" --location "$REGION" >/dev/null 2>&1 || \
+          gcloud artifacts repositories create "$AR_REPO" \
+            --project "$GCP_PROJECT" --location "$REGION" \
+            --repository-format=docker
+
+      - name: Build and push image
+        id: build
+        working-directory: recipe-lanes
+        run: |
+          IMAGE="${REGION}-docker.pkg.dev/${GCP_PROJECT}/${AR_REPO}/${SERVICE}:pr-${{ github.event.number }}-${{ github.sha }}"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          # docker build (not `gcloud builds submit --tag`, which does NOT accept
+          # --build-arg). The NEXT_PUBLIC_* values must be build args so next build
+          # inlines them. Push to Artifact Registry via the gcloud cred helper.
+          gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+          BUILD_ARGS=()
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            BUILD_ARGS+=(--build-arg "$line")
+          done <<'ARGS'
+          ${{ steps.cfg.outputs.args }}
+          ARGS
+          BUILD_ARGS+=(--build-arg NEXT_PUBLIC_ENV_NAME=preview)
+          docker build "${BUILD_ARGS[@]}" -t "$IMAGE" .
+          docker push "$IMAGE"
+
+      - name: Deploy to Cloud Run (tagged, no traffic)
+        id: deploy
+        run: |
+          gcloud run deploy "$SERVICE" \
+            --project "$GCP_PROJECT" --region "$REGION" \
+            --image "${{ steps.build.outputs.image }}" \
+            --tag "pr-${{ github.event.number }}" \
+            --no-traffic \
+            --allow-unauthenticated \
+            --set-env-vars "NEXT_PUBLIC_ENV_NAME=preview,ADMIN_EMAILS=binghelpdesk@gmail.com"
+          URL=$(gcloud run services describe "$SERVICE" \
+            --project "$GCP_PROJECT" --region "$REGION" \
+            --format="value(status.traffic.url)" \
+            --filter="status.traffic.tag=pr-${{ github.event.number }}" | head -n1)
+          if [ -z "$URL" ]; then
+            URL=$(gcloud run services describe "$SERVICE" \
+              --project "$GCP_PROJECT" --region "$REGION" \
+              --format="json" | node -e '
+                const d=JSON.parse(require("fs").readFileSync(0,"utf8"));
+                const t=(d.status?.traffic||[]).find(x=>x.tag==="pr-${{ github.event.number }}");
+                if(t?.url)process.stdout.write(t.url);')
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Post sticky preview comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: cloud-run-preview
+          message: |
+            ### Cloud Run preview ready
+
+            **URL:** ${{ steps.deploy.outputs.url }}
+            **Commit:** `${{ github.sha }}`
+            **Service:** `recipe-lanes-preview` (tag `pr-${{ github.event.number }}`) on `recipe-lanes-staging`
+
+            > Preview shares staging Firestore / Auth / Storage — treat data as shared.
+
+  teardown:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_STAGING }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Remove preview tag
+        run: |
+          gcloud run services update-traffic "$SERVICE" \
+            --project "$GCP_PROJECT" --region "$REGION" \
+            --remove-tags "pr-${{ github.event.number }}" || \
+            echo "No tag pr-${{ github.event.number }} to remove; skipping."
+
+      - name: Delete pushed preview images
+        run: |
+          IMAGE_PATH="${REGION}-docker.pkg.dev/${GCP_PROJECT}/${AR_REPO}/${SERVICE}"
+          gcloud artifacts docker tags list "$IMAGE_PATH" \
+            --filter="tag.basename()~^pr-${{ github.event.number }}-" \
+            --format="value(tag.basename())" 2>/dev/null | while read -r TAG; do
+            [ -z "$TAG" ] && continue
+            gcloud artifacts docker images delete "${IMAGE_PATH}:${TAG}" \
+              --delete-tags --quiet || true
+          done
+
+      - name: Update sticky comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: cloud-run-preview
+          message: |
+            ### Cloud Run preview torn down
+
+            The `pr-${{ github.event.number }}` preview tag has been removed.

--- a/gcp/monitoring/apply.sh
+++ b/gcp/monitoring/apply.sh
@@ -9,7 +9,7 @@
 # Env vars (all overridable):
 #   PROJECT_ID               GCP project (positional $1 wins). Required.
 #   ALERT_EMAIL              Email for the notification channel (positional $2 wins).
-#                            Default: binghelpdesk@gmail.com
+#                            Default: you@example.com
 #   ALERT_THRESHOLD          N — fire when count > N.       Default: 50
 #   ALERT_ALIGNMENT_PERIOD   X — alignment window seconds.  Default: 600s
 #   DRY_RUN=1 (or --dry-run) Print gcloud commands without executing.

--- a/recipe-lanes/.dockerignore
+++ b/recipe-lanes/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.next
+model-cache
+.env
+.env.*
+tests
+e2e
+playwright-report
+test-results
+.git
+Dockerfile
+.dockerignore

--- a/recipe-lanes/Dockerfile
+++ b/recipe-lanes/Dockerfile
@@ -1,0 +1,56 @@
+# Cloud Run preview image for RecipeLanes.
+# Build context is `recipe-lanes/`. The workflow copies
+# functions/src/vector-search/data/icon_index.json into place before build;
+# prebuild.js tolerates its absence (writes an empty index).
+#
+# Single-stage build: `next build` produces a default (.next) build and we run
+# it with `next start`. onnxruntime-node is aliased to onnxruntime-web (WASM) in
+# next.config.ts, so no native .so is needed at runtime.
+FROM node:20-slim
+
+# sharp ships prebuilt binaries for linux-x64 glibc, so no extra OS deps are
+# required on node:20-slim (Debian glibc). Add libc6/openssl only if a future
+# sharp/onnx native path needs them.
+
+ENV NODE_ENV=production
+
+# --- Build-time public Firebase config (inlined by `next build`) ---
+# These MUST be present at build time because Next.js inlines NEXT_PUBLIC_* vars.
+ARG NEXT_PUBLIC_FIREBASE_API_KEY
+ARG NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+ARG NEXT_PUBLIC_FIREBASE_PROJECT_ID
+ARG NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
+ARG NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
+ARG NEXT_PUBLIC_FIREBASE_APP_ID
+ARG NEXT_PUBLIC_ENV_NAME=preview
+
+ENV NEXT_PUBLIC_FIREBASE_API_KEY=$NEXT_PUBLIC_FIREBASE_API_KEY \
+    NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=$NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN \
+    NEXT_PUBLIC_FIREBASE_PROJECT_ID=$NEXT_PUBLIC_FIREBASE_PROJECT_ID \
+    NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=$NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET \
+    NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=$NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID \
+    NEXT_PUBLIC_FIREBASE_APP_ID=$NEXT_PUBLIC_FIREBASE_APP_ID \
+    NEXT_PUBLIC_ENV_NAME=$NEXT_PUBLIC_ENV_NAME
+
+WORKDIR /app
+
+# Install deps first for layer caching. --include=dev is required because
+# NODE_ENV=production would otherwise make npm omit devDependencies, and
+# next build needs them (next, typescript, tailwind, etc).
+COPY package.json package-lock.json ./
+RUN npm ci --include=dev
+
+# App source (build context is recipe-lanes/; see .dockerignore).
+COPY . .
+
+# prebuild.js downloads Xenova/all-MiniLM-L6-v2 into model-cache/ (needs network)
+# and copies icon_index.json; then next build. MOCK_AI is never set here.
+RUN npm run build
+
+# Cloud Run injects PORT (default 8080). Do NOT hardcode 8001.
+ENV PORT=8080
+EXPOSE 8080
+
+# Mirror scripts/start.sh: add onnxruntime-node's bundled lib dir to
+# LD_LIBRARY_PATH (harmless with the WASM alias) and start on $PORT.
+CMD ["sh", "-c", "ONNX_BIN_DIR=$(node -e \"try{const p=require('path');const pkg=require.resolve('onnxruntime-node/package.json');const d=p.join(p.dirname(pkg),'bin','napi-v6','linux','x64');const fs=require('fs');if(fs.existsSync(d))process.stdout.write(d);}catch(e){}\" 2>/dev/null); if [ -n \"$ONNX_BIN_DIR\" ]; then export LD_LIBRARY_PATH=\"${ONNX_BIN_DIR}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}\"; fi; exec npx next start -p ${PORT:-8080}"]

--- a/recipe-lanes/scripts/setup-preview-pipeline.sh
+++ b/recipe-lanes/scripts/setup-preview-pipeline.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# One-time IAM/API setup for the per-PR Cloud Run preview pipeline
+# (.github/workflows/pr-preview.yml). Run once per project.
+#
+# Deploys always target recipe-lanes-staging (see pr-preview.yml GCP_PROJECT),
+# but this script accepts any project so the same setup can be reused if a
+# second preview target (e.g. a future main-tracking backend) is added.
+
+set -e
+
+PROJECT_ID=$1
+if [ -z "$PROJECT_ID" ]; then
+    echo "Usage: $0 [PROJECT_ID]"
+    echo "  e.g. $0 recipe-lanes-staging"
+    exit 1
+fi
+
+REGION="us-central1"
+AR_REPO="preview"
+
+# Deploy SA: the credential the pr-preview.yml workflow authenticates as
+# (FIREBASE_SERVICE_ACCOUNT_STAGING secret -> default Firebase Admin SDK SA).
+DEPLOY_SA="firebase-adminsdk-fbsvc@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# Runtime SA: what the deployed Cloud Run *service* runs as (default compute
+# SA, since no --service-account is passed to `gcloud run deploy` in the
+# workflow). Needs the same data-plane access the app needs at runtime.
+COMPUTE_PROJECT_NUMBER=$(gcloud projects describe "${PROJECT_ID}" --format="value(projectNumber)")
+RUNTIME_SA="${COMPUTE_PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+
+echo "🚀 Setting up preview pipeline for project: ${PROJECT_ID}"
+
+# 1. Enable required APIs
+APIS=(
+    run.googleapis.com
+    artifactregistry.googleapis.com
+    aiplatform.googleapis.com
+)
+echo "Verifying required APIs..."
+for API in "${APIS[@]}"; do
+    if gcloud services list --project="${PROJECT_ID}" --filter="config.name:${API}" --format="value(config.name)" 2>/dev/null | grep -q "${API}"; then
+        echo "API ${API} already enabled."
+    else
+        echo "Enabling ${API}..."
+        gcloud services enable "${API}" --project="${PROJECT_ID}"
+    fi
+done
+
+# 2. Create the Artifact Registry repo the workflow pushes preview images to
+# (the workflow also self-heals this, but it needs create permission first).
+if gcloud artifacts repositories describe "${AR_REPO}" --project="${PROJECT_ID}" --location="${REGION}" >/dev/null 2>&1; then
+    echo "Artifact Registry repo ${AR_REPO} already exists."
+else
+    echo "Creating Artifact Registry repo: ${AR_REPO}"
+    gcloud artifacts repositories create "${AR_REPO}" \
+        --project="${PROJECT_ID}" --location="${REGION}" \
+        --repository-format=docker
+fi
+
+# Function to check and add role (mirrors setup-icon-processor-sa.sh)
+check_and_add_role() {
+    local MEMBER=$1
+    local ROLE=$2
+
+    EXISTING=$(gcloud projects get-iam-policy "${PROJECT_ID}" \
+        --flatten="bindings[].members" \
+        --filter="bindings.role:${ROLE} AND bindings.members:${MEMBER}" \
+        --format="value(bindings.role)" 2>/dev/null || true)
+
+    if [ "$EXISTING" == "$ROLE" ]; then
+        echo "Role ${ROLE} already granted to ${MEMBER}"
+    else
+        echo "Adding ${ROLE} to ${MEMBER}..."
+        gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+            --member="${MEMBER}" \
+            --role="${ROLE}" \
+            --condition=None >/dev/null
+    fi
+}
+
+# 3. Grant the deploy SA what it needs to build, push, and deploy previews
+DEPLOY_ROLES=(
+    "roles/run.admin"
+    "roles/iam.serviceAccountUser"
+    "roles/artifactregistry.writer"
+    "roles/artifactregistry.admin"
+)
+echo "Verifying deploy SA (${DEPLOY_SA}) roles..."
+for ROLE in "${DEPLOY_ROLES[@]}"; do
+    check_and_add_role "serviceAccount:${DEPLOY_SA}" "${ROLE}"
+done
+
+# 4. Grant the runtime SA what the deployed preview app needs to serve traffic
+RUNTIME_ROLES=(
+    "roles/aiplatform.user"
+    "roles/datastore.user"
+    "roles/storage.objectAdmin"
+)
+echo "Verifying runtime SA (${RUNTIME_SA}) roles..."
+for ROLE in "${RUNTIME_ROLES[@]}"; do
+    check_and_add_role "serviceAccount:${RUNTIME_SA}" "${ROLE}"
+done
+
+echo "✅ Preview pipeline setup complete for ${PROJECT_ID}!"
+echo "Deploy SA: ${DEPLOY_SA}"
+echo "Runtime SA: ${RUNTIME_SA}"
+echo "Artifact Registry: ${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}"


### PR DESCRIPTION
## What this does

Adds per-PR frontend previews on Cloud Run in the staging GCP project (`recipe-lanes-staging`):

- **`recipe-lanes/Dockerfile`** — single-stage Node 20 image: `npm ci --include=dev`, `npm run build` (runs `prebuild.js` model download + `next build`; MOCK_AI is never set), starts `next start` on `$PORT`. NEXT_PUBLIC_* Firebase config is passed as build args (read from the committed `apphosting.staging.yaml`).
- **`recipe-lanes/.dockerignore`** — excludes `node_modules`, `.next`, tests, and `.env*` (including `.env.test`, so `MOCK_AI=true` cannot leak into the image).
- **`.github/workflows/pr-preview.yml`** — on PR open/sync/reopen: builds + pushes to Artifact Registry and deploys to the shared `recipe-lanes-preview` Cloud Run service as a tagged, no-traffic revision (`--tag pr-<n>`), then posts/updates a sticky comment with the preview URL. On PR close: removes the traffic tag and deletes the pushed `pr-<n>-*` images.

Previews talk to the shared **staging Firebase backend** (Firestore/Auth/Storage/Functions).

## Staging-lease rule

A first job diffs the PR's changed files. If any touch backend paths —
`recipe-lanes/functions/**`, `recipe-lanes/firestore.rules`, `recipe-lanes/firestore.indexes.json`, `recipe-lanes/storage.rules` — the preview is **skipped entirely**: the PR gets the `needs-staging-lease` label (created if missing) and a sticky comment explaining it needs exclusive staging validation instead. Backend changes cannot be safely previewed against a backend shared by every other open PR.

## Defaults chosen

- Previews are deployed `--allow-unauthenticated` (public URL; the app itself still gates via Firebase login).

## One-time setup required (not yet run)

Before the first workflow run, on `recipe-lanes-staging`:

1. Enable APIs: `run.googleapis.com`, `artifactregistry.googleapis.com`, `aiplatform.googleapis.com`
   ```
   gcloud services enable run.googleapis.com artifactregistry.googleapis.com aiplatform.googleapis.com --project recipe-lanes-staging
   ```
2. Create the Artifact Registry repo `preview` (the workflow also creates it if missing, but the deploy SA then needs create rights):
   ```
   gcloud artifacts repositories create preview --project recipe-lanes-staging --location us-central1 --repository-format=docker
   ```
3. Grant the deploy service account (the `client_email` inside the `FIREBASE_SERVICE_ACCOUNT_STAGING` secret):
   `roles/run.admin`, `roles/iam.serviceAccountUser`, `roles/artifactregistry.writer`
   ```
   for R in roles/run.admin roles/iam.serviceAccountUser roles/artifactregistry.writer; do
     gcloud projects add-iam-policy-binding recipe-lanes-staging --member "serviceAccount:<DEPLOY_SA_EMAIL>" --role "$R"
   done
   ```
4. Grant the runtime service account (default compute SA) `roles/aiplatform.user` plus Firestore/Storage access:
   ```
   gcloud projects add-iam-policy-binding recipe-lanes-staging --member "serviceAccount:<PROJECT_NUMBER>-compute@developer.gserviceaccount.com" --role roles/aiplatform.user
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHrdQcf4KzH4bM4XuNpcSc
