### PR TITLE
fix(lanes): keep carrot/pan legend visible while any icon is still loading (#60)

### DIFF
--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -32,7 +32,7 @@ import { standardizeIngredientName, formatDisplayName } from '@/lib/utils';
 import { IngredientsSidebar } from '@/components/recipe-lanes/ui/ingredients-sidebar';
 import { TimelineView } from '@/components/recipe-lanes/timeline-view';
 import type { RecipeGraph, LayoutModeId } from '@/lib/recipe-lanes/types';
-import { hasNodeIcon, preserveNodeShortlist, getNodeShortlistLength, getNodeIngredientName, getNodeHydeQueries, extractBatchIngredients } from '@/lib/recipe-lanes/model-utils';
+import { hasPendingIcons, preserveNodeShortlist, getNodeShortlistLength, getNodeIngredientName, getNodeHydeQueries, extractBatchIngredients } from '@/lib/recipe-lanes/model-utils';
 import { useRecipeStore } from '@/lib/stores/recipe-store';
 import { LayoutMode } from '@/lib/recipe-lanes/layout';
 import { Wand2, ChefHat, ArrowRight, Code, MessageSquare, Send, LayoutDashboard, Kanban, GitGraph, Columns, AlignCenter, Network, Sparkles, CircleDot, Share2, Sprout, Move, RotateCw, Orbit, Type, Play, Pause, Pencil, RotateCcw, Globe, Lock, Plus, LayoutGrid, Star, User, ShoppingBasket, HelpCircle, Github, Camera } from 'lucide-react';
@@ -760,7 +760,10 @@ const handleVisualize = async () => {
 
     if (authLoading) return <div className="min-h-screen bg-zinc-950 flex items-center justify-center text-zinc-500 font-mono">Loading...</div>;
   
-  const hasIcons = graph?.nodes.some(n => hasNodeIcon(n));
+  // Show the carrot/pan legend while ANY icon is still unloaded (issue #60):
+  // it must stay up as long as a placeholder is visible, not vanish once the
+  // first icon resolves.
+  const iconsPending = hasPendingIcons(graph ?? null);
   const isPublic = graph?.visibility === 'public';
 
   // Common Nav Item Styles
@@ -1246,7 +1249,7 @@ const handleVisualize = async () => {
                     {/* Desktop Layout (Floating) */}
                     <div className="hidden md:block absolute bottom-4 left-4 p-3 bg-white/90 backdrop-blur rounded-lg shadow-lg border border-zinc-200 text-xs text-zinc-700 pointer-events-auto">
                         <div className="font-bold text-zinc-400 uppercase tracking-widest text-[10px]">Legend</div>
-                        {!hasIcons && (
+                        {iconsPending && (
                             <>
                                 <div className="flex items-center gap-2"><span className="text-xl">🥕</span> Ingredients</div>
                                 <div className="flex items-center gap-2"><span className="text-xl">🍳</span> Actions</div>
@@ -1294,7 +1297,7 @@ const handleVisualize = async () => {
                     <div className="md:hidden flex h-16 bg-white/95 backdrop-blur border-t border-zinc-200 pointer-events-auto">
                         {/* Legend (Left Half) */}
                         <div className="w-1/2 p-2 text-[10px] text-zinc-600 border-r border-zinc-100 flex flex-col justify-center gap-1">
-                            {!hasIcons && <div className="truncate">🥕 Ingredients  🍳 Actions</div>}
+                            {iconsPending && <div className="truncate">🥕 Ingredients  🍳 Actions</div>}
                             <div className="font-bold text-zinc-800">Tap & Hold: Select Branch</div>
                         </div>
                         

--- a/recipe-lanes/lib/recipe-lanes/model-utils.ts
+++ b/recipe-lanes/lib/recipe-lanes/model-utils.ts
@@ -436,6 +436,18 @@ export function hasNodeIcon(node: RecipeNode): boolean {
 }
 
 /**
+ * True when at least one node in the graph is still awaiting its icon — i.e.
+ * rendering a placeholder carrot/pan rather than a resolved icon. Drives the
+ * "🥕 Ingredients / 🍳 Actions" legend: it should stay visible as long as any
+ * icon hasn't loaded, and disappear only once every node has one. Returns
+ * false for a null/empty graph (no placeholders to explain). See issue #60.
+ */
+export function hasPendingIcons(graph: RecipeGraph | null): boolean {
+    if (!graph) return false;
+    return graph.nodes.some(n => !hasNodeIcon(n));
+}
+
+/**
  * Reconstructs the public Firebase Storage URL from a path.
  * In emulator environments (local-project-id), points to the Storage emulator.
  * Format: https://firebasestorage.googleapis.com/v0/b/{bucket}/o/{encoded-path}?alt=media

--- a/recipe-lanes/tests/model-utils.test.ts
+++ b/recipe-lanes/tests/model-utils.test.ts
@@ -5,7 +5,15 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { RecipeGraph, RecipeNode } from '../lib/recipe-lanes/types';
-import { getNodeStatus, setNodeStatus, prependToShortlist, buildShortlistEntry, toRecipeIcon } from '../lib/recipe-lanes/model-utils';
+import { getNodeStatus, setNodeStatus, prependToShortlist, buildShortlistEntry, toRecipeIcon, hasNodeIcon, hasPendingIcons } from '../lib/recipe-lanes/model-utils';
+
+/** A node whose current shortlist entry resolves to a real icon (id set). */
+function withIcon(id: string): RecipeNode {
+    return makeNode(id, {
+        iconShortlist: [buildShortlistEntry({ id: `icon-${id}`, visualDescription: `v-${id}` }, 'generated')],
+        shortlistIndex: 0,
+    });
+}
 
 function makeNode(id: string, overrides: Partial<RecipeNode> = {}): RecipeNode {
     return {
@@ -54,6 +62,31 @@ describe('model-utils setNodeStatus/getNodeStatus', () => {
         const changed = setNodeStatus(g, 'c', 'failed');
         assert.equal(changed, false);
         assert.equal(getNodeStatus(g, 'c'), 'failed');
+    });
+});
+
+describe('hasPendingIcons (issue #60 — carrot/pan legend visibility)', () => {
+    it('returns false for a null or empty graph', () => {
+        assert.equal(hasPendingIcons(null), false);
+        assert.equal(hasPendingIcons(makeGraph([])), false);
+    });
+
+    it('returns true when NO node has an icon yet (all placeholders)', () => {
+        const g = makeGraph([makeNode('a'), makeNode('b')]);
+        assert.equal(hasPendingIcons(g), true);
+    });
+
+    it('stays true while SOME icons are still unloaded (the bug: legend vanished once the first icon loaded)', () => {
+        // One node resolved, one still a placeholder → legend must remain visible.
+        const g = makeGraph([withIcon('a'), makeNode('b')]);
+        assert.equal(hasNodeIcon(g.nodes[0]), true);
+        assert.equal(hasNodeIcon(g.nodes[1]), false);
+        assert.equal(hasPendingIcons(g), true);
+    });
+
+    it('returns false only once EVERY node has a resolved icon', () => {
+        const g = makeGraph([withIcon('a'), withIcon('b')]);
+        assert.equal(hasPendingIcons(g), false);
     });
 });
 


### PR DESCRIPTION
Closes #60.

## What & why

The lanes legend's "🥕 Ingredients / 🍳 Actions" explainer tells the user what the placeholder carrot/pan icons mean while real icons are being generated. It was gated on:

```ts
const hasIcons = graph?.nodes.some(n => hasNodeIcon(n));   // ...{!hasIcons && <legend/>}
```

`hasIcons` is true as soon as **any one** node resolves an icon, so the explainer vanished the moment the *first* icon loaded — even though other nodes were still showing placeholder carrots/pans. Issue #60: *"So long as there's an icon that hasn't loaded, the legend should show carrot and pan."*

## The change (smallest that closes it)

- **`lib/recipe-lanes/model-utils.ts`** — new pure helper `hasPendingIcons(graph)`: returns `true` while **any** node still lacks a resolved icon (`!hasNodeIcon(n)`), and `false` for a null/empty graph (no placeholders to explain). This is the exact inverse condition the legend needs.
- **`app/lanes/page.tsx`** — replace `hasIcons`/`!hasIcons` with `const iconsPending = hasPendingIcons(graph ?? null)` and render both the desktop and mobile legends when `iconsPending`. The explainer now stays up until **every** node has an icon, then hides.

The god-file (`app/lanes/page.tsx`) edit is confined to the one derived flag and the two `{iconsPending && …}` conditions — no logic beyond swapping the predicate. All decision logic lives in the pure, unit-tested helper.

## How verified

- **New pure unit tests** — `tests/model-utils.test.ts`, suite `hasPendingIcons (issue #60 …)` (tier: `test:unit:pure`, runs in the CI **fast-checks** job). Cases:
  - null / empty graph → `false`
  - no node has an icon yet (all placeholders) → `true`
  - **some** icons still unloaded (the regression: one resolved + one placeholder) → `true` — this is the exact scenario the old `hasIcons` got wrong
  - every node has a resolved icon → `false`
- **Local gate (pre-commit hook), all green:** `npm run lint` (0 errors, warnings are pre-existing repo-wide), `npm run typecheck` (clean), and the full `npm run test:unit:pure` — **330/330 pass**, including the 4 new cases.
- The `integration` and `e2e` suites run unchanged as regression guards (the change touches `app/`, `lib/`, `tests/`, so CI is not docs-only-skipped).

## Risks / unsure about

- **"Loaded" = model-level, not pixel-level.** `hasNodeIcon` reflects whether a node has a resolved icon in its shortlist, not whether the `<img>` has finished painting in the browser. That matches the placeholder-render condition (the node shows the carrot/pan emoji exactly when it has no resolved icon URL), so it's the right signal for this legend.
- **No component/e2e test for the rendered legend visibility** — the conditional lives in the `app/lanes/page.tsx` client god-file; the branch it now keys on (`hasPendingIcons`) is covered at the pure-unit tier. An e2e assertion on the legend node could be added if desired.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M6NpXn7YLKki44ikrwdpte)_