### PR TITLE
feat(gallery): filter My Recipes to copies of a source recipe (#11)

### DIFF
--- a/recipe-lanes/app/gallery/page.tsx
+++ b/recipe-lanes/app/gallery/page.tsx
@@ -26,16 +26,22 @@ import { LogoutButton } from '@/components/logout-button';
 
 export const dynamic = 'force-dynamic';
 
-export default async function GalleryPage({ searchParams }: { searchParams: Promise<{ q?: string; filter?: string }> }) {
-  const { q: query, filter: rawFilter } = await searchParams;
+export default async function GalleryPage({ searchParams }: { searchParams: Promise<{ q?: string; filter?: string; sourceId?: string }> }) {
+  const { q: query, filter: rawFilter, sourceId } = await searchParams;
   const filter = rawFilter || 'public';
   const session = await getAuthService().verifyAuth();
-  
+
   let recipes = [];
   let errorMsg = null;
 
   try {
-      if (filter === 'mine') {
+      if (filter === 'source') {
+          // My copies of a specific source recipe (see the "existing copies" banner in /lanes).
+          if (!session) return <Login />;
+          recipes = sourceId
+              ? await getDataService().checkExistingCopies(sourceId, session.uid)
+              : await getDataService().getUserRecipes(session.uid);
+      } else if (filter === 'mine') {
           if (!session) return <Login />;
           recipes = await getDataService().getUserRecipes(session.uid);
       } else if (filter === 'starred') {
@@ -136,10 +142,10 @@ export default async function GalleryPage({ searchParams }: { searchParams: Prom
         <div className="flex flex-col md:flex-row md:items-end justify-between gap-6 border-b border-zinc-800 pb-6">
             <div>
                 <h1 className="text-3xl font-bold tracking-tight text-zinc-100 flex items-center gap-3">
-                    {filter === 'mine' ? 'My Recipes' : filter === 'starred' ? 'Starred Recipes' : 'Community Gallery'}
+                    {filter === 'mine' ? 'My Recipes' : filter === 'starred' ? 'Starred Recipes' : filter === 'source' ? 'Recipe Copies' : 'Community Gallery'}
                 </h1>
                 <p className="text-zinc-500 text-sm mt-1">
-                    {filter === 'mine' ? 'Recipes you created' : filter === 'starred' ? 'Your favorites' : 'Explore recipes visualized by the community'}
+                    {filter === 'mine' ? 'Recipes you created' : filter === 'starred' ? 'Your favorites' : filter === 'source' ? 'Your copies of this recipe' : 'Explore recipes visualized by the community'}
                 </p>
             </div>
 

--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -871,8 +871,7 @@ const handleVisualize = async () => {
                 {/* Existing Copies Banner - Hide if Fork Prompt is active */}
                 {existingCopies && existingCopies.length > 0 && !showForkPrompt && !existingCopiesDismissed && (
                     <Banner color="blue" onDismiss={() => setExistingCopiesDismissed(true)}>
-                        {/* TODO: Filter by sourceId when implemented */}
-                        <span>You have <Link href="/gallery?filter=mine" className="underline font-bold hover:text-white">{existingCopies.length} existing {existingCopies.length > 1 ? 'copies' : 'copy'}</Link> of this recipe. <Link href={`/lanes?id=${existingCopies[0].id}`} className="underline font-bold hover:text-white">Go to latest?</Link></span>
+                        <span>You have <Link href={`/gallery?filter=source&sourceId=${recipeId}`} className="underline font-bold hover:text-white">{existingCopies.length} existing {existingCopies.length > 1 ? 'copies' : 'copy'}</Link> of this recipe. <Link href={`/lanes?id=${existingCopies[0].id}`} className="underline font-bold hover:text-white">Go to latest?</Link></span>
                         <div className="flex flex-wrap justify-center gap-2">
                             <button onClick={handleFork} className="underline font-bold hover:text-white">
                                 Save another copy?
@@ -891,8 +890,7 @@ const handleVisualize = async () => {
                 {/* Fork Prompt Banner (Destructive Action Intercept) */}
                 {showForkPrompt && existingCopies && existingCopies.length > 0 && (
                     <Banner color="blue" onDismiss={() => setShowForkPrompt(false)}>
-                        {/* TODO: Filter by sourceId when implemented */}
-                        <span>You have <Link href="/gallery?filter=mine" className="underline font-bold hover:text-white">{existingCopies.length} existing {existingCopies.length === 1 ? 'copy' : 'copies'}</Link> of this recipe, to make changes, open one of these. Any further changes won&apos;t be saved.</span>
+                        <span>You have <Link href={`/gallery?filter=source&sourceId=${recipeId}`} className="underline font-bold hover:text-white">{existingCopies.length} existing {existingCopies.length === 1 ? 'copy' : 'copies'}</Link> of this recipe, to make changes, open one of these. Any further changes won&apos;t be saved.</span>
                         <div className="flex gap-2">
                             <button onClick={handleFork} className="underline font-bold hover:text-white">
                                 Save another copy

--- a/recipe-lanes/tests/gallery-view.test.ts
+++ b/recipe-lanes/tests/gallery-view.test.ts
@@ -53,6 +53,35 @@ describe('Gallery View (Memory)', () => {
         assert.ok(!myTitles.includes('Other Public'));
     });
 
+    it('filters to a user\'s copies of a specific source recipe (issue #11)', async () => {
+        // The source recipe being viewed.
+        const sourceId = await service.saveRecipe({ ...mockGraph, title: 'Original' }, undefined, 'me', 'public');
+
+        // Two of MY copies of that source.
+        await service.saveRecipe({ ...mockGraph, title: 'My Copy 1', sourceId }, undefined, 'me', 'private');
+        await service.saveRecipe({ ...mockGraph, title: 'My Copy 2', sourceId }, undefined, 'me', 'private');
+
+        // Another user's copy of the SAME source — must not leak into my view.
+        await service.saveRecipe({ ...mockGraph, title: 'Their Copy', sourceId }, undefined, 'other', 'private');
+
+        // My copy of a DIFFERENT source — must not appear either.
+        await service.saveRecipe({ ...mockGraph, title: 'Unrelated Copy', sourceId: 'other-source' }, undefined, 'me', 'private');
+
+        const copies = await service.checkExistingCopies(sourceId, 'me');
+        const titles = copies.map((r: any) => r.title).sort();
+
+        assert.deepStrictEqual(titles, ['My Copy 1', 'My Copy 2']);
+        assert.ok(!titles.includes('Their Copy'));
+        assert.ok(!titles.includes('Unrelated Copy'));
+        assert.ok(!titles.includes('Original'));
+    });
+
+    it('returns no copies for a source that has none', async () => {
+        const sourceId = await service.saveRecipe({ ...mockGraph, title: 'Lonely Original' }, undefined, 'me', 'public');
+        const copies = await service.checkExistingCopies(sourceId, 'me');
+        assert.strictEqual(copies.length, 0);
+    });
+
     it('should handle starred recipes', async () => {
         const id1 = await service.saveRecipe({ ...mockGraph, title: 'Starred One' }, undefined, 'other', 'public');
         await service.toggleStar(id1, 'me');


### PR DESCRIPTION
Closes #11.

## What & why

When a user views a recipe they've copied before, the "Existing Copies" banner in `/lanes` told them *"You have N existing copies of this recipe"* — but the link went to **all** of My Recipes, not the copies of *that* recipe. This implements the `?filter=source&sourceId=...` view the issue asked for.

- **`app/gallery/page.tsx`** — new `filter === 'source'` branch. When `sourceId` is present it lists the signed-in user's copies of that source via the existing `checkExistingCopies(sourceId, uid)` data method (an `ownerId == uid && sourceId == source` query); with no `sourceId` it degrades gracefully to all My Recipes. Requires a session, mirroring the `mine`/`starred` branches. Added a "Recipe Copies" / "Your copies of this recipe" heading.
- **`app/lanes/page.tsx`** — both existing-copies banners (the info banner and the fork-prompt banner) now link to `/gallery?filter=source&sourceId=${recipeId}`, where `recipeId` is the currently-viewed source recipe. Removed the two stale `TODO: Filter by sourceId` comments. These banners only render once `existingCopies.length > 0`, which the copies-check effect only sets when `recipeId` is truthy, so no null `sourceId` can reach the URL.

No new data-service method was needed — `checkExistingCopies` already performed exactly this owner+source query for the banner itself, so the gallery now reuses it. The high-blast-radius files were touched minimally (a two-line link change each in `lanes/page.tsx`; no store/merge logic).

## How verified

- **New pure unit tests** in `recipe-lanes/tests/gallery-view.test.ts` (tier: `test:unit:pure` → CI **fast-checks** job), exercising the exact logic the new gallery branch relies on:
  - *"filters to a user's copies of a specific source recipe (issue #11)"* — asserts `checkExistingCopies(sourceId, 'me')` returns only my copies of that source, and excludes another user's copy of the same source, my copy of a different source, and the source recipe itself.
  - *"returns no copies for a source that has none"* — empty result for a source with no copies.
- **Local gate, all green:** `npm run lint` (0 errors), `npm run typecheck` (clean), and the full `npm run test:unit:pure` — **328/328 pass** (also re-run green by the pre-commit hook).
- This change touches `app/` and `tests/`, so the CI `fast-checks`, `integration`, and `e2e` jobs execute (not docs-only). I'm watching CI and will report the outcome.

## Risks / unsure about

- The gallery `filter=source` branch and the banner `<Link>` hrefs are wired to the unit-tested `checkExistingCopies` method, but the server-component branch and JSX links themselves aren't unit-tested — that matches this repo's convention (existing gallery tests target the data-service methods, not the component); the `e2e` tier covers UI wiring.
- With `filter=source` and a missing/blank `sourceId`, the view falls back to all My Recipes rather than erroring — a deliberate graceful degrade for a hand-edited URL.
- No new Firestore index is required: `checkExistingCopies` was already in use in production for the banner's copy count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQG1ihgUpv9D3kv4K6SHWD

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQG1ihgUpv9D3kv4K6SHWD)_