### PR TITLE
feat(gallery): filter My Recipes by source recipe (#11)

### DIFF
--- a/recipe-lanes/app/gallery/page.tsx
+++ b/recipe-lanes/app/gallery/page.tsx
@@ -26,8 +26,8 @@ import { LogoutButton } from '@/components/logout-button';
 
 export const dynamic = 'force-dynamic';
 
-export default async function GalleryPage({ searchParams }: { searchParams: Promise<{ q?: string; filter?: string }> }) {
-  const { q: query, filter: rawFilter } = await searchParams;
+export default async function GalleryPage({ searchParams }: { searchParams: Promise<{ q?: string; filter?: string; sourceId?: string }> }) {
+  const { q: query, filter: rawFilter, sourceId } = await searchParams;
   const filter = rawFilter || 'public';
   const session = await getAuthService().verifyAuth();
   
@@ -38,6 +38,11 @@ export default async function GalleryPage({ searchParams }: { searchParams: Prom
       if (filter === 'mine') {
           if (!session) return <Login />;
           recipes = await getDataService().getUserRecipes(session.uid);
+      } else if (filter === 'source') {
+          if (!session) return <Login />;
+          // My copies of a specific source recipe (issue #11). Without a
+          // sourceId there is nothing to filter on, so show an empty result.
+          recipes = sourceId ? await getDataService().checkExistingCopies(sourceId, session.uid) : [];
       } else if (filter === 'starred') {
           if (!session) return <Login />;
           recipes = await getDataService().getStarredRecipes(session.uid);
@@ -136,10 +141,10 @@ export default async function GalleryPage({ searchParams }: { searchParams: Prom
         <div className="flex flex-col md:flex-row md:items-end justify-between gap-6 border-b border-zinc-800 pb-6">
             <div>
                 <h1 className="text-3xl font-bold tracking-tight text-zinc-100 flex items-center gap-3">
-                    {filter === 'mine' ? 'My Recipes' : filter === 'starred' ? 'Starred Recipes' : 'Community Gallery'}
+                    {filter === 'mine' ? 'My Recipes' : filter === 'source' ? 'My Copies' : filter === 'starred' ? 'Starred Recipes' : 'Community Gallery'}
                 </h1>
                 <p className="text-zinc-500 text-sm mt-1">
-                    {filter === 'mine' ? 'Recipes you created' : filter === 'starred' ? 'Your favorites' : 'Explore recipes visualized by the community'}
+                    {filter === 'mine' ? 'Recipes you created' : filter === 'source' ? 'Your copies of this recipe' : filter === 'starred' ? 'Your favorites' : 'Explore recipes visualized by the community'}
                 </p>
             </div>
 

--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -871,8 +871,7 @@ const handleVisualize = async () => {
                 {/* Existing Copies Banner - Hide if Fork Prompt is active */}
                 {existingCopies && existingCopies.length > 0 && !showForkPrompt && !existingCopiesDismissed && (
                     <Banner color="blue" onDismiss={() => setExistingCopiesDismissed(true)}>
-                        {/* TODO: Filter by sourceId when implemented */}
-                        <span>You have <Link href="/gallery?filter=mine" className="underline font-bold hover:text-white">{existingCopies.length} existing {existingCopies.length > 1 ? 'copies' : 'copy'}</Link> of this recipe. <Link href={`/lanes?id=${existingCopies[0].id}`} className="underline font-bold hover:text-white">Go to latest?</Link></span>
+                        <span>You have <Link href={`/gallery?filter=source&sourceId=${recipeId}`} className="underline font-bold hover:text-white">{existingCopies.length} existing {existingCopies.length > 1 ? 'copies' : 'copy'}</Link> of this recipe. <Link href={`/lanes?id=${existingCopies[0].id}`} className="underline font-bold hover:text-white">Go to latest?</Link></span>
                         <div className="flex flex-wrap justify-center gap-2">
                             <button onClick={handleFork} className="underline font-bold hover:text-white">
                                 Save another copy?
@@ -891,8 +890,7 @@ const handleVisualize = async () => {
                 {/* Fork Prompt Banner (Destructive Action Intercept) */}
                 {showForkPrompt && existingCopies && existingCopies.length > 0 && (
                     <Banner color="blue" onDismiss={() => setShowForkPrompt(false)}>
-                        {/* TODO: Filter by sourceId when implemented */}
-                        <span>You have <Link href="/gallery?filter=mine" className="underline font-bold hover:text-white">{existingCopies.length} existing {existingCopies.length === 1 ? 'copy' : 'copies'}</Link> of this recipe, to make changes, open one of these. Any further changes won&apos;t be saved.</span>
+                        <span>You have <Link href={`/gallery?filter=source&sourceId=${recipeId}`} className="underline font-bold hover:text-white">{existingCopies.length} existing {existingCopies.length === 1 ? 'copy' : 'copies'}</Link> of this recipe, to make changes, open one of these. Any further changes won&apos;t be saved.</span>
                         <div className="flex gap-2">
                             <button onClick={handleFork} className="underline font-bold hover:text-white">
                                 Save another copy

--- a/recipe-lanes/tests/gallery-view.test.ts
+++ b/recipe-lanes/tests/gallery-view.test.ts
@@ -53,6 +53,37 @@ describe('Gallery View (Memory)', () => {
         assert.ok(!myTitles.includes('Other Public'));
     });
 
+    // Backs the gallery `?filter=source&sourceId=...` view (issue #11): the
+    // "Existing Copies" banner links here, and the gallery delegates to
+    // checkExistingCopies to show only the current user's copies of a source.
+    it('should filter my copies of a given source recipe (issue #11)', async () => {
+        const sourceId = 'src-1';
+        await service.saveRecipe({ ...mockGraph, title: 'My Copy A', sourceId }, undefined, 'me', 'private');
+        await service.saveRecipe({ ...mockGraph, title: 'My Copy B', sourceId }, undefined, 'me', 'private');
+        // A copy of a different source — must not appear.
+        await service.saveRecipe({ ...mockGraph, title: 'Copy Of Other Source', sourceId: 'src-2' }, undefined, 'me', 'private');
+        // Another user's copy of the same source — must not appear.
+        await service.saveRecipe({ ...mockGraph, title: 'Their Copy', sourceId }, undefined, 'someone-else', 'private');
+        // An unrelated recipe with no sourceId — must not appear.
+        await service.saveRecipe({ ...mockGraph, title: 'Not A Copy' }, undefined, 'me', 'private');
+
+        const copies = await service.checkExistingCopies(sourceId, 'me');
+        const titles = copies.map((r: any) => r.title);
+
+        assert.strictEqual(copies.length, 2);
+        assert.ok(titles.includes('My Copy A'));
+        assert.ok(titles.includes('My Copy B'));
+        assert.ok(!titles.includes('Copy Of Other Source'));
+        assert.ok(!titles.includes('Their Copy'));
+        assert.ok(!titles.includes('Not A Copy'));
+    });
+
+    it('should return no copies for a source that has none (issue #11)', async () => {
+        await service.saveRecipe({ ...mockGraph, title: 'Solo', sourceId: 'src-9' }, undefined, 'me', 'private');
+        const copies = await service.checkExistingCopies('src-does-not-exist', 'me');
+        assert.strictEqual(copies.length, 0);
+    });
+
     it('should handle starred recipes', async () => {
         const id1 = await service.saveRecipe({ ...mockGraph, title: 'Starred One' }, undefined, 'other', 'public');
         await service.toggleStar(id1, 'me');


### PR DESCRIPTION
Closes #11.

## What & why

The "Existing Copies" banner in the lanes editor told the user they had N copies of the recipe they were viewing, but its link went to **all** of My Recipes (`?filter=mine`). Issue #11 asks for the link to land on a view filtered to *just the copies of that source recipe*, via `?filter=source&sourceId=...`.

- **`app/gallery/page.tsx`** — new `filter === 'source'` branch. It reuses the existing `checkExistingCopies(sourceId, uid)` data-service query, which already filters `ownerId == uid && sourceId == sourceId` server-side (the required `ownerId + sourceId + created_at` composite index is already present in `firestore.indexes.json`). Added `sourceId` to the `searchParams` type and a "My Copies" / "Your copies of this recipe" title+subtitle. Requires a session, and returns an empty list when no `sourceId` is supplied (nothing to filter on).
- **`app/lanes/page.tsx`** — both existing-copies banners (the passive banner and the fork-prompt banner) now link to `/gallery?filter=source&sourceId=${recipeId}` and the two `TODO: Filter by sourceId when implemented` notes are removed. `recipeId` is the id of the recipe being viewed (the source the copies were made from) and is guaranteed non-null wherever these banners render, since `existingCopies` is only populated by `checkExistingCopiesAction(recipeId)`.

Smallest change that closes the issue: no new data-service method, no schema/mapper changes — the existing `checkExistingCopies` query is exactly "the current user's copies of source X". The `data-service.ts` god file was **not** touched.

## How verified

- **New pure unit tests** in `tests/gallery-view.test.ts` (tier: `test:unit:pure`, runs in the CI **fast-checks** job), exercising the exact query the `?filter=source` view delegates to:
  - `should filter my copies of a given source recipe (issue #11)` — returns only my copies of a source; excludes copies of a *different* source, another user's copies of the *same* source, and unrelated non-copies.
  - `should return no copies for a source that has none (issue #11)` — empty result for an unknown source id.
- **Local gate (pre-commit hook), all green:** `npm run lint` (0 errors), `npm run typecheck` (clean), and the full `npm run test:unit:pure` — **328/328 pass**, including the two new cases.
- The `e2e` suite runs unchanged as a regression guard on the gallery/banner flow.
- I'm watching CI (`fast-checks`, `integration`, `e2e`) and will report the outcome; these jobs should execute (the change touches `app/` and `tests/`, not docs-only).

## Risks / unsure about

- **No component/e2e test for the banner href itself.** The banners live in the `app/lanes/page.tsx` god file (client component); the link is a two-token string change (`filter=mine` → `filter=source&sourceId=${recipeId}`). The *data* behavior the link depends on is covered at the pure-unit tier. An e2e assertion on the banner href could be added if desired.
- **Copies of copies:** the filter keys on the immediate `sourceId`. A copy-of-a-copy has the intermediate copy as its `sourceId`, so it appears under that intermediate recipe, not the original — this matches how `checkExistingCopies` (and the banner's own count) already behave, so it's consistent, not a regression.
- **Empty `sourceId`:** if the URL is hit with `?filter=source` and no `sourceId`, the view shows an empty "My Copies" list rather than erroring. The banner always supplies a `sourceId`, so this only affects hand-edited URLs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1dW8k5vAorp5z8kgUf79v)_