### PR TITLE
feat(agents): persist Gemini run logs as artifacts; pin gemini-3.1-pro-preview

### DIFF
--- a/.github/workflows/feedback-triage.yml
+++ b/.github/workflows/feedback-triage.yml
@@ -67,8 +67,36 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
+          GEMINI_MODEL: gemini-3.1-pro-preview
           GH_TOKEN: ${{ steps.agent_token.outputs.token || secrets.AGENT_GH_PAT || github.token }}
           GITHUB_TOKEN: ${{ steps.agent_token.outputs.token || secrets.AGENT_GH_PAT || github.token }}
           NEXT_PUBLIC_FIREBASE_PROJECT_ID: recipe-lanes
         run: |
-          gemini --approval-mode=yolo -p "$(cat .github/gemini/feedback-triage.md)"
+          gemini --approval-mode=yolo -p "$(cat .github/gemini/feedback-triage.md)" 2>&1 | tee "$RUNNER_TEMP/gemini-run.log"
+
+      - name: Collect and scrub agent logs
+        if: always()
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          APP_TOKEN: ${{ steps.agent_token.outputs.token }}
+          FALLBACK_TOKEN: ${{ secrets.AGENT_GH_PAT || github.token }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/gemini-logs"
+          cp "$RUNNER_TEMP/gemini-run.log" "$RUNNER_TEMP/gemini-logs/" 2>/dev/null || true
+          # Gemini CLI session transcripts (full conversation + tool calls)
+          cp -r "$HOME/.gemini/tmp" "$RUNNER_TEMP/gemini-logs/sessions" 2>/dev/null || true
+          # Artifacts on a public repo are downloadable — scrub credentials.
+          find "$RUNNER_TEMP/gemini-logs" -type f | while read -r f; do
+            for s in "$GEMINI_API_KEY" "$APP_TOKEN" "$FALLBACK_TOKEN"; do
+              [ -n "$s" ] && sed -i "s|$s|***SCRUBBED***|g" "$f" || true
+            done
+          done
+
+      - name: Upload agent logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gemini-logs-${{ github.run_id }}
+          path: ${{ runner.temp }}/gemini-logs/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/gemini-comment-responder.yml
+++ b/.github/workflows/gemini-comment-responder.yml
@@ -72,7 +72,35 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
+          GEMINI_MODEL: gemini-3.1-pro-preview
           GH_TOKEN: ${{ steps.agent_token.outputs.token || secrets.AGENT_GH_PAT || github.token }}
           GITHUB_TOKEN: ${{ steps.agent_token.outputs.token || secrets.AGENT_GH_PAT || github.token }}
         run: |
-          gemini --approval-mode=yolo -p "/address-comment ${{ github.event.issue.number }}"
+          gemini --approval-mode=yolo -p "/address-comment ${{ github.event.issue.number }}" 2>&1 | tee "$RUNNER_TEMP/gemini-run.log"
+
+      - name: Collect and scrub agent logs
+        if: always()
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          APP_TOKEN: ${{ steps.agent_token.outputs.token }}
+          FALLBACK_TOKEN: ${{ secrets.AGENT_GH_PAT || github.token }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/gemini-logs"
+          cp "$RUNNER_TEMP/gemini-run.log" "$RUNNER_TEMP/gemini-logs/" 2>/dev/null || true
+          # Gemini CLI session transcripts (full conversation + tool calls)
+          cp -r "$HOME/.gemini/tmp" "$RUNNER_TEMP/gemini-logs/sessions" 2>/dev/null || true
+          # Artifacts on a public repo are downloadable — scrub credentials.
+          find "$RUNNER_TEMP/gemini-logs" -type f | while read -r f; do
+            for s in "$GEMINI_API_KEY" "$APP_TOKEN" "$FALLBACK_TOKEN"; do
+              [ -n "$s" ] && sed -i "s|$s|***SCRUBBED***|g" "$f" || true
+            done
+          done
+
+      - name: Upload agent logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gemini-logs-${{ github.run_id }}
+          path: ${{ runner.temp }}/gemini-logs/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/gemini-issue-solver.yml
+++ b/.github/workflows/gemini-issue-solver.yml
@@ -84,6 +84,7 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
+          GEMINI_MODEL: gemini-3.1-pro-preview
           GH_TOKEN: ${{ steps.agent_token.outputs.token || secrets.AGENT_GH_PAT || github.token }}
           GITHUB_TOKEN: ${{ steps.agent_token.outputs.token || secrets.AGENT_GH_PAT || github.token }}
           TARGET_ISSUE: ${{ github.event_name == 'issues' && github.event.issue.number || github.event.inputs.issue_number }}
@@ -94,4 +95,31 @@ jobs:
             PROMPT="/resolve-issue"
           fi
           echo "Executing: gemini --approval-mode=yolo -p \"$PROMPT\""
-          gemini --approval-mode=yolo -p "$PROMPT"
+          gemini --approval-mode=yolo -p "$PROMPT" 2>&1 | tee "$RUNNER_TEMP/gemini-run.log"
+
+      - name: Collect and scrub agent logs
+        if: always()
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          APP_TOKEN: ${{ steps.agent_token.outputs.token }}
+          FALLBACK_TOKEN: ${{ secrets.AGENT_GH_PAT || github.token }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/gemini-logs"
+          cp "$RUNNER_TEMP/gemini-run.log" "$RUNNER_TEMP/gemini-logs/" 2>/dev/null || true
+          # Gemini CLI session transcripts (full conversation + tool calls)
+          cp -r "$HOME/.gemini/tmp" "$RUNNER_TEMP/gemini-logs/sessions" 2>/dev/null || true
+          # Artifacts on a public repo are downloadable — scrub credentials.
+          find "$RUNNER_TEMP/gemini-logs" -type f | while read -r f; do
+            for s in "$GEMINI_API_KEY" "$APP_TOKEN" "$FALLBACK_TOKEN"; do
+              [ -n "$s" ] && sed -i "s|$s|***SCRUBBED***|g" "$f" || true
+            done
+          done
+
+      - name: Upload agent logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gemini-logs-${{ github.run_id }}
+          path: ${{ runner.temp }}/gemini-logs/
+          if-no-files-found: ignore
+          retention-days: 30


### PR DESCRIPTION
## What & why
- **Run logs now exist.** Headless `gemini -p` buffers output, so the timed-out issue-#32 run left nothing to inspect. Every agent run (solver, comment responder, feedback triage) now `tee`s its console stream and uploads it together with Gemini CLI's own session transcripts (`~/.gemini/tmp`, full conversation + tool calls) as a workflow artifact `gemini-logs-<run_id>`, kept 30 days, uploaded even on failure/cancel.
- **Scrubbing:** artifacts on a public repo are downloadable by any logged-in user, and Actions' secret masking does not apply inside artifact files — so the Gemini API key, the minted app token, and the PAT/GITHUB_TOKEN are replaced with `***SCRUBBED***` before upload.
- **Model pinned to `gemini-3.1-pro-preview`** via `GEMINI_MODEL` in all three workflows (was: CLI default). Verified against the key's model list — 3.1 Pro is preview-only right now; swap to the stable alias when Google ships one.

## How verified
All three workflows YAML-parse. Runtime verification is the next agent run: download `gemini-logs-*` from its run page and confirm console log + session transcripts are present and scrubbed.

## Risks / unsure about
- The sed-based scrub handles the three known credentials; anything else the agent echoes (it shouldn't have access to more) is not masked.
- `gemini-3.1-pro-preview` is a preview model — Google can retire it; if runs start failing with model-not-found, update `GEMINI_MODEL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)