### PR TITLE
feat(iac): migrate GCP infra scripts to Terraform (roadmap Tier 3)

### DIFF
--- a/gcp/monitoring/README.md
+++ b/gcp/monitoring/README.md
@@ -1,5 +1,10 @@
 # Icon-forge alerting as code (`gcp/monitoring/`)
 
+> **Superseded by Terraform.** This stack is now declared in
+> [`gcp/terraform/`](../terraform/README.md) (`modules/project-baseline/monitoring.tf`).
+> These scripts remain only until both envs have been imported + applied via
+> Terraform; do not evolve the YAML here — change the Terraform instead.
+
 Source of truth for the **Cloud Monitoring** alert that fires when too many icons
 are forged in a short window (Bug 171). The team originally created this by hand
 in the prod project; these files commit that config and make it reproducible

--- a/gcp/terraform/.gitignore
+++ b/gcp/terraform/.gitignore
@@ -1,0 +1,9 @@
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.auto.tfvars.example
+# Lock files generated on this arm64 Pi would pin arm64-only hashes and break
+# init elsewhere; provider versions are pinned via required_providers instead.
+.terraform.lock.hcl
+crash.log

--- a/gcp/terraform/README.md
+++ b/gcp/terraform/README.md
@@ -1,0 +1,82 @@
+# RecipeLanes infrastructure as Terraform (`gcp/terraform/`)
+
+Terraform is the target home for all hand-rolled GCP infra (agent-isolation
+roadmap, Tier 3). This directory migrates the three existing script bundles
+into one declarative baseline per project:
+
+| Superseded source | Now lives in |
+|---|---|
+| `gcp/monitoring/` (icon-forge alert metric/channel/policy + `apply.sh`) | `modules/project-baseline/monitoring.tf` |
+| `recipe-lanes/scripts/setup-icon-processor-sa.sh` | `modules/project-baseline/icon-processor.tf` |
+| `recipe-lanes/scripts/setup-preview-pipeline.sh` | `modules/project-baseline/apis.tf` + `preview-pipeline.tf` |
+
+The scripts stay in the tree until the owner has run the import + first apply
+for both envs; after that they should be deleted in a follow-up PR.
+
+## Layout
+
+```
+gcp/terraform/
+├── modules/project-baseline/   # everything one project needs (shared)
+├── envs/staging/               # recipe-lanes-staging (preview pipeline ON)
+├── envs/prod/                  # recipe-lanes        (preview pipeline OFF)
+├── bootstrap-state-bucket.sh   # one-time: create gs://recipe-lanes-tfstate
+└── import.sh                   # adopt live resources into state (per env)
+```
+
+- State: GCS backend, bucket `recipe-lanes-tfstate` (in the prod project,
+  versioned), prefixes `envs/staging` and `envs/prod`.
+- IAM is **additive-only** (`google_project_iam_member`). Authoritative IAM
+  resources (`google_project_iam_policy` / `_binding`) are banned here — they
+  read-modify-write whole bindings and can wipe grants made outside Terraform
+  (see the 2026-07-04 authorizedDomains outage postmortem).
+- `enable_preview_pipeline` gates the per-PR preview infra; it is `true` only
+  for staging. Prod's existing `preview` Artifact Registry repo is deliberately
+  left unmanaged.
+
+## First-time adoption runbook (owner, one time per env)
+
+Terraform must **import** the live resources, not re-create them. Staging
+first; prod only after staging converges.
+
+```bash
+# 0. Auth (user creds — the firebase-adminsdk SAs can't read monitoring/IAM)
+gcloud auth login
+gcloud auth application-default login   # what the terraform provider uses
+
+# 1. One-time state bucket
+cd gcp/terraform && ./bootstrap-state-bucket.sh
+
+# 2. Staging
+export TF_VAR_alert_email=you@example.com
+cd envs/staging
+terraform init
+cd ../.. && ./import.sh staging
+cd envs/staging && terraform plan     # expect empty or additive-only
+terraform apply                       # only after reading the plan
+
+# 3. Prod — same dance with `prod`, only after staging is verified
+```
+
+**Read the plan before every apply.** After import the plan should be empty or
+additive-only. Any *change* usually means live config drifted from the old
+scripts (e.g. the hand-tuned prod alert threshold — override with
+`TF_VAR_alert_threshold` / `TF_VAR_alert_alignment_period` if the live values
+should win, or let Terraform converge them deliberately). Any *destroy* is a
+red flag — stop and investigate.
+
+## Day-2 changes
+
+Edit the module / env files, open a PR (plan output pasted into the PR body),
+and apply after merge. Never `terraform apply` unreviewed changes to prod, and
+never fall back to one-off `gcloud` mutations — that recreates the drift this
+directory exists to eliminate.
+
+## Notes
+
+- `terraform validate` needs no credentials and is safe anywhere. `plan`/
+  `apply`/`import` need owner ADC.
+- Alert tunables: `alert_threshold` (default 20) and `alert_alignment_period`
+  (default `86400s`), same defaults as the old `apply.sh`.
+- The log filter in `monitoring.tf` must stay byte-for-byte in sync with
+  `docs/alerting-icon-forge.md`.

