### PR TITLE
fix(ci): register PR preview hosts as Firebase authorized domains

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -193,6 +193,72 @@ jobs:
           fi
           echo "url=$URL" >> "$GITHUB_OUTPUT"
 
+      - name: Register preview host as authorized Firebase Auth domain
+        run: |
+          set -euo pipefail
+          URL="${{ steps.deploy.outputs.url }}"
+          if [ -z "$URL" ]; then
+            echo "::error::Cloud Run deploy produced no URL; cannot register authorized domain."
+            exit 1
+          fi
+          # Strip scheme and any trailing path to get just the hostname.
+          HOST="${URL#https://}"
+          HOST="${HOST#http://}"
+          HOST="${HOST%%/*}"
+          echo "Registering authorized domain: $HOST"
+
+          TOKEN=$(gcloud auth print-access-token)
+          CONFIG_URL="https://identitytoolkit.googleapis.com/admin/v2/projects/${GCP_PROJECT}/config"
+
+          ATTEMPTS=5
+          SUCCESS=false
+          for i in $(seq 1 "$ATTEMPTS"); do
+            GET_RESP=$(curl -sS -w '\n%{http_code}' -X GET "$CONFIG_URL" \
+              -H "Authorization: Bearer ${TOKEN}")
+            GET_BODY=$(echo "$GET_RESP" | sed '$d')
+            GET_CODE=$(echo "$GET_RESP" | tail -n1)
+
+            if [ "$GET_CODE" = "403" ]; then
+              echo "::error::Permission denied (403) reading Identity Toolkit config for project ${GCP_PROJECT}. The FIREBASE_SERVICE_ACCOUNT_STAGING service account needs a role with firebaseauth.configs.update (e.g. roles/firebaseauth.admin)."
+              exit 1
+            fi
+            if [ "$GET_CODE" -lt 200 ] || [ "$GET_CODE" -ge 300 ]; then
+              echo "GET failed with status $GET_CODE (attempt $i/$ATTEMPTS); retrying..."
+              sleep 3
+              continue
+            fi
+
+            NEW_DOMAINS=$(echo "$GET_BODY" | jq -c --arg host "$HOST" \
+              '((.authorizedDomains // []) + [$host]) | unique')
+
+            PATCH_RESP=$(curl -sS -w '\n%{http_code}' -X PATCH \
+              "${CONFIG_URL}?updateMask=authorizedDomains" \
+              -H "Authorization: Bearer ${TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -nc --argjson domains "$NEW_DOMAINS" '{authorizedDomains: $domains}')")
+            PATCH_BODY=$(echo "$PATCH_RESP" | sed '$d')
+            PATCH_CODE=$(echo "$PATCH_RESP" | tail -n1)
+
+            if [ "$PATCH_CODE" = "403" ]; then
+              echo "::error::Permission denied (403) updating Identity Toolkit config for project ${GCP_PROJECT}. The FIREBASE_SERVICE_ACCOUNT_STAGING service account needs a role with firebaseauth.configs.update (e.g. roles/firebaseauth.admin)."
+              exit 1
+            fi
+            if [ "$PATCH_CODE" -ge 200 ] && [ "$PATCH_CODE" -lt 300 ]; then
+              echo "Authorized domain '$HOST' registered."
+              SUCCESS=true
+              break
+            fi
+
+            echo "PATCH failed with status $PATCH_CODE (attempt $i/$ATTEMPTS); response: $PATCH_BODY"
+            echo "Retrying (likely a concurrent-update race with another PR preview)..."
+            sleep 3
+          done
+
+          if [ "$SUCCESS" != "true" ]; then
+            echo "::error::Failed to register authorized domain '$HOST' after ${ATTEMPTS} attempts."
+            exit 1
+          fi
+
       - name: Post sticky preview comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
@@ -215,6 +281,82 @@ jobs:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_STAGING }}
 
       - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deregister preview host from authorized Firebase Auth domains
