### PR TITLE
fix: guard against non-finite React Flow handle coords in edge geometry (#30)

### DIFF
--- a/recipe-lanes/components/recipe-lanes/edges/floating-edge.tsx
+++ b/recipe-lanes/components/recipe-lanes/edges/floating-edge.tsx
@@ -31,7 +31,7 @@ interface EdgeProps {
   style?: React.CSSProperties;
   data?: any;
 }
-import { getEdgeParams } from '../../../lib/recipe-lanes/graph-utils';
+import { getEdgeParams, isFiniteHandlePos } from '../../../lib/recipe-lanes/graph-utils';
 import { useRecipeStore } from '../../../lib/stores/recipe-store';
 
 function FloatingEdge({ id, source, target, markerEnd, style, data, sourceX, sourceY, targetX, targetY }: EdgeProps) {
@@ -45,11 +45,16 @@ function FloatingEdge({ id, source, target, markerEnd, style, data, sourceX, sou
     return null;
   }
 
+  // Only forward handle positions once RF has actually measured them. Before
+  // then RF can supply NaN coords, and typeof NaN === 'number' would sneak them
+  // past a plain typeof check into the edge geometry (issue #30).
+  const sourceHandle = { x: sourceX, y: sourceY };
+  const targetHandle = { x: targetX, y: targetY };
   const { sx, sy, tx, ty, sourcePos, targetPos } = getEdgeParams(
       sourceNode,
       targetNode,
-      (typeof sourceX === 'number' && typeof sourceY === 'number') ? { x: sourceX, y: sourceY } : undefined,
-      (typeof targetX === 'number' && typeof targetY === 'number') ? { x: targetX, y: targetY } : undefined,
+      isFiniteHandlePos(sourceHandle) ? sourceHandle : undefined,
+      isFiniteHandlePos(targetHandle) ? targetHandle : undefined,
       {
         source: sourceNode.data?.isLeaf ? leafNodeScale : 1,
         target: targetNode.data?.isLeaf ? leafNodeScale : 1,

--- a/recipe-lanes/lib/recipe-lanes/graph-utils.ts
+++ b/recipe-lanes/lib/recipe-lanes/graph-utils.ts
@@ -51,6 +51,21 @@ function getFrame(node: Node, handlePos?: { x: number, y: number }, scale = 1): 
     return getClassicFrame(handlePos, isIngredient, scale);
 }
 
+/**
+ * A handle position handed to us by React Flow is only usable when both
+ * coordinates are finite numbers. During hydration (after a save/reload, before
+ * React Flow has measured each node's handle bounds) RF can pass non-finite
+ * coordinates — most commonly `NaN` from `undefined` bounds arithmetic. Because
+ * `typeof NaN === 'number'`, a plain `typeof` guard lets those through, and they
+ * poison the intersection math below into `NaN` edge endpoints. That renders as
+ * arrows "detached" from their nodes or pointing at (0,0)-ish garbage — the
+ * intermittent-after-reload symptom in issue #30. Treat a non-finite handle
+ * position as "no handle position" and fall back to node-geometry-derived centers.
+ */
+export function isFiniteHandlePos(pos?: { x: number; y: number } | null): pos is { x: number; y: number } {
+    return !!pos && Number.isFinite(pos.x) && Number.isFinite(pos.y);
+}
+
 // Helper to get center
 function getCenter(node: Node, handlePos?: { x: number, y: number }, scale = 1) {
     const frame = getFrame(node, handlePos, scale);
@@ -159,12 +174,20 @@ export function getEdgeParams(
 ) {
     const sScale = scales?.source ?? 1;
     const tScale = scales?.target ?? 1;
-    const c1 = getCenter(source, sourceHandlePos, sScale);
-    const c2 = getCenter(target, targetHandlePos, tScale);
+
+    // Discard non-finite handle positions (see isFiniteHandlePos) so a single
+    // hydration-time NaN can't propagate into every derived coordinate below.
+    // Sanitizing here — the sole public entry point — covers getCenter, getBBox
+    // and getRadius in one place.
+    const sHandle = isFiniteHandlePos(sourceHandlePos) ? sourceHandlePos : undefined;
+    const tHandle = isFiniteHandlePos(targetHandlePos) ? targetHandlePos : undefined;
+
+    const c1 = getCenter(source, sHandle, sScale);
+    const c2 = getCenter(target, tHandle, tScale);
 
     let sInter, tInter;
 
-    const bbox1 = getBBox(source, sourceHandlePos, sScale);
+    const bbox1 = getBBox(source, sHandle, sScale);
     if (bbox1) {
         sInter = getRectIntersection(c1, c2, bbox1);
     } else {
@@ -172,7 +195,7 @@ export function getEdgeParams(
         sInter = getNodeIntersection(c1, c2, r1);
     }
 
-    const bbox2 = getBBox(target, targetHandlePos, tScale);
+    const bbox2 = getBBox(target, tHandle, tScale);
     if (bbox2) {
         tInter = getRectIntersection(c2, c1, bbox2);
     } else {

--- a/recipe-lanes/tests/graph.test.ts
+++ b/recipe-lanes/tests/graph.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { getEdgeParams } from '../lib/recipe-lanes/graph-utils';
+import { getEdgeParams, isFiniteHandlePos } from '../lib/recipe-lanes/graph-utils';
 import { calculateBridgeEdges, MinimalEdge } from '../lib/recipe-lanes/graph-logic';
 
 // --- HELPERS ---
@@ -22,6 +22,56 @@ describe('Graph Utilities & Logic', () => {
             const result = getEdgeParams(n1, n2);
             assert.ok(Math.abs(result.sx - 50) < 1);
             assert.ok(Math.abs(result.sy - 86) < 1);
+        });
+
+        // Regression for issue #30: after save/reload, React Flow can hand the
+        // floating edge non-finite handle coordinates before it has measured a
+        // node's handle bounds. typeof NaN === 'number', so a plain typeof guard
+        // let those through and the intersection math produced NaN endpoints —
+        // arrows "detached" from their nodes / pointing at garbage coordinates.
+        it('returns finite endpoints when handle positions are NaN (hydration)', () => {
+            const n1 = createNode('1', 0, 0);
+            const n2 = createNode('2', 0, 200);
+            const result = getEdgeParams(n1, n2, { x: NaN, y: NaN }, { x: NaN, y: NaN });
+            for (const v of [result.sx, result.sy, result.tx, result.ty]) {
+                assert.ok(Number.isFinite(v), `expected a finite coordinate, got ${v}`);
+            }
+        });
+
+        it('treats non-finite handle positions the same as no handle position', () => {
+            const n1 = createNode('1', 0, 0);
+            const n2 = createNode('2', 0, 200);
+            const noHandles = getEdgeParams(n1, n2);
+            const badHandles = getEdgeParams(n1, n2, { x: NaN, y: 5 }, { x: Infinity, y: -Infinity });
+            assert.ok(Math.abs(noHandles.sx - badHandles.sx) < 1e-9);
+            assert.ok(Math.abs(noHandles.sy - badHandles.sy) < 1e-9);
+            assert.ok(Math.abs(noHandles.tx - badHandles.tx) < 1e-9);
+            assert.ok(Math.abs(noHandles.ty - badHandles.ty) < 1e-9);
+        });
+
+        it('still honors a valid (finite) handle position', () => {
+            const n1 = createNode('1', 0, 0);
+            const n2 = createNode('2', 0, 200);
+            const result = getEdgeParams(n1, n2, { x: 50, y: 40 }, { x: 50, y: 240 });
+            for (const v of [result.sx, result.sy, result.tx, result.ty]) {
+                assert.ok(Number.isFinite(v));
+            }
+        });
+    });
+
+    describe('isFiniteHandlePos', () => {
+        it('accepts finite coordinate pairs (including zero and negatives)', () => {
+            assert.strictEqual(isFiniteHandlePos({ x: 0, y: 0 }), true);
+            assert.strictEqual(isFiniteHandlePos({ x: -12.5, y: 300 }), true);
+        });
+
+        it('rejects nullish and non-finite coordinates', () => {
+            assert.strictEqual(isFiniteHandlePos(undefined), false);
+            assert.strictEqual(isFiniteHandlePos(null), false);
+            assert.strictEqual(isFiniteHandlePos({ x: NaN, y: 0 }), false);
+            assert.strictEqual(isFiniteHandlePos({ x: 0, y: NaN }), false);
+            assert.strictEqual(isFiniteHandlePos({ x: Infinity, y: 0 }), false);
+            assert.strictEqual(isFiniteHandlePos({ x: 0, y: -Infinity }), false);
         });
     });
 


### PR DESCRIPTION
Closes #30.

## What & why

Issue #30: graph arrows detach or point to incorrect coordinates after save/reload — intermittently. The owner's triage narrowed it to the edge-geometry helpers in `lib/recipe-lanes/graph-utils.ts` misbehaving during hydration, before React Flow has measured node/handle bounds.

Root cause (traced): the floating edge (`components/recipe-lanes/edges/floating-edge.tsx`) passes React Flow's `sourceX/sourceY/targetX/targetY` into `getEdgeParams` as handle positions. Before RF measures a node's handle bounds after a reload, those coordinates can be **`NaN`** (undefined-bounds arithmetic). The guards were `typeof sourceX === 'number'` — but `typeof NaN === 'number'` is `true`, so `NaN` slipped through. It then propagated through `getCenter` → `getBBox`/`getNodeIntersection` into **`NaN` edge endpoints**, which render as arrows detached from their nodes or pointing at (0,0)-ish garbage. Once RF re-measures and re-renders, coordinates self-correct — hence the "intermittent, after reload" symptom.

## The fix (smallest change)

- **`lib/recipe-lanes/graph-utils.ts`** — new pure exported guard `isFiniteHandlePos(pos)` (`!!pos && Number.isFinite(x) && Number.isFinite(y)`). `getEdgeParams` (the sole public entry) now sanitizes both handle positions up front, so a non-finite handle is treated as "no handle position" and falls back to the existing node-geometry-derived centers instead of poisoning `getCenter`/`getBBox`/`getRadius`. Sanitizing at this one point covers all three.
- **`components/recipe-lanes/edges/floating-edge.tsx`** — replaces the weak `typeof` checks with `isFiniteHandlePos`, rejecting `NaN`/`Infinity` at the source (defense in depth).

No node-geometry constants or the reference-preserving store logic were touched; the valid-handle path is unchanged, so correctly-measured edges render exactly as before. `0` is intentionally still accepted (a node/handle legitimately at the origin is finite).

## How verified

Added to `tests/graph.test.ts` (pure tier — already registered in the `test:unit:pure` list, runs in the CI **fast-checks** job):
- **`returns finite endpoints when handle positions are NaN (hydration)`** — the direct regression: `getEdgeParams(n1, n2, {x:NaN,y:NaN}, {x:NaN,y:NaN})` must yield finite `sx/sy/tx/ty`. This test **fails on the pre-fix math** (I confirmed it produces `NaN` before the sanitization) and passes after.
- **`treats non-finite handle positions the same as no handle position`** — `NaN`/`Infinity` handles produce exactly the no-handle fallback coordinates.
- **`still honors a valid (finite) handle position`** — finite handles are not discarded.
- **`isFiniteHandlePos`** — accepts finite pairs (incl. `0` and negatives); rejects `undefined`/`null`/`NaN`/`Infinity`.

Local gate: `npm run lint` (0 errors), `npm run typecheck` (clean), scoped `tests/graph.test.ts` → 9/9 pass. The pre-commit hook (lint + typecheck + full `test:unit:pure`) ran green on commit. CI's `fast-checks`, `integration`, and `e2e` jobs execute for this change (it touches `lib/`, `components/`, `tests/` — not docs-only).

## Risks / unsure about

- This eliminates the `NaN`-endpoint ("detached arrow") class deterministically. If any residual after-reload misalignment is instead caused by RF supplying a *finite-but-stale* `{0,0}` before measurement, that can't be distinguished from a legitimate origin handle by value alone and is out of scope here — but the reachable, demonstrable defect (NaN through a `typeof` guard) is fixed.
- The non-minimal `node.width ?? 100` fallback in `getCenter`/`getRadius` is effectively dead code (all real recipe nodes are `type: 'minimal'`; lanes carry no edges; timeline nodes use their own edge geometry), so it was left untouched to keep the change minimal.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gq7p2M7bCcbFrpV3N4J8ci)_