--- a/gcp/terraform/bootstrap-state-bucket.sh
+++ b/gcp/terraform/bootstrap-state-bucket.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# One-time bootstrap: create the GCS bucket that holds Terraform state for
+# both envs (prefixes envs/staging and envs/prod). Lives in the PROD project
+# because that's the durable admin home; the bucket itself is tiny.
+#
+# Usage: ./bootstrap-state-bucket.sh   (needs owner gcloud auth)
+
+set -euo pipefail
+
+BUCKET="recipe-lanes-tfstate"
+PROJECT="recipe-lanes"
+LOCATION="us-central1"
+
+if gcloud storage buckets describe "gs://${BUCKET}" --project="${PROJECT}" >/dev/null 2>&1; then
+  echo "Bucket gs://${BUCKET} already exists."
+else
+  echo "Creating gs://${BUCKET} in ${PROJECT} (${LOCATION})..."
+  gcloud storage buckets create "gs://${BUCKET}" \
+    --project="${PROJECT}" \
+    --location="${LOCATION}" \
+    --uniform-bucket-level-access \
+    --public-access-prevention
+fi
+
+# Versioning: lets us recover from a corrupted/clobbered state file.
+gcloud storage buckets update "gs://${BUCKET}" --versioning
+echo "✅ State bucket ready: gs://${BUCKET}"