+        run: |
+          set -euo pipefail
+          URL=$(gcloud run services describe "$SERVICE" \
+            --project "$GCP_PROJECT" --region "$REGION" \
+            --format="value(status.traffic.url)" \
+            --filter="status.traffic.tag=pr-${{ github.event.number }}" 2>/dev/null | head -n1)
+          if [ -z "$URL" ]; then
+            URL=$(gcloud run services describe "$SERVICE" \
+              --project "$GCP_PROJECT" --region "$REGION" \
+              --format="json" 2>/dev/null | node -e '
+                const d=JSON.parse(require("fs").readFileSync(0,"utf8"));
+                const t=(d.status?.traffic||[]).find(x=>x.tag==="pr-${{ github.event.number }}");
+                if(t?.url)process.stdout.write(t.url);' || true)
+          fi
+          if [ -z "$URL" ]; then
+            echo "No tagged URL found for pr-${{ github.event.number }}; nothing to deregister."
+            exit 0
+          fi
+          HOST="${URL#https://}"
+          HOST="${HOST#http://}"
+          HOST="${HOST%%/*}"
+          echo "Deregistering authorized domain: $HOST"
+
+          TOKEN=$(gcloud auth print-access-token)
+          CONFIG_URL="https://identitytoolkit.googleapis.com/admin/v2/projects/${GCP_PROJECT}/config"
+
+          ATTEMPTS=5
+          SUCCESS=false
+          for i in $(seq 1 "$ATTEMPTS"); do
+            GET_RESP=$(curl -sS -w '\n%{http_code}' -X GET "$CONFIG_URL" \
+              -H "Authorization: Bearer ${TOKEN}")
+            GET_BODY=$(echo "$GET_RESP" | sed '$d')
+            GET_CODE=$(echo "$GET_RESP" | tail -n1)
+
+            if [ "$GET_CODE" = "403" ]; then
+              echo "::error::Permission denied (403) reading Identity Toolkit config for project ${GCP_PROJECT}. The FIREBASE_SERVICE_ACCOUNT_STAGING service account needs a role with firebaseauth.configs.update (e.g. roles/firebaseauth.admin)."
+              exit 1
+            fi
+            if [ "$GET_CODE" -lt 200 ] || [ "$GET_CODE" -ge 300 ]; then
+              echo "GET failed with status $GET_CODE (attempt $i/$ATTEMPTS); retrying..."
+              sleep 3
+              continue
+            fi
+
+            NEW_DOMAINS=$(echo "$GET_BODY" | jq -c --arg host "$HOST" \
+              '[(.authorizedDomains // [])[] | select(. != $host)]')
+
+            PATCH_RESP=$(curl -sS -w '\n%{http_code}' -X PATCH \
+              "${CONFIG_URL}?updateMask=authorizedDomains" \
+              -H "Authorization: Bearer ${TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -nc --argjson domains "$NEW_DOMAINS" '{authorizedDomains: $domains}')")
+            PATCH_BODY=$(echo "$PATCH_RESP" | sed '$d')
+            PATCH_CODE=$(echo "$PATCH_RESP" | tail -n1)
+
+            if [ "$PATCH_CODE" = "403" ]; then
+              echo "::error::Permission denied (403) updating Identity Toolkit config for project ${GCP_PROJECT}. The FIREBASE_SERVICE_ACCOUNT_STAGING service account needs a role with firebaseauth.configs.update (e.g. roles/firebaseauth.admin)."
+              exit 1
+            fi
+            if [ "$PATCH_CODE" -ge 200 ] && [ "$PATCH_CODE" -lt 300 ]; then
+              echo "Authorized domain '$HOST' removed."
+              SUCCESS=true
+              break
+            fi
+
+            echo "PATCH failed with status $PATCH_CODE (attempt $i/$ATTEMPTS); response: $PATCH_BODY"
+            echo "Retrying (likely a concurrent-update race with another PR preview)..."
+            sleep 3
+          done
+
+          if [ "$SUCCESS" != "true" ]; then
+            echo "::error::Failed to deregister authorized domain '$HOST' after ${ATTEMPTS} attempts."
+            exit 1
+          fi
 
       - name: Remove preview tag
         run: |

--- a/recipe-lanes/scripts/setup-preview-pipeline.sh
+++ b/recipe-lanes/scripts/setup-preview-pipeline.sh
@@ -84,6 +84,13 @@ DEPLOY_ROLES=(
     "roles/iam.serviceAccountUser"
     "roles/artifactregistry.writer"
     "roles/artifactregistry.admin"
+    # Needed for pr-preview.yml's authorized-domains automation: it calls the
+    # Identity Toolkit Admin API (GET/PATCH .../admin/v2/projects/<id>/config)
+    # to register/deregister each PR's Cloud Run preview hostname in staging's
+    # Firebase Auth "Authorized domains" list, so preview sign-in doesn't fail
+    # with auth/unauthorized-domain. That call requires
+    # firebaseauth.configs.update, granted by roles/firebaseauth.admin.
+    "roles/firebaseauth.admin"
 )
 echo "Verifying deploy SA (${DEPLOY_SA}) roles..."
 for ROLE in "${DEPLOY_ROLES[@]}"; do


### PR DESCRIPTION
## What & why

Every PR-preview sign-in currently fails with `FirebaseError: auth/unauthorized-domain`. Each PR preview is a Cloud Run tagged revision served from a dynamic host (`pr-<N>---recipe-lanes-preview-<hash>-uc.a.run.app`) and shares staging's Firebase Auth (`recipe-lanes-staging`). Firebase blocks OAuth sign-in from any origin not on that project's "Authorized domains" allowlist, and `pr-preview.yml` deploys the preview and posts its URL but never registers the domain, so sign-in fails on every preview.

This PR:
- Adds a step to the `deploy` job (right after `steps.deploy.outputs.url` is produced) that reads the current `authorizedDomains` list via the Identity Toolkit Admin API (`GET .../admin/v2/projects/recipe-lanes-staging/config`), appends the preview's hostname (de-duplicated with `jq unique`), and `PATCH`es it back.
- Adds a mirror step to the `teardown` job (`closed` path) that re-resolves the tagged preview URL, removes that hostname from the list, and `PATCH`es it back, so the allowlist doesn't grow unbounded across PRs.
- Both steps retry the read-modify-write up to 5 times with a short sleep, since `authorizedDomains` is a single shared list with no ETag and concurrent PRs can race on it.
- Both steps fail loudly (`exit 1` with a clear `::error::`) on a 403 from either the GET or PATCH, rather than silently no-op'ing, since a 403 means the CI service account lacks the required IAM role.
- Adds `roles/firebaseauth.admin` to the existing idempotent `recipe-lanes/scripts/setup-preview-pipeline.sh` `DEPLOY_ROLES` list (rather than a new parallel script — that script already owns this SA's IAM setup and already confirms the deploy SA identity: `firebase-adminsdk-fbsvc@recipe-lanes-staging.iam.gserviceaccount.com`, which is what backs the `FIREBASE_SERVICE_ACCOUNT_STAGING` secret).

## How verified

- No live GCP/Firebase calls were made from this change — this is workflow-authoring only, per the task brief.
- YAML: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-preview.yml'))"` parses cleanly; confirmed all 4 existing jobs (`detect-backend-changes`, `needs-staging-lease`, `deploy`, `teardown`) are still present and unchanged apart from the new steps.
- Each embedded `run:` block (across both new steps and the untouched existing ones) was extracted and checked with `bash -n` after substituting `${{ ... }}` GitHub expressions with placeholders — all pass.
- `actionlint` wasn't available in this sandbox (no network egress to fetch the release binary), so this is YAML+bash-syntax level validation, not full action-schema linting.
- `recipe-lanes/scripts/setup-preview-pipeline.sh` was checked with `bash -n` and is otherwise untouched aside from the one added role line.
- The live Identity Toolkit API path (add/remove domain, retry-on-race, 403 handling) can only be exercised once this is merged and the IAM grant below is applied — it wasn't invoked against real infra here.

## Risks / unsure about

- **IAM grant required before this can work at all:** the `FIREBASE_SERVICE_ACCOUNT_STAGING` service account (`firebase-adminsdk-fbsvc@recipe-lanes-staging.iam.gserviceaccount.com`) must be granted `roles/firebaseauth.admin` (or any role with `firebaseauth.configs.update`) on `recipe-lanes-staging`. The pipeline cannot self-grant this. **The owner needs to run:**
  ```bash
  ./recipe-lanes/scripts/setup-preview-pipeline.sh recipe-lanes-staging
  ```
  (This now includes the new role alongside the other deploy-SA roles it already manages. It's idempotent/safe to re-run.) Until this grant lands, every deploy/teardown will hit the new 403 guard and fail loudly by design — that's intentional so a missing grant is visible rather than silently swallowed, but it does mean **this PR should not be merged and left unattended without also running that script**, or previews will start failing CI on the new step.
- **Concurrent-PR race:** `authorizedDomains` is a single shared list per project with no ETag/optimistic-concurrency support. The retry loop (up to 5 attempts, re-GET before each PATCH) is a pragmatic mitigation, not a guarantee — a sufficiently unlucky pileup of simultaneous PR opens/closes could still exhaust retries. If this proves flaky in practice, consider serializing these steps via a workflow-level concurrency group scoped across all PRs (not just per-PR, as the existing `concurrency:` block is).
- **Authorized-domains count limit:** Firebase enforces a cap on the authorized-domains list size (historically documented around low hundreds). With many previews open in parallel plus failed teardowns leaking entries, this list could theoretically approach that limit over time. There's no cleanup-of-stale-entries safety net here beyond the teardown step itself; if teardown fails (e.g., PR closed without the teardown job running, or a 403), entries could accumulate. Worth a periodic reconciliation job if this becomes a real problem.
- I did not attempt to run the actual `add-iam-policy-binding` grant against live `recipe-lanes-staging` infra — that's explicitly the owner's call, not something this change applies on its own.