### PR TITLE
feat(ctf): App Hosting config for the CTF backend

### DIFF
--- a/recipe-lanes/apphosting.ctf.yaml
+++ b/recipe-lanes/apphosting.ctf.yaml
@@ -1,0 +1,29 @@
+# App Hosting config for the CTF backend (recipe-lanes-ctf project).
+# Selected by the `ctf` App Hosting backend (environment = ctf).
+#
+# Points the app at the ISOLATED recipe-lanes-ctf Firebase project — its own
+# Auth/Firestore/Storage, no access to prod or staging data. See the CTF fork
+# notes in docs/agent-isolation-roadmap.md.
+#
+# The NEXT_PUBLIC_FIREBASE_* values are client-side config (shipped to the
+# browser, not secret) — same as apphosting.prod.yaml / apphosting.staging.yaml.
+env:
+  - variable: NEXT_PUBLIC_FIREBASE_API_KEY
+    value: AIzaSyBCmSf_qTFBeCzFOeffqsvUhLhrERGK8OQ
+  - variable: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+    value: recipe-lanes-ctf.firebaseapp.com
+  - variable: NEXT_PUBLIC_FIREBASE_PROJECT_ID
+    value: recipe-lanes-ctf
+  - variable: NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
+    value: recipe-lanes-ctf.firebasestorage.app
+  - variable: NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
+    value: "1005946856175"
+  - variable: NEXT_PUBLIC_FIREBASE_APP_ID
+    value: "1:1005946856175:web:09f733a839281ab667311a"
+  # Placeholder: overrides the base apphosting.yaml `secret: GEMINI_API_KEY`
+  # mapping so the build doesn't require a Secret Manager entry in the CTF
+  # project. AI (Gemini) calls will fail at runtime until a real key is set;
+  # everything else works. Swap for a real `secret:` ref when the CTF fork
+  # needs live AI.
+  - variable: GEMINI_API_KEY
+    value: PLACEHOLDER_SET_A_REAL_KEY


### PR DESCRIPTION
## What & why

Adds `recipe-lanes/apphosting.ctf.yaml` so the newly-created `ctf` App Hosting backend (in `recipe-lanes-ctf`) can deploy the app from `main` at `ctf--recipe-lanes-ctf.asia-southeast1.hosted.app`.

Mirrors the existing `apphosting.prod.yaml` / `apphosting.staging.yaml` pattern, pointing the app at the **isolated** `recipe-lanes-ctf` Firebase project (its own Auth/Firestore/Storage — no prod/staging data access). The backend's `environment` field is set to `ctf`, which is how App Hosting selects this file.

`GEMINI_API_KEY` is a **placeholder value** overriding the base `apphosting.yaml` secret mapping, so the build needs no Secret Manager entry in the CTF project. AI (Gemini) calls fail at runtime until a real key is set; everything else works — matches the "get main deployed for now" intent.

## Context (already done outside this PR)

- `ctf` App Hosting backend created (GitHub connection authorized, repo linked to `main`, runtime SA set).
- Firestore (Native, asia-southeast1) created in `recipe-lanes-ctf`.
- Backend `environment` set to `ctf`.

Merging this triggers the first rollout (App Hosting continuous deployment on `main`).

## How it was verified

- `NEXT_PUBLIC_FIREBASE_*` values pulled directly from the CTF project's web app SDK config (`firebase apps:sdkconfig`).
- Pre-commit lint/typecheck/unit passed.

## Risks / unsure about

- Deploys the **real** app (not yet the vulnerable fork) to a public URL — intended placeholder.
- Client Firebase values are non-secret (browser-shipped), consistent with the committed prod/staging yamls. No real secrets added.
- Custom domain `ctf.recipelanes.com` is **not** wired yet — follow-up once this rollout is confirmed healthy (and after the DNS-to-infra nameserver cutover lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3doAMcDQw1wuQg3jk3r5N