### PR TITLE
Gate /icon_overview behind auth

### DIFF
--- a/recipe-lanes/app/icon_overview/page.tsx
+++ b/recipe-lanes/app/icon_overview/page.tsx
@@ -60,6 +60,10 @@ export default function Home() {
   useEffect(() => {
     async function init() {
       if (authLoading) return;
+      if (!user) {
+          setInitializing(false);
+          return;
+      }
       if (recipeId) {
           setInitializing(false);
           return;
@@ -91,7 +95,7 @@ export default function Home() {
             deleteRecipeAction(recipeId).catch(console.error);
         }
     };
-  }, [authLoading, recipeId]); // Run when auth ready or ID changes
+  }, [authLoading, recipeId, user]); // Run when auth ready or ID changes
 
   // 2. Listen for Updates
   useEffect(() => {
@@ -208,6 +212,24 @@ export default function Home() {
     return (
       <div className="flex min-h-screen w-full bg-zinc-900 text-zinc-100 font-mono items-center justify-center">
         <div className="animate-pulse text-yellow-500">INITIALIZING SESSION...</div>
+      </div>
+    );
+  }
+
+  // Icon Maker is an internal forging/debug tool, not a public-facing feature — gate it behind auth (Issue #172).
+  if (!user) {
+    return (
+      <div className="flex min-h-screen w-full bg-zinc-900 text-zinc-100 font-mono items-center justify-center p-4">
+        <div className="text-center space-y-4 max-w-sm">
+          <ChefHat className="w-10 h-10 text-yellow-500 mx-auto" />
+          <p className="text-zinc-400">Sign in to use the icon forge.</p>
+          <button
+            onClick={signIn}
+            className="px-4 py-2 rounded bg-yellow-500 text-zinc-900 font-bold uppercase tracking-wider text-sm hover:bg-yellow-400"
+          >
+            Login
+          </button>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## What & why

`/icon_overview` ("Icon Maker") is an internal icon-forging/debug tool, not a public-facing feature. Anonymous visitors could previously load the page freely — the `useEffect` init ran regardless of auth state, silently creating a Firestore "debug recipe" doc on every anonymous visit, and the full forge/gallery UI was rendered for anyone. A comment already in `app/actions.ts` noted: *"Anonymous visitors can VIEW /icon_overview; forging is gated by config"* — the actual forge action was already rate/config-gated, but the page itself was not gated at all.

This closes #172 by requiring sign-in to view/use the page:
- The init effect now skips creating the debug recipe entirely when there is no authenticated `user` (no more Firestore writes for anonymous visits).
- Unauthenticated visitors now see a simple "Sign in to use the icon forge" screen with a Login button instead of the full tool.

Smallest change that closes the issue — no changes to the god files (`data-service.ts`, `app/lanes/page.tsx`, `react-flow-diagram.tsx`) and no changes to the existing server-side forge-rate-limiting logic in `app/actions.ts`.

## How verified

- Local: `npm run lint` — 0 errors (pre-existing warnings only, none new).
- Local: `npm run typecheck` — passes cleanly.
- Local: `npm run test:unit:pure` (part of the pre-commit hook) — 307/307 tests pass.
- CI: GitHub Actions run on this PR — see checks below (will link once green).
- Self-review via `/code-review` (low effort, diff-only pass) — no findings.

## Risks / unsure about

- This is client-side gating only (the page is a `'use client'` component). The existing server action `createDebugRecipeAction` itself has no auth check — a direct POST to the server action endpoint could still create a debug recipe doc even after this change. That's a pre-existing gap this PR doesn't close; flagging for a possible follow-up if that's a real concern.
- I did not verify this in a running browser (no local emulator/dev server was started per the run's local-check-only constraints) — only lint/typecheck/unit tests were run locally. CI's e2e suite (`e2e/recipes.spec.ts`, "Shared Gallery: hover reveals label and delete removes icon") exercises `/icon_overview` post-login and should catch any regression there.
- The exact copy/UX of the sign-in gate ("Sign in to use the icon forge") is a judgment call — happy to adjust wording/styling if you had something specific in mind.


---
_Generated by [Claude Code](https://claude.ai/code/session_0133V2v4W1oFYw6gb9NvHx2t)_