--- a/gcp/terraform/envs/prod/main.tf
+++ b/gcp/terraform/envs/prod/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_version = ">= 1.7"
+
+  backend "gcs" {
+    bucket = "recipe-lanes-tfstate"
+    prefix = "envs/prod"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "google" {
+  project = "recipe-lanes"
+  region  = "us-central1"
+}
+
+variable "alert_email" {
+  description = "Recipient for icon-forge alerts (pass via TF_VAR_alert_email or terraform.tfvars — not committed)."
+  type        = string
+}
+
+module "baseline" {
+  source = "../../modules/project-baseline"
+
+  project_id     = "recipe-lanes"
+  project_number = "173546820314"
+
+  # Per-PR previews deploy to staging only; prod's existing `preview` Artifact
+  # Registry repo is deliberately left unmanaged.
+  enable_preview_pipeline = false
+
+  alert_email = var.alert_email
+}

--- a/gcp/terraform/envs/staging/main.tf
+++ b/gcp/terraform/envs/staging/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_version = ">= 1.7"
+
+  backend "gcs" {
+    bucket = "recipe-lanes-tfstate"
+    prefix = "envs/staging"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "google" {
+  project = "recipe-lanes-staging"
+  region  = "us-central1"
+}
+
+variable "alert_email" {
+  description = "Recipient for icon-forge alerts (pass via TF_VAR_alert_email or terraform.tfvars — not committed)."
+  type        = string
+}
+
+module "baseline" {
+  source = "../../modules/project-baseline"
+
+  project_id              = "recipe-lanes-staging"
+  project_number          = "580985798196"
+  enable_preview_pipeline = true
+
+  alert_email = var.alert_email
+}

--- a/gcp/terraform/import.sh
+++ b/gcp/terraform/import.sh
@@ -68,7 +68,8 @@ if [ "${PREVIEW}" = "1" ]; then
       "projects/${PROJECT_ID}/locations/${REGION}/repositories/preview"
 
   for role in roles/run.admin roles/iam.serviceAccountUser \
-              roles/artifactregistry.writer roles/artifactregistry.admin; do
+              roles/artifactregistry.writer roles/artifactregistry.admin \
+              roles/firebaseauth.admin; do
     imp "module.baseline.google_project_iam_member.preview_deploy[\"${role}\"]" \
         "${PROJECT_ID} ${role} serviceAccount:${DEPLOY_SA}"
   done

--- a/gcp/terraform/import.sh
+++ b/gcp/terraform/import.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# import.sh — adopt the already-live GCP resources into Terraform state so the
+# first `terraform apply` converges instead of trying to re-create them.
+#
+# Usage (from gcp/terraform/):
+#   ./import.sh staging      # or: ./import.sh prod
+#
+# Prereqs:
+#   - owner gcloud auth (gcloud auth login + gcloud auth application-default login)
+#   - state bucket exists (./bootstrap-state-bucket.sh)
+#   - terraform init has been run in the env dir
+#   - TF_VAR_alert_email set (terraform needs vars even to import)
+#
+# Best-effort and idempotent: a resource that is already in state, or that
+# doesn't exist remotely yet (apply will create it), logs a warning and the
+# script moves on. Review `terraform plan` output afterwards — the goal is a
+# plan that is empty or additive-only.
+
+set -uo pipefail
+
+ENV="${1:-}"
+case "${ENV}" in
+  staging) PROJECT_ID="recipe-lanes-staging"; PROJECT_NUMBER="580985798196"; PREVIEW=1 ;;
+  prod)    PROJECT_ID="recipe-lanes";         PROJECT_NUMBER="173546820314"; PREVIEW=0 ;;
+  *) echo "Usage: $0 staging|prod" >&2; exit 1 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}/envs/${ENV}"
+
+REGION="us-central1"
+ICON_SA="icon-processor@${PROJECT_ID}.iam.gserviceaccount.com"
+APP_HOSTING_SA="firebase-app-hosting-compute@${PROJECT_ID}.iam.gserviceaccount.com"
+DEPLOY_SA="firebase-adminsdk-fbsvc@${PROJECT_ID}.iam.gserviceaccount.com"
+RUNTIME_SA="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+
+imp() {
+  local addr="$1" id="$2"
+  echo "--> import ${addr}"
+  if ! terraform import "${addr}" "${id}"; then
+    echo "    WARN: import failed for ${addr} (already in state, or not live yet) — continuing"
+  fi
+}
+
+# --- APIs ---------------------------------------------------------------
+for api in run.googleapis.com artifactregistry.googleapis.com aiplatform.googleapis.com; do
+  imp "module.baseline.google_project_service.apis[\"${api}\"]" "${PROJECT_ID}/${api}"
+done
+
+# --- icon-processor SA + roles -------------------------------------------
+imp 'module.baseline.google_service_account.icon_processor' \
+    "projects/${PROJECT_ID}/serviceAccounts/${ICON_SA}"
+
+for role in roles/datastore.user roles/storage.objectAdmin roles/aiplatform.user \
+            roles/logging.logWriter roles/cloudtrace.agent \
+            roles/iam.serviceAccountTokenCreator roles/cloudtasks.enqueuer roles/run.invoker; do
+  imp "module.baseline.google_project_iam_member.icon_processor[\"${role}\"]" \
+      "${PROJECT_ID} ${role} serviceAccount:${ICON_SA}"
+done
+
+imp 'module.baseline.google_project_iam_member.app_hosting_run_invoker' \
+    "${PROJECT_ID} roles/run.invoker serviceAccount:${APP_HOSTING_SA}"
+
+# --- preview pipeline (staging only) --------------------------------------
+if [ "${PREVIEW}" = "1" ]; then
+  imp 'module.baseline.google_artifact_registry_repository.preview[0]' \
+      "projects/${PROJECT_ID}/locations/${REGION}/repositories/preview"
+
+  for role in roles/run.admin roles/iam.serviceAccountUser \
+              roles/artifactregistry.writer roles/artifactregistry.admin; do
+    imp "module.baseline.google_project_iam_member.preview_deploy[\"${role}\"]" \
+        "${PROJECT_ID} ${role} serviceAccount:${DEPLOY_SA}"
+  done
+
+  for role in roles/aiplatform.user roles/datastore.user roles/storage.objectAdmin; do
+    imp "module.baseline.google_project_iam_member.preview_runtime[\"${role}\"]" \
+        "${PROJECT_ID} ${role} serviceAccount:${RUNTIME_SA}"
+  done
+fi
+
+# --- monitoring stack ------------------------------------------------------
+# Metric name is deterministic; channel/policy ids are numeric and looked up
+# live by displayName (matching gcp/monitoring/apply.sh semantics).
+imp 'module.baseline.google_logging_metric.icon_forged_count' "icon_forged_count"
+
+CHANNEL_ID="$(gcloud beta monitoring channels list --project="${PROJECT_ID}" \
+  --filter='displayName="Icon-forge alerts"' --format='value(name)' 2>/dev/null | head -n1)"
+if [ -n "${CHANNEL_ID}" ]; then
+  imp 'module.baseline.google_monitoring_notification_channel.icon_forge_email' "${CHANNEL_ID}"
+else
+  echo "    NOTE: no live 'Icon-forge alerts' channel in ${PROJECT_ID}; apply will create it"
+fi
+
+POLICY_ID="$(gcloud alpha monitoring policies list --project="${PROJECT_ID}" \
+  --filter='displayName="Icon forge rate too high"' --format='value(name)' 2>/dev/null | head -n1)"
+if [ -n "${POLICY_ID}" ]; then
+  imp 'module.baseline.google_monitoring_alert_policy.icon_forged_rate' "${POLICY_ID}"
+else
+  echo "    NOTE: no live 'Icon forge rate too high' policy in ${PROJECT_ID}; apply will create it"
+fi
+
+echo
+echo "==> imports done for ${ENV}. Now run:  terraform plan"
+echo "    Expect an empty or additive-only plan. Investigate any change/destroy"
+echo "    before applying — especially in prod."

