### PR TITLE
feat(ctf): use real Gemini key from CTF Secret Manager

### DIFF
--- a/recipe-lanes/apphosting.ctf.yaml
+++ b/recipe-lanes/apphosting.ctf.yaml
@@ -20,10 +20,11 @@ env:
     value: "1005946856175"
   - variable: NEXT_PUBLIC_FIREBASE_APP_ID
     value: "1:1005946856175:web:09f733a839281ab667311a"
-  # Placeholder: overrides the base apphosting.yaml `secret: GEMINI_API_KEY`
-  # mapping so the build doesn't require a Secret Manager entry in the CTF
-  # project. AI (Gemini) calls will fail at runtime until a real key is set;
-  # everything else works. Swap for a real `secret:` ref when the CTF fork
-  # needs live AI.
+  # Gemini key from the CTF project's own Secret Manager (GEMINI_API_KEY,
+  # value copied from the prod key). Reuses base apphosting.yaml's secret
+  # mapping; kept explicit here for clarity.
+  # SECURITY: this is currently the SAME key as prod/staging. Before the fork
+  # is made deliberately vulnerable, rotate the CTF project to a dedicated,
+  # restricted key so an exploit can't exfiltrate the prod key.
   - variable: GEMINI_API_KEY
-    value: PLACEHOLDER_SET_A_REAL_KEY
+    secret: GEMINI_API_KEY


### PR DESCRIPTION
## What & why

Swaps the placeholder `GEMINI_API_KEY` in `apphosting.ctf.yaml` for a real `secret:` reference, so AI/recipe-parsing works on the CTF deploy.

Already done outside the repo:
- Created `GEMINI_API_KEY` secret in `recipe-lanes-ctf` (value copied from the prod key).
- Granted `roles/secretmanager.secretAccessor` to the App Hosting runtime SA (`firebase-app-hosting-compute@recipe-lanes-ctf`).

## Risks / unsure about

- **Shares the prod Gemini key for now.** Flagged in-comment: before the fork is made deliberately vulnerable, rotate the CTF project to a dedicated, usage-restricted key so an exploit can't exfiltrate the prod key. Fine as an interim.
- Merging triggers a fresh rollout that supersedes the placeholder one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3doAMcDQw1wuQg3jk3r5N