### PR TITLE
feat(iac): stand up recipe-lanes-ctf project (isolated CTF fork)

### DIFF
--- a/gcp/terraform/envs/ctf/README.md
+++ b/gcp/terraform/envs/ctf/README.md
@@ -1,0 +1,39 @@
+# `envs/ctf` — recipe-lanes-ctf
+
+A separate GCP/Firebase project for the **deliberately-vulnerable teaching
+fork** of RecipeLanes (served at `ctf.recipelanes.com`). It is isolated by
+design: its own Firestore/Auth/Storage and service accounts, and **no IAM on
+`recipe-lanes` or `recipe-lanes-staging`** — a student exploiting the CTF app
+can only reach throwaway CTF data.
+
+## What this env manages today
+
+- The `recipe-lanes-ctf` project + billing link (`prevent_destroy`).
+- Core APIs (Firebase, Firestore, Identity Toolkit, Storage, Run, Cloud Build,
+  Artifact Registry, App Hosting, Vertex AI).
+- Firebase enablement (`google_firebase_project`).
+
+## Deliberately deferred (future PRs, once the fork branch exists)
+
+- **App Hosting backend** (`google_firebase_app_hosting_backend`) pointing at
+  the fork's repo/branch. App Hosting mints its own custom-domain claim (TXT) +
+  serving records, which don't exist until the backend does.
+- **`ctf.recipelanes.com` DNS record** in `envs/prod/dns.tf` — target comes
+  from the App Hosting backend above.
+- **Data layer**: `google_firestore_database` (prod uses `australia-southeast1`;
+  Firestore location is permanent — pick to match the fork's needs), Auth
+  config, Storage bucket.
+
+## Apply
+
+```bash
+export TF_VAR_billing_account=...  # the shared billing account id (kept out of the repo)
+cd envs/ctf
+terraform init
+terraform plan     # creating a new billed project — read before applying
+terraform apply
+```
+
+Creating the project needs the caller to have `billing.resourceAssociations.create`
+on that billing account (the owner's user creds do). Find the id with
+`gcloud billing projects describe recipe-lanes --format='value(billingAccountName)'`.

--- a/gcp/terraform/envs/ctf/main.tf
+++ b/gcp/terraform/envs/ctf/main.tf
@@ -1,0 +1,100 @@
+terraform {
+  required_version = ">= 1.7"
+
+  backend "gcs" {
+    bucket = "recipe-lanes-tfstate"
+    prefix = "envs/ctf"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
+  }
+}
+
+# No project set on the providers: the google_project resource below CREATES
+# recipe-lanes-ctf, so API calls during creation are billed to the ADC quota
+# project, not the not-yet-existing CTF project.
+provider "google" {
+  region = "us-central1"
+}
+
+provider "google-beta" {
+  region = "us-central1"
+}
+
+# No default: this is an internal identifier we keep out of the public repo.
+# Pass it at apply time via TF_VAR_billing_account (same one prod/staging use).
+variable "billing_account" {
+  description = "Billing account to attach recipe-lanes-ctf to (same one prod/staging use). Set via TF_VAR_billing_account."
+  type        = string
+}
+
+# --- the CTF project --------------------------------------------------------
+# A deliberately-vulnerable teaching fork of the app. It is a SEPARATE project
+# on purpose: its own Firestore/Auth/Storage and service accounts, zero access
+# to prod or staging data. A student who exploits it can only reach throwaway
+# CTF data. Nothing here should ever be granted IAM on recipe-lanes[-staging].
+resource "google_project" "ctf" {
+  name            = "RecipeLanes CTF"
+  project_id      = "recipe-lanes-ctf"
+  billing_account = var.billing_account
+
+  labels = {
+    environment = "ctf"
+    purpose     = "security-training"
+  }
+
+  # Guard against a fat-fingered `terraform destroy` nuking the project.
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# --- APIs -------------------------------------------------------------------
+# Everything the App Hosting fork will need at deploy + runtime. App Hosting
+# itself (firebaseapphosting) and the domain claim are wired in a later PR,
+# once the fork branch exists and the backend can generate its serving records.
+resource "google_project_service" "ctf" {
+  for_each = toset([
+    "cloudresourcemanager.googleapis.com",
+    "serviceusage.googleapis.com",
+    "firebase.googleapis.com",
+    "firestore.googleapis.com",
+    "identitytoolkit.googleapis.com",
+    "storage.googleapis.com",
+    "firebasestorage.googleapis.com",
+    "run.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "firebaseapphosting.googleapis.com",
+    "aiplatform.googleapis.com",
+  ])
+
+  project            = google_project.ctf.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+# --- Firebase ---------------------------------------------------------------
+# Turns the bare GCP project into a Firebase project (google-beta resource).
+resource "google_firebase_project" "ctf" {
+  provider = google-beta
+  project  = google_project.ctf.project_id
+
+  depends_on = [google_project_service.ctf]
+}
+
+output "ctf_project_id" {
+  value = google_project.ctf.project_id
+}
+
+output "ctf_project_number" {
+  value = google_project.ctf.number
+}


### PR DESCRIPTION
## What & why

Provisions `recipe-lanes-ctf`, a **separate** GCP/Firebase project for the deliberately-vulnerable teaching fork that will serve `ctf.recipelanes.com`. Separate project = its own Firestore/Auth/Storage and service accounts, **no IAM on prod or staging** — a student who exploits the CTF app reaches only throwaway CTF data.

New `envs/ctf` root (state prefix `envs/ctf`):
- `google_project` `recipe-lanes-ctf` on billing `01ED2F-…` with `prevent_destroy`.
- Core APIs: Firebase, Firestore, Identity Toolkit, Storage, Run, Cloud Build, Artifact Registry, App Hosting, Vertex AI.
- `google_firebase_project` (Firebase-enables it).

## Deliberately deferred to a follow-up PR (see envs/ctf/README.md)

Because App Hosting mints its own domain-claim TXT + serving records only once a real backend exists, and Firestore's location is permanent:
- App Hosting backend pointing at the fork's branch (fork isn't written yet).
- The `ctf.recipelanes.com` record in `envs/prod/dns.tf` (target comes from that backend).
- The data layer (Firestore — prod is `australia-southeast1` — Auth, Storage).

## How it was verified

- `terraform validate` + `plan`: **14 to add, 0 to change, 0 to destroy**. Touches nothing in the existing prod/staging state.
- Providers set no `project`, so creation-time API calls bill to the ADC quota project rather than the not-yet-existent CTF project.

## Risks / unsure about

- Creating this is a **new billed project**. It's near-empty until the fork lands, so cost ≈ \$0, but it does start a billing association. `prevent_destroy` blocks accidental teardown (remove that flag deliberately if you ever want to delete it).
- The intentionally-vulnerable app is a standing internet-facing risk *once deployed* — hence the hard project isolation here and the deferred, reviewable deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3doAMcDQw1wuQg3jk3r5N