### PR TITLE
feat(ctf): adopt runtime resources into Terraform

### DIFF
--- a/gcp/terraform/envs/ctf/README.md
+++ b/gcp/terraform/envs/ctf/README.md
@@ -37,3 +37,37 @@ terraform apply
 Creating the project needs the caller to have `billing.resourceAssociations.create`
 on that billing account (the owner's user creds do). Find the id with
 `gcloud billing projects describe recipe-lanes --format='value(billingAccountName)'`.
+
+## Runtime resources (`runtime.tf`) — adopt with `runtime-adopt.sh`
+
+`runtime.tf` manages the Firestore database, the App Hosting runtime SA's
+`aiplatform.user` grant (needed by the genkit/Vertex recipe parser), and the
+Identity Platform config (authorized domains). These were first created
+imperatively while bringing the site up; after merging, run:
+
+```bash
+export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)  # TF state creds
+./runtime-adopt.sh          # imports the live resources
+terraform plan              # expect no changes
+terraform apply
+```
+
+## What is NOT Terraform (and shouldn't be)
+
+Infra is Terraform; **app artifacts are deployed from the app repo**, not here —
+this is the normal split, not a gap:
+
+| Thing | Managed by |
+|---|---|
+| Firestore **rules** & indexes, Storage rules | `firebase deploy` (app repo) / CI |
+| **Cloud Functions** (`vectorSearch`, `processIconTask`) | `firebase deploy --only functions` / CI |
+| The Next.js app itself | App Hosting continuous deploy from `main` |
+
+Genuinely manual / can't be clean IaC here:
+- **Google sign-in provider** — `google_identity_platform_default_supported_idp_config`
+  needs an OAuth `client_id`/`client_secret`; the Firebase console auto-provisions
+  a Google-managed client in one click. Putting a client secret in this **public**
+  repo is a non-starter, so enabling Google stays a console click (Authentication →
+  Sign-in method → Google → Enable).
+- **`GEMINI_API_KEY` secret value** — the secret can be TF-managed but its value
+  can't live in a public repo; supply via `TF_VAR` or create out-of-band.

--- a/gcp/terraform/envs/ctf/runtime-adopt.sh
+++ b/gcp/terraform/envs/ctf/runtime-adopt.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# runtime-adopt.sh — import the CTF runtime resources (created imperatively
+# while bringing the site up) into Terraform state, so runtime.tf manages them
+# without recreating anything.
+#
+# Run AFTER this branch's runtime.tf is merged to main (so shared state and the
+# main config agree). Needs owner creds:
+#   export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token)
+#
+# Idempotent-ish: a resource already in state logs a warning and is skipped.
+
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+imp() {
+  echo "--> import $1"
+  terraform import "$1" "$2" || echo "    WARN: import failed (already in state?) — continuing"
+}
+
+imp 'google_firestore_database.default'                'projects/recipe-lanes-ctf/databases/(default)'
+imp 'google_project_iam_member.apphosting_aiplatform'  'recipe-lanes-ctf roles/aiplatform.user serviceAccount:firebase-app-hosting-compute@recipe-lanes-ctf.iam.gserviceaccount.com'
+imp 'google_identity_platform_config.auth'             'projects/recipe-lanes-ctf'
+
+echo
+echo "==> done. Now run:  terraform plan   (expect no changes / additive-only)"

--- a/gcp/terraform/envs/ctf/runtime.tf
+++ b/gcp/terraform/envs/ctf/runtime.tf
@@ -1,0 +1,42 @@
+# CTF runtime resources, adopted into Terraform (imported from the live
+# resources that were first created imperatively while bringing the site up).
+# See runtime-adopt.sh for the import commands.
+
+# --- Firestore (permanent location: asia-southeast1, co-located w/ backend) --
+resource "google_firestore_database" "default" {
+  project     = google_project.ctf.project_id
+  name        = "(default)"
+  location_id = "asia-southeast1"
+  type        = "FIRESTORE_NATIVE"
+
+  depends_on = [google_project_service.ctf]
+}
+
+# --- Vertex AI access for the App Hosting runtime SA -------------------------
+# Without this the recipe parser (genkit vertexAI, gemini-2.5-flash) fails with
+# "Invalid AI Response Format".
+resource "google_project_iam_member" "apphosting_aiplatform" {
+  project = google_project.ctf.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:firebase-app-hosting-compute@${google_project.ctf.project_id}.iam.gserviceaccount.com"
+}
+
+# --- Firebase Auth / Identity Platform config -------------------------------
+# Manages the authorized-domains list for Google sign-in popups. The Google
+# provider itself (google_identity_platform_default_supported_idp_config) is
+# NOT managed here: it needs an OAuth client_id/secret that the Firebase console
+# auto-provisions and that would be a credential in this PUBLIC repo — enabling
+# it stays a one-time console click (documented in README).
+resource "google_identity_platform_config" "auth" {
+  project = google_project.ctf.project_id
+
+  authorized_domains = [
+    "recipe-lanes-ctf.firebaseapp.com",
+    "recipe-lanes-ctf.web.app",
+    "ctf--recipe-lanes-ctf.asia-southeast1.hosted.app",
+    "ctf.recipelanes.com",
+    "localhost",
+  ]
+
+  depends_on = [google_project_service.ctf]
+}


### PR DESCRIPTION
## What & why

Closes the gap between the CTF infra that was created imperatively (bringing the site up) and what's in Terraform. Adds `envs/ctf/runtime.tf` managing:

- `google_firestore_database` (asia-southeast1)
- `google_project_iam_member` `aiplatform.user` for the App Hosting runtime SA — this was the fix for the **"Invalid AI Response Format"** parser failure (the app parses recipes via genkit/Vertex AI using the SA, not the Gemini key)
- `google_identity_platform_config` (authorized domains for Google sign-in)

`runtime-adopt.sh` imports the live resources so **nothing is recreated**. Run after merge, then `terraform plan` should be clean.

## The infra-vs-app-code boundary (answering "everything via Terraform")

Infra → Terraform. **App artifacts → `firebase deploy` from the app repo**, which is the correct split, not a missing piece:

| Thing | Managed by |
|---|---|
| Firestore rules & indexes, Storage rules | `firebase deploy` / CI |
| Cloud Functions (`vectorSearch`, `processIconTask`) | `firebase deploy --only functions` / CI |
| The Next.js app | App Hosting continuous deploy from `main` |

Two things genuinely can't be clean IaC in a **public** repo (documented in README):
- **Google sign-in provider** needs an OAuth client_id/secret; the console auto-provisions a Google-managed client in one click. A client secret can't go in a public repo → stays a console click.
- **GEMINI_API_KEY secret value** — secret can be TF-managed, value can't live in the repo (use TF_VAR).

## How it was verified

- `terraform validate` passes.
- Import IDs match the live resources (Firestore `(default)`, the IAM member, the identity-platform config).

## Note

Not yet applied — imports run post-merge (shared state). Separately, the live site still needs Firestore rules (just deployed via REST) and Cloud Functions (not yet deployed to CTF) for full feature parity; those are app-deploy concerns, tracked separately from this infra PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3doAMcDQw1wuQg3jk3r5N