--- a/gcp/terraform/modules/project-baseline/apis.tf
+++ b/gcp/terraform/modules/project-baseline/apis.tf
@@ -1,0 +1,14 @@
+# APIs previously enabled by recipe-lanes/scripts/setup-preview-pipeline.sh.
+# disable_on_destroy = false: removing a service from this list must never
+# switch the API off in a live project.
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "run.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "aiplatform.googleapis.com",
+  ])
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}

--- a/gcp/terraform/modules/project-baseline/icon-processor.tf
+++ b/gcp/terraform/modules/project-baseline/icon-processor.tf
@@ -1,0 +1,40 @@
+# Icon-processor function identity + roles.
+# Source of truth was recipe-lanes/scripts/setup-icon-processor-sa.sh.
+#
+# IAM is managed with additive google_project_iam_member ONLY — never
+# google_project_iam_policy/binding, which are authoritative and can wipe
+# bindings that exist outside this config.
+
+resource "google_service_account" "icon_processor" {
+  project      = var.project_id
+  account_id   = "icon-processor"
+  display_name = "Icon Processor Function Identity"
+}
+
+locals {
+  icon_processor_roles = [
+    "roles/datastore.user",
+    "roles/storage.objectAdmin",
+    "roles/aiplatform.user",
+    "roles/logging.logWriter",
+    "roles/cloudtrace.agent",
+    "roles/iam.serviceAccountTokenCreator",
+    "roles/cloudtasks.enqueuer",
+    "roles/run.invoker",
+  ]
+}
+
+resource "google_project_iam_member" "icon_processor" {
+  for_each = toset(local.icon_processor_roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.icon_processor.email}"
+}
+
+# App Hosting frontend must be able to invoke the icon-processor Cloud Run service.
+resource "google_project_iam_member" "app_hosting_run_invoker" {
+  project = var.project_id
+  role    = "roles/run.invoker"
+  member  = "serviceAccount:firebase-app-hosting-compute@${var.project_id}.iam.gserviceaccount.com"
+}

