### PR TITLE
fix(agents): realistic Gemini job timeouts + ripgrep on runners

### DIFF
--- a/.github/workflows/gemini-comment-responder.yml
+++ b/.github/workflows/gemini-comment-responder.yml
@@ -34,7 +34,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-    timeout-minutes: 20
+    timeout-minutes: 60
 
     steps:
       - name: Mint agent token (GitHub App)
@@ -58,8 +58,10 @@ jobs:
           cache: 'npm'
           cache-dependency-path: recipe-lanes/package-lock.json
 
-      - name: Install Gemini CLI
-        run: npm install -g @google/gemini-cli --silent
+      - name: Install Gemini CLI and ripgrep
+        run: |
+          npm install -g @google/gemini-cli --silent
+          sudo apt-get install -y --no-install-recommends ripgrep
 
       - name: Configure Git
         run: |

--- a/.github/workflows/gemini-issue-solver.yml
+++ b/.github/workflows/gemini-issue-solver.yml
@@ -45,7 +45,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-    timeout-minutes: 25
+    timeout-minutes: 90
 
     steps:
       - name: Mint agent token (GitHub App)
@@ -70,8 +70,10 @@ jobs:
           cache: 'npm'
           cache-dependency-path: recipe-lanes/package-lock.json
 
-      - name: Install Gemini CLI
-        run: npm install -g @google/gemini-cli --silent
+      - name: Install Gemini CLI and ripgrep
+        run: |
+          npm install -g @google/gemini-cli --silent
+          sudo apt-get install -y --no-install-recommends ripgrep
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
## What & why
First real solver run (issue #32) was cancelled at `timeout-minutes: 25` before finishing — CI's `fast-checks` alone currently takes ~28 min and the agent's contract requires blocking until CI is green, so 25 min could never fit implement + CI wait. Solver → 90 min, comment responder → 60 min. Also installs `ripgrep` on the runner (the run log showed 'Ripgrep is not available. Falling back to GrepTool'), which speeds up the agent's code search.

## How verified
YAML parses; values confirmed by grep. Real verification is re-running the solver on issue #32 after merge (runner minutes are free on public repos, so longer timeouts cost nothing).

## Risks / unsure about
A genuinely hung run now holds the concurrency slot for up to 90 min instead of 25. Acceptable: runs are serialized per the `gemini-agent` group, and a stuck run can be cancelled manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)