### PR TITLE
feat(ctf): DNS records for ctf.recipelanes.com custom domain

### DIFF
--- a/gcp/terraform/envs/infra/dns.tf
+++ b/gcp/terraform/envs/infra/dns.tf
@@ -48,6 +48,26 @@ resource "google_dns_record_set" "staging_a" {
   rrdatas      = ["35.219.201.32"]
 }
 
+# CTF fork (recipe-lanes-ctf App Hosting backend). A + ownership TXT required
+# by the App Hosting custom-domain for ctf.recipelanes.com.
+resource "google_dns_record_set" "ctf_a" {
+  project      = "recipe-lanes-infra"
+  managed_zone = google_dns_managed_zone.recipelanes_com.name
+  name         = "ctf.recipelanes.com."
+  type         = "A"
+  ttl          = 300
+  rrdatas      = ["35.219.201.32"]
+}
+
+resource "google_dns_record_set" "ctf_txt" {
+  project      = "recipe-lanes-infra"
+  managed_zone = google_dns_managed_zone.recipelanes_com.name
+  name         = "ctf.recipelanes.com."
+  type         = "TXT"
+  ttl          = 3600
+  rrdatas      = ["\"fah-claim=00b-02-b2c3e38b-617e-40c6-b790-6f51147b69da\""]
+}
+
 # Firebase App Hosting certificate-manager ACME delegation.
 resource "google_dns_record_set" "acme_delegation" {
   project      = "recipe-lanes-infra"


### PR DESCRIPTION
## What & why

Wires the custom domain `ctf.recipelanes.com` onto the CTF App Hosting backend. Adds the two records the backend's custom-domain requires, in the infra-homed `recipelanes.com` zone:

- **A** `ctf.recipelanes.com` → `35.219.201.32`
- **TXT** `ctf.recipelanes.com` → `fah-claim=…` (App Hosting ownership verification)

The custom domain resource is already created on the backend (cert is active); these records satisfy its host + ownership checks. After merge+apply, App Hosting reconciles and `https://ctf.recipelanes.com` serves the CTF site.

## How it was verified

- Record values taken directly from the backend domain's `requiredDnsUpdates`.
- `terraform validate` + `plan`: **2 to add, 0 to change, 0 to destroy**.

## Risks / unsure about

- Ownership/host reconcile + cert can take a few minutes to an hour after the records propagate.
- The fah-claim token is an ownership proof (not a secret), consistent with the apex fah-claim TXT already committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3doAMcDQw1wuQg3jk3r5N