### PR TITLE
feat(ctf): App Hosting SA roles for icon forging

### DIFF
--- a/gcp/terraform/envs/ctf/icon-processor.tf
+++ b/gcp/terraform/envs/ctf/icon-processor.tf
@@ -40,3 +40,28 @@ resource "google_project_iam_member" "compute_cloudbuild_builder" {
   role    = "roles/cloudbuild.builds.builder"
   member  = "serviceAccount:${google_project.ctf.number}-compute@developer.gserviceaccount.com"
 }
+
+# App Hosting runtime SA (the Next.js server actions run as this). To FORGE
+# icons it enqueues Cloud Tasks to the processIconTask queue and mints the
+# invoker OIDC token, so it needs cloudtasks.enqueuer + iam.serviceAccountUser.
+# The rest mirror prod's firebase-app-hosting-compute grants (trace/logging/
+# run.invoker) so the CTF app has parity. Without cloudtasks.enqueuer the forge
+# silently no-ops (nothing reaches processIconTask).
+locals {
+  apphosting_sa = "firebase-app-hosting-compute@${google_project.ctf.project_id}.iam.gserviceaccount.com"
+  apphosting_roles = [
+    "roles/cloudtasks.enqueuer",
+    "roles/iam.serviceAccountUser",
+    "roles/run.invoker",
+    "roles/cloudtrace.agent",
+    "roles/logging.logWriter",
+  ]
+}
+
+resource "google_project_iam_member" "apphosting_sa" {
+  for_each = toset(local.apphosting_roles)
+
+  project = google_project.ctf.project_id
+  role    = each.value
+  member  = "serviceAccount:${local.apphosting_sa}"
+}


### PR DESCRIPTION
## What & why

Forging icons on the CTF site silently did nothing — no task ever reached `processIconTask` (zero logs). Cause: the App Hosting runtime SA (which runs the Next.js server actions) was missing **`cloudtasks.enqueuer`** and **`iam.serviceAccountUser`**, so it couldn't enqueue to the `processIconTask` Cloud Tasks queue or mint the invoker token.

Grants the 5 roles prod's `firebase-app-hosting-compute` SA has that CTF's lacked: `cloudtasks.enqueuer`, `iam.serviceAccountUser`, `run.invoker`, `cloudtrace.agent`, `logging.logWriter`. All scoped to `recipe-lanes-ctf`.

(Follow-up to #259, which merged before this commit landed.)

## How it was verified

- Diffed prod vs CTF App Hosting SA roles — exactly these 5 were missing.
- Applied (targeted); `terraform validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3doAMcDQw1wuQg3jk3r5N