--- a/gcp/terraform/modules/project-baseline/monitoring.tf
+++ b/gcp/terraform/modules/project-baseline/monitoring.tf
@@ -1,0 +1,63 @@
+# Icon-forge alerting stack (Bug 171).
+# Source of truth was gcp/monitoring/*.yaml + apply.sh; design rationale in
+# docs/alerting-icon-forge.md. The log filter must stay byte-for-byte in sync
+# with that runbook.
+
+resource "google_logging_metric" "icon_forged_count" {
+  project     = var.project_id
+  name        = "icon_forged_count"
+  description = "Count of successful icon generations (Bug 171 alerting)"
+
+  # Counter metric: one increment per matching log entry (no value extractor).
+  filter = "resource.type=\"cloud_run_revision\"\nresource.labels.service_name=\"processicontask\"\njsonPayload.event=\"icon_forged\""
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+  }
+}
+
+resource "google_monitoring_notification_channel" "icon_forge_email" {
+  project      = var.project_id
+  type         = "email"
+  display_name = "Icon-forge alerts"
+  description  = "Email channel for icon-forge rate alerts (Bug 171)"
+
+  labels = {
+    email_address = var.alert_email
+  }
+}
+
+resource "google_monitoring_alert_policy" "icon_forged_rate" {
+  project      = var.project_id
+  display_name = "Icon forge rate too high"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "too many icon_forged"
+
+    condition_threshold {
+      filter          = "metric.type=\"logging.googleapis.com/user/icon_forged_count\" resource.type=\"cloud_run_revision\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = var.alert_threshold
+      duration        = "0s"
+
+      aggregations {
+        alignment_period   = var.alert_alignment_period
+        per_series_aligner = "ALIGN_COUNT"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  alert_strategy {
+    notification_prompts = ["OPENED"]
+  }
+
+  notification_channels = [google_monitoring_notification_channel.icon_forge_email.id]
+
+  depends_on = [google_logging_metric.icon_forged_count]
+}

--- a/gcp/terraform/modules/project-baseline/preview-pipeline.tf
+++ b/gcp/terraform/modules/project-baseline/preview-pipeline.tf
@@ -13,6 +13,10 @@ locals {
     "roles/iam.serviceAccountUser",
     "roles/artifactregistry.writer",
     "roles/artifactregistry.admin",
+    # pr-preview.yml's authorized-domains automation PATCHes the Identity
+    # Toolkit Admin API to (de)register each PR's preview hostname in Firebase
+    # Auth authorized domains; needs firebaseauth.configs.update.
+    "roles/firebaseauth.admin",
   ]
   preview_runtime_roles = [
     "roles/aiplatform.user",

--- a/gcp/terraform/modules/project-baseline/preview-pipeline.tf
+++ b/gcp/terraform/modules/project-baseline/preview-pipeline.tf
@@ -1,0 +1,49 @@
+# Per-PR Cloud Run preview pipeline (.github/workflows/pr-preview.yml).
+# Source of truth was recipe-lanes/scripts/setup-preview-pipeline.sh.
+# Gated by enable_preview_pipeline — previews deploy to staging only.
+
+locals {
+  # Deploy SA: what pr-preview.yml authenticates as (FIREBASE_SERVICE_ACCOUNT_STAGING).
+  preview_deploy_sa = "firebase-adminsdk-fbsvc@${var.project_id}.iam.gserviceaccount.com"
+  # Runtime SA: what the deployed Cloud Run service runs as (default compute SA).
+  preview_runtime_sa = "${var.project_number}-compute@developer.gserviceaccount.com"
+
+  preview_deploy_roles = [
+    "roles/run.admin",
+    "roles/iam.serviceAccountUser",
+    "roles/artifactregistry.writer",
+    "roles/artifactregistry.admin",
+  ]
+  preview_runtime_roles = [
+    "roles/aiplatform.user",
+    "roles/datastore.user",
+    "roles/storage.objectAdmin",
+  ]
+}
+
+resource "google_artifact_registry_repository" "preview" {
+  count = var.enable_preview_pipeline ? 1 : 0
+
+  project       = var.project_id
+  location      = var.region
+  repository_id = "preview"
+  format        = "DOCKER"
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_project_iam_member" "preview_deploy" {
+  for_each = var.enable_preview_pipeline ? toset(local.preview_deploy_roles) : toset([])
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${local.preview_deploy_sa}"
+}
+
+resource "google_project_iam_member" "preview_runtime" {
+  for_each = var.enable_preview_pipeline ? toset(local.preview_runtime_roles) : toset([])
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${local.preview_runtime_sa}"
+}

--- a/gcp/terraform/modules/project-baseline/variables.tf
+++ b/gcp/terraform/modules/project-baseline/variables.tf
@@ -1,0 +1,38 @@
+variable "project_id" {
+  description = "GCP project id (recipe-lanes or recipe-lanes-staging)."
+  type        = string
+}
+
+variable "project_number" {
+  description = "Numeric project number (for the default compute runtime SA)."
+  type        = string
+}
+
+variable "region" {
+  description = "Primary region for regional resources (Artifact Registry)."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "enable_preview_pipeline" {
+  description = "Provision the per-PR Cloud Run preview pipeline (Artifact Registry repo + deploy/runtime IAM). Staging only today."
+  type        = bool
+  default     = false
+}
+
+variable "alert_email" {
+  description = "Recipient for the icon-forge alert notification channel."
+  type        = string
+}
+
+variable "alert_threshold" {
+  description = "Icon-forge alert: fire when icon_forged_count > N within the alignment window."
+  type        = number
+  default     = 20
+}
+
+variable "alert_alignment_period" {
+  description = "Icon-forge alert: alignment window (seconds, e.g. \"86400s\" = 1 day)."
+  type        = string
+  default     = "86400s"
+}

--- a/gcp/terraform/modules/project-baseline/versions.tf
+++ b/gcp/terraform/modules/project-baseline/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.7"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/recipe-lanes/.husky/pre-commit
+++ b/recipe-lanes/.husky/pre-commit
@@ -10,7 +10,7 @@ fi
 
 # Check if any file is NOT in the ignore list
 # We use grep -v to find files that DON'T match the ignore patterns
-NON_IGNORE_FILES=$(echo "$STAGED_FILES" | grep -vE '^(\.github/|recipe-lanes/\.husky/|docs/|recipe-lanes/scripts/|skills/|README\.md|LICENSE|CONTRIBUTING\.md|CLAUDE\.md)')
+NON_IGNORE_FILES=$(echo "$STAGED_FILES" | grep -vE '^(\.github/|recipe-lanes/\.husky/|docs/|gcp/|recipe-lanes/scripts/|skills/|README\.md|LICENSE|CONTRIBUTING\.md|CLAUDE\.md)')
 
 if [ -z "$NON_IGNORE_FILES" ]; then
   echo "Non-code changes detected. Skipping presubmit checks."


### PR DESCRIPTION
## What & why

Tier 3 of the agent-isolation roadmap (`docs/agent-isolation-roadmap.md`): the three hand-rolled GCP infra bundles become one declarative Terraform baseline, instantiated per project.

| Superseded source | Terraform home |
|---|---|
| `gcp/monitoring/` (icon-forge alert metric/channel/policy) | `modules/project-baseline/monitoring.tf` |
| `recipe-lanes/scripts/setup-icon-processor-sa.sh` | `modules/project-baseline/icon-processor.tf` |
| `recipe-lanes/scripts/setup-preview-pipeline.sh` | `modules/project-baseline/apis.tf` + `preview-pipeline.tf` |

- Two env roots: `envs/staging` (preview pipeline **on**) and `envs/prod` (**off**). GCS state backend (`recipe-lanes-tfstate`, bootstrap script included, bucket versioned).
- `import.sh <env>` adopts the already-live resources into state so the first apply converges instead of re-creating anything. Monitoring channel/policy IDs are looked up live by displayName (same semantics as the old `apply.sh`).
- **IAM is additive-only** (`google_project_iam_member`); authoritative `iam_policy`/`iam_binding` are deliberately banned (2026-07-04 authorizedDomains incident class).
- Old scripts stay in-tree until both envs are imported + applied; `gcp/monitoring/README.md` is marked superseded. Deleting the scripts is a follow-up PR.
- Also adds `gcp/` to the pre-commit non-code skip list (pure infra config, same category as `docs/` and `recipe-lanes/scripts/`).

## How it was verified

- `terraform init && terraform validate` passes for **both** env roots against provider `google ~> 6.0` (validates all resource/attribute schemas, incl. `alert_strategy.notification_prompts`).
- `terraform fmt -check -recursive` clean; `bash -n` clean on both scripts.
- Live inventory cross-checked read-only via gcloud: project numbers (staging `580985798196`, prod `173546820314`), `icon-processor` SA and `preview` AR repo confirmed present in both projects.
- **Not verified:** a live `terraform plan`/`import` — that needs owner user-credentials (`gcloud auth application-default login`; the firebase-adminsdk SAs can't read monitoring/IAM, and your user gcloud token on the Pi has expired). Runbook is in `gcp/terraform/README.md`.

## Risks / unsure about

- **Import-time drift**: if the live prod alert policy was hand-tuned away from the committed defaults (threshold 20 / window 86400s), the first plan after import will show a change. The README tells you to read the plan and either override via `TF_VAR_alert_threshold`/`TF_VAR_alert_alignment_period` or converge deliberately. **Never apply on a plan that shows a destroy.**
- The monitoring YAML→HCL translation (esp. the log filter string and `notification_prompts: [OPENED]`) is schema-validated but not live-diffed against prod, for the same credential reason.
- Prod also has a `preview` AR repo; it's intentionally left unmanaged (previews are staging-only).
- State bucket is created in the prod project — a new, versioned, private bucket; nothing existing is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3doAMcDQw1wuQg3jk3r5N