### PR TITLE
fix(lanes): clear recipe input box after forging (issue #156)

### DIFF
--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -624,11 +624,13 @@ const handleVisualize = async () => {
         url.searchParams.delete('new');
         url.searchParams.set('id', res.id);
 
-        // Move the draft under the new recipe's key and clear the blank-page
-        // draft so a fresh /lanes tab starts blank (issue #183). Works for both
-        // the text and photo flows — an empty recipeText just clears the blank
-        // draft without writing a per-recipe entry.
-        commitDraftOnForge(localStorage, res.id, recipeText);
+        // The pasted text has moved from the input box into the recipe (the
+        // diagram) — clear the input box (issue #156) and drop its draft so a
+        // fresh /lanes tab starts blank (issue #183) and reopening this recipe
+        // shows an empty input rather than the old text. Works for both the text
+        // and photo flows (photo flow just has an already-empty recipeText).
+        commitDraftOnForge(localStorage, res.id);
+        setRecipeText('');
 
         autoFillIconsRef.current = true;
         clearMessages();

--- a/recipe-lanes/lib/recipe-lanes/draft-persistence.ts
+++ b/recipe-lanes/lib/recipe-lanes/draft-persistence.ts
@@ -25,10 +25,13 @@
  *  - While editing a NEW (unsaved) recipe there is no `id` in the URL, so the
  *    draft is stored under BLANK_DRAFT_KEY. Refreshing the blank page restores
  *    it.
- *  - Once you forge, the recipe gets an id/URL. `commitDraftOnForge` copies the
- *    text to a per-recipe key (keyed under the new URL) and CLEARS the blank
- *    draft, so opening a fresh `/lanes` tab starts blank.
- *  - Loading an existing recipe (`?id=`) restores/saves under that recipe's key.
+ *  - Once you forge, the pasted text has "moved" from the input box into the
+ *    recipe itself (the diagram). `commitDraftOnForge` therefore DROPS the input
+ *    draft entirely — both the new recipe's per-recipe key and the blank draft —
+ *    so opening a fresh `/lanes` tab starts blank AND reopening the forged
+ *    recipe shows an empty input box rather than the old pasted text (issue #156).
+ *  - Loading an existing recipe (`?id=`) restores/saves any in-progress typing
+ *    under that recipe's key (until it too is forged).
  *
  * These functions are pure over a minimal Storage-like interface so they can be
  * unit-tested without a browser.
@@ -69,13 +72,14 @@ export function saveDraft(storage: DraftStorage, id: string | null | undefined, 
 }
 
 /**
- * Called right after a successful forge yields `newId`: move the text under the
- * new recipe's key and clear the blank draft so a fresh `/lanes` tab is blank.
+ * Called right after a successful forge yields `newId`: the pasted text has
+ * moved into the recipe, so drop the input draft entirely. Clears both the new
+ * recipe's per-recipe draft (so reopening it shows an empty input box, not the
+ * old pasted text — issue #156) and the blank draft (so a fresh `/lanes` tab is
+ * blank — issue #183).
  */
-export function commitDraftOnForge(storage: DraftStorage, newId: string, text: string): void {
-  if (text) {
-    storage.setItem(draftKey(newId), text);
-  }
+export function commitDraftOnForge(storage: DraftStorage, newId: string): void {
+  storage.removeItem(draftKey(newId));
   storage.removeItem(BLANK_DRAFT_KEY);
 }
 

--- a/recipe-lanes/tests/draft-persistence.test.ts
+++ b/recipe-lanes/tests/draft-persistence.test.ts
@@ -77,28 +77,38 @@ describe('forging a recipe', () => {
   let storage: ReturnType<typeof makeStorage>;
   beforeEach(() => { storage = makeStorage(); });
 
-  it('moves the text to the new url key and clears the blank draft', () => {
+  it('clears the input draft so the box is empty after forging (issue #156)', () => {
     // Typed on the blank page, then forged into recipe "r1".
     saveDraft(storage, null, 'two eggs, flour');
-    commitDraftOnForge(storage, 'r1', 'two eggs, flour');
+    commitDraftOnForge(storage, 'r1');
 
-    // Text now lives under the new recipe's key...
-    assert.equal(loadDraft(storage, 'r1'), 'two eggs, flour');
-    // ...and the blank draft is gone.
+    // The text has moved into the recipe: reopening r1 shows an empty input box...
+    assert.equal(loadDraft(storage, 'r1'), '');
+    // ...and the blank draft is gone too.
     assert.equal(storage.getItem(BLANK_DRAFT_KEY), null);
   });
 
   it('leaves a fresh tab (no id) blank after a forge', () => {
     saveDraft(storage, null, 'two eggs, flour');
-    commitDraftOnForge(storage, 'r1', 'two eggs, flour');
+    commitDraftOnForge(storage, 'r1');
 
     // Opening a brand new /lanes tab restores nothing.
     assert.equal(loadDraft(storage, null), '');
   });
 
-  it('still restores the forged recipe when you reopen its url', () => {
-    commitDraftOnForge(storage, 'r1', 'two eggs, flour');
-    assert.equal(loadDraft(storage, 'r1'), 'two eggs, flour');
+  it('clears a pre-existing per-recipe draft when re-forging the same recipe', () => {
+    // Editing an already-saved recipe r1, then re-forging it: the stale input
+    // text must not linger under the recipe key.
+    saveDraft(storage, 'r1', 'edited eggs, flour');
+    commitDraftOnForge(storage, 'r1');
+    assert.equal(loadDraft(storage, 'r1'), '');
+  });
+
+  it('does not touch OTHER recipes\' drafts when forging', () => {
+    // In-progress typing on another recipe r2 is unrelated and must survive.
+    saveDraft(storage, 'r2', 'other recipe wip');
+    commitDraftOnForge(storage, 'r1');
+    assert.equal(loadDraft(storage, 'r2'), 'other recipe wip');
   });
 });
 


### PR DESCRIPTION
Closes #156.

## What & why

Issue #156: *"text moves from input box to recipe box"* / *"or maybe get rid of the forge button…"*.

Today, after you forge a recipe, the raw pasted text keeps sitting in the input textarea alongside the freshly-rendered diagram, and reopening a forged recipe re-populates that input with the old pasted text. This change makes the text **move out of the input box** once it has become the recipe (the diagram is the "recipe box"):

- `finalizeCreatedRecipe` now clears the live textarea (`setRecipeText('')`) right after a successful forge.
- `commitDraftOnForge` now **drops the input draft entirely** — it removes both the new recipe's per-recipe draft key and the blank-page draft — instead of copying the forged text under the recipe key. So reopening the recipe shows an empty input box, not the old text.

The blank-page behaviour from #183 (a fresh `/lanes` tab starts blank) is preserved. The draft is only cleared on a **successful** forge — `finalizeCreatedRecipe` throws on an errored/empty result *before* reaching this code — so a failed forge never loses the user's typed text.

I kept the forge button itself (the issue's alternative "get rid of the forge button" idea was a loose suggestion; removing the primary create action is a much larger UX change and out of scope for the smallest fix that addresses the title).

## How verified

- **New/updated pure unit tests** in `recipe-lanes/tests/draft-persistence.test.ts` (tier: `test:unit:pure`, run by the **fast-checks** CI job), exercising the changed rule directly:
  - `clears the input draft so the box is empty after forging (issue #156)` — after `commitDraftOnForge`, both the per-recipe key and blank key are empty.
  - `clears a pre-existing per-recipe draft when re-forging the same recipe` — stale input text under the recipe key does not linger.
  - `does not touch OTHER recipes' drafts when forging` — unrelated in-progress drafts survive.
  - `leaves a fresh tab (no id) blank after a forge` — #183 behaviour retained.
- Local pre-checks all green: `npm run lint` (0 errors), `npm run typecheck` (clean), and the scoped `npm run test:one -- tests/draft-persistence.test.ts` (11/11 pass). The full `test:unit:pure` suite also passed via the pre-commit hook.
- Please confirm the CI **fast-checks / integration / e2e** jobs run and pass on this PR.

## Risks / unsure about

- **Behaviour reversal vs #183's side-effect:** #183 previously restored the forged text into the input when you reopened a recipe's URL (see the old `still restores the forged recipe when you reopen its url` test, now replaced). This PR intentionally reverses that specific side-effect because it is exactly what #156 complains about. If the owner actually wants the source text preserved for reference on reopen, this is the line to reconsider.
- **Interpretation of a vague issue:** the issue is a short UX musing. I implemented the reading that matches the title ("text moves from input box to recipe box"). The forge-button-removal alternative was deliberately not done.
- **No component-level test for the live `setRecipeText('')` clear:** that lives inside `finalizeCreatedRecipe` (router/store side-effects) and isn't covered by a pure unit test; the reference-preserving draft rule it depends on *is* covered. An e2e assertion on the textarea emptying after forge could be added if desired.
- **God-file touch:** `app/lanes/page.tsx` is flagged high-blast-radius in CLAUDE.md. The change there is a two-line, self-contained edit inside the existing `finalizeCreatedRecipe` post-success block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156RTErotF2Uqj5BMJMgx3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_0156RTErotF2Uqj5BMJMgx3Q)_