### PR TITLE
fix(ctf): pin org_id so Terraform doesn't try to move the project

### DIFF
--- a/gcp/terraform/envs/ctf/main.tf
+++ b/gcp/terraform/envs/ctf/main.tf
@@ -46,6 +46,12 @@ resource "google_project" "ctf" {
   project_id      = "recipe-lanes-ctf"
   billing_account = var.billing_account
 
+  # The recipelanes.com Cloud org (auto-created with the Workspace domain).
+  # New projects land in it by default; pinning this keeps Terraform from
+  # trying to move the project OUT of the org on apply. (Prod predates the
+  # org and is org-less, so it has no org_id.)
+  org_id = "247736101927"
+
   labels = {
     environment = "ctf"
     purpose     = "security-training"


### PR DESCRIPTION
## What & why

While reconciling the CTF runtime into Terraform, `terraform plan` showed `org_id = "247736101927" -> null` on `google_project.ctf` — i.e. it wanted to **move the project out of the `recipelanes.com` Cloud org**.

That org (`247736101927`) was auto-created with the Workspace domain; new projects default into it, so `recipe-lanes-ctf` is a member — but the merged `main.tf` never declared `org_id`. Pinning it to the real value makes the plan a no-op for that field and removes the latent "move project on next apply" hazard. (Prod predates the org and is org-less, so it correctly has no `org_id`.)

## How it was verified

- After the change, `terraform plan` = **0 add, 1 change, 0 destroy**, and the 1 change is an unrelated benign empty-block cleanup on the identity-platform config — no org move.

## Risks

- None to the org itself; this only stops Terraform from attempting a move. `org_id` is set-once semantics matching current state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3doAMcDQw1wuQg3jk3r5N