### PR TITLE
fix(gallery): report the real icon total so /icon_overview pagination works

### DIFF
--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -36,3 +36,13 @@ A shared, curated log of significant decisions, incidents, and infra/process cha
 **Testing note.** The claim logic is pure and lives in `.github/scripts/agent-claim-logic.mjs` with `node --test` coverage (including a regression case replaying the #278 collision). CI's `changes` filter deliberately excludes `.github/**` from the `code` signal, so these tests needed their own `agent-scripts` job with its own path filter — otherwise a PR touching only agent tooling would silently skip every check.
 
 **Amendment (same day).** Contract tightened after owner feedback: a worker is dispatched to **one** labeled issue, so losing the claim race means **resign** — end the run quietly as a success — not "pick a different issue". A losing run has nothing to fall back to and must not go shopping for other work to fill itself. `list`/`status` are diagnostics only (`list` now always exits 0), so exit 3 unambiguously means "resign".
+
+---
+
+## 2026-07-27 — `agent-claim.mjs` cannot reach the GitHub REST API from the cloud runner
+
+Working issue #280 from a Claude-Code-on-the-web session, `node .github/scripts/agent-claim.mjs claim 280` failed with **401 Bad credentials**. The cause is the sandbox, not the script: outbound HTTPS goes through an agent proxy, `GH_TOKEN`/`GITHUB_TOKEN` are `proxy-injected` placeholders rather than real tokens, and a direct call to `api.github.com` is rejected with *"GitHub access is not enabled for this session"*. In that environment the **GitHub MCP tools are the only working GitHub path** — and Node's `fetch` does not honour `HTTPS_PROXY` by default anyway, so the script bypasses the proxy even when it is configured.
+
+The claim protocol itself is fine and was honoured by hand for #280: post the claim comment with the same hidden `<!-- agent-claim worker="…" -->` marker (`add_issue_comment`), add `agent-claimed` (`issue_write`, which replaces the whole label set — resend the existing labels), wait out the settle window, then re-read the comments and keep the issue only if your claim is the earliest live one. Other workers parse the marker, not the poster, so a hand-staked claim arbitrates identically.
+
+**For future runs:** if `agent-claim.mjs` exits 1 with a 401/403, do not treat it as "no claim needed" and do not skip the claim — fall back to staking it via MCP as above. Making the script proxy-aware (an undici `ProxyAgent`, or `NODE_USE_ENV_PROXY`) would only help if the proxy allowed `api.github.com` for this session, which it does not.

--- a/recipe-lanes/components/shared-gallery.tsx
+++ b/recipe-lanes/components/shared-gallery.tsx
@@ -24,6 +24,7 @@ import { IconStats } from '@/lib/recipe-lanes/types';
 import { getIconThumbUrl } from '@/lib/recipe-lanes/model-utils';
 import { GALLERY_LABEL_TRANSFORM_CLASS } from '@/lib/recipe-lanes/gallery-label';
 import { formatIconCreatedAt } from '@/lib/recipe-lanes/icon-created-at';
+import { ICON_GALLERY_PAGE_SIZE } from '@/lib/config';
 
 interface SharedGalleryProps {
   onIconClick?: (icon: IconStats, ingredientName: string) => void;
@@ -37,13 +38,12 @@ export function SharedGallery({ onIconClick }: SharedGalleryProps = {}) {
   const [search, setSearch] = useState('');
   // View mode: grid of thumbnails (default) or a list showing creation time (#279).
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
-  const limitCount = 20;
 
   useEffect(() => {
     const fetchIcons = async () => {
       setLoading(true);
       try {
-        const res = await getPagedIconsAction(page, limitCount, search);
+        const res = await getPagedIconsAction(page, ICON_GALLERY_PAGE_SIZE, search);
         setIcons(res.icons);
         setTotal(res.total);
       } catch (err) {
@@ -75,7 +75,7 @@ export function SharedGallery({ onIconClick }: SharedGalleryProps = {}) {
       }
   };
 
-  const totalPages = Math.ceil(total / limitCount);
+  const totalPages = Math.ceil(total / ICON_GALLERY_PAGE_SIZE);
 
   return (
     <div className="w-full space-y-6 pt-8 border-t border-zinc-800" data-testid="shared-gallery">

--- a/recipe-lanes/lib/config.ts
+++ b/recipe-lanes/lib/config.ts
@@ -26,6 +26,18 @@ export const DB_COLLECTION_FEEDBACK = 'feedback';
 export const DB_COLLECTION_ICON_INDEX = 'icon_index';
 export const DB_COLLECTION_CONFIG = 'config';
 
+/**
+ * Icons per page in the shared icon gallery (/icon_overview). Shared by the
+ * client pager and the server query so the two cannot drift apart.
+ */
+export const ICON_GALLERY_PAGE_SIZE = 20;
+
+/**
+ * How many of the newest icons a gallery search scans. `icon_index` has no
+ * server-side text index, so search filters this window in memory.
+ */
+export const ICON_SEARCH_SCAN_LIMIT = 1000;
+
 // Runtime config document for the icon-generation queue. Both the server actions
 // and the Cloud Function read this so abuse controls are adjustable without a redeploy.
 export const ICON_QUEUE_CONFIG_DOC = 'icon_queue';

--- a/recipe-lanes/lib/data-service.ts
+++ b/recipe-lanes/lib/data-service.ts
@@ -23,7 +23,7 @@ import { randomUUID } from 'crypto';
 import { claimHashForCreate, isValidClaim } from './recipe-lanes/claim-token';
 import sharp from 'sharp';
 import type { RecipeGraph, IconStats, ShortlistEntry } from './recipe-lanes/types';
-import { DB_COLLECTION_INGREDIENTS, DB_COLLECTION_ICON_INDEX, DB_COLLECTION_QUEUE, DB_COLLECTION_RECIPES } from './config';
+import { DB_COLLECTION_INGREDIENTS, DB_COLLECTION_ICON_INDEX, DB_COLLECTION_QUEUE, DB_COLLECTION_RECIPES, ICON_GALLERY_PAGE_SIZE, ICON_SEARCH_SCAN_LIMIT } from './config';
 import { standardizeIngredientName, removeUndefined, computeStoredOwnerName } from './utils';
 // import { calculateWilsonLCB } from './utils';
 import { applyIconToNode, assignNodeShortlist, buildShortlistEntry, clearNodeShortlist, computeShortlistDelta, getEntryIcon, getIconPath, getIconStoragePaths, getIconThumbPath, getIconUrl, getNodeHydeQueries, getNodeIconId, getNodeIconUrl, getNodeIngredientName, getNodeShortlist, getNodeShortlistLength, getPendingImpressionIds, getPendingRejectionIds, getPendingImpressionTargets, getPendingRejectionTargets, getSeenIconIds, hasNodeIcon, iconIndexEntryToStats, markEntryImpressedAtIndex, markSeenEntriesImpressed, markSeenEntriesRejected, mutateNodesByIngredient, prependToShortlist, rankIconsByEmbedding, toRecipeIcon, setNodeStatusByIngredient, extractBatchIngredients } from './recipe-lanes/model-utils';
@@ -632,21 +632,20 @@ export class FirebaseDataService implements DataService {
     // aaand it doesn't work...
     // Removed duplicate retryIconGeneration
 
+  // `total` is the size of the whole matching set, NOT of the page — the gallery
+  // pager derives its page count from it (`Math.ceil(total / limit)`), so an
+  // estimate derived from the current page produced phantom pages that render
+  // empty (issue #280).
   async getPagedIcons(page: number, limit: number, query?: string): Promise<{ icons: any[], total: number }> {
       try {
-          const offset = (page - 1) * limit;
+          const safeLimit = Math.max(1, Math.floor(limit) || ICON_GALLERY_PAGE_SIZE);
+          const safePage = Math.max(1, Math.floor(page) || 1);
+          const offset = (safePage - 1) * safeLimit;
 
-          let q: FirebaseFirestore.Query = db.collection(DB_COLLECTION_ICON_INDEX)
+          const base: FirebaseFirestore.Query = this._db.collection(DB_COLLECTION_ICON_INDEX)
               .orderBy('created_at', 'desc');
-          
-          if (!query) {
-              q = q.offset(offset).limit(limit);
-          } else {
-              q = q.limit(1000); 
-          }
 
-          const snapshot = await q.get();
-          let allIcons: any[] = snapshot.docs.map(doc => {
+          const mapDocs = (docs: FirebaseFirestore.QueryDocumentSnapshot[]): any[] => docs.map(doc => {
               const data = doc.data();
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               const { embedding, embedding_minilm, ...rest } = data;
@@ -659,17 +658,26 @@ export class FirebaseDataService implements DataService {
               };
           });
 
-          if (query && query.trim()) {
-              const term = query.toLowerCase().trim();
-              allIcons = allIcons.filter((i: any) => 
-                  i.visualDescription?.toLowerCase().includes(term) || 
-                  i.ingredient_name?.toLowerCase().includes(term)
-              );
-              allIcons = allIcons.slice(offset, offset + limit);
+          const term = query?.toLowerCase().trim() ?? '';
+
+          if (!term) {
+              // Unfiltered: Firestore pages for us, and count() gives the exact total.
+              const [snapshot, countSnapshot] = await Promise.all([
+                  base.offset(offset).limit(safeLimit).get(),
+                  base.count().get(),
+              ]);
+              return { icons: mapDocs(snapshot.docs), total: countSnapshot.data().count };
           }
 
-          const totalEstimate = allIcons.length > 0 ? (page * limit) + allIcons.length : (page - 1) * limit;
-          return { icons: allIcons, total: totalEstimate };
+          // Search: there is no server-side text index, so the newest
+          // ICON_SEARCH_SCAN_LIMIT icons are filtered in memory. `total` is the
+          // size of that filtered set, so the pager only offers pages that exist.
+          const snapshot = await base.limit(ICON_SEARCH_SCAN_LIMIT).get();
+          const matches = mapDocs(snapshot.docs).filter((i: any) =>
+              i.visualDescription?.toLowerCase().includes(term) ||
+              i.ingredient_name?.toLowerCase().includes(term)
+          );
+          return { icons: matches.slice(offset, offset + safeLimit), total: matches.length };
       } catch (e: any) {
           console.warn('getPagedIcons failed:', e.message);
           return { icons: [], total: 0 };

--- a/recipe-lanes/scripts/unit-test-manifest.mjs
+++ b/recipe-lanes/scripts/unit-test-manifest.mjs
@@ -47,6 +47,7 @@ export const INTEGRATION_TESTS = [
   'functions-metadata.test.ts',
   'hybrid-integration.test.ts',
   'icon-apply-auth.test.ts',
+  'icon-gallery-pagination-integration.test.ts',
   'icon-index.test.ts',
   'icon-queue-config.test.ts',
   'impression-rejection.test.ts',

--- a/recipe-lanes/tests/icon-gallery-pagination-integration.test.ts
+++ b/recipe-lanes/tests/icon-gallery-pagination-integration.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Emulator-backed pagination tests for the shared icon gallery (issue #280).
+ *
+ * tests/icon-gallery-pagination.test.ts covers the paging arithmetic with a
+ * stubbed Firestore. This file covers what a stub cannot: that the real
+ * Firestore query getPagedIcons builds — `orderBy(...).count()` alongside
+ * `orderBy(...).offset(...).limit(...)` — actually behaves as assumed.
+ *
+ * Requires the Firestore emulator. Run via `npm run test:unit:integration`, or
+ * directly with the emulator already running:
+ *   npx env-cmd -f .env.test node --import tsx --test tests/icon-gallery-pagination-integration.test.ts
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { getDataService } from '../lib/data-service';
+import { db } from '../lib/firebase-admin';
+import { DB_COLLECTION_ICON_INDEX } from '../lib/config';
+
+/** Unique per run so a shared emulator instance cannot cross-contaminate. */
+const RUN_TAG = `pagintest${Date.now()}`;
+const SEEDED_IDS: string[] = [];
+
+async function seedIcon(index: number, name: string): Promise<void> {
+    const id = `${RUN_TAG}-${index}`;
+    await db.collection(DB_COLLECTION_ICON_INDEX).doc(id).set({
+        icon_id: id,
+        ingredient_name: name,
+        visualDescription: name,
+        url: `https://example.com/${id}.png`,
+        // Distinct, ordered timestamps — getPagedIcons orders by created_at desc,
+        // and documents without the field are excluded from the ordered query.
+        created_at: new Date(1_700_000_000_000 + index * 1000),
+    });
+    SEEDED_IDS.push(id);
+}
+
+describe('getPagedIcons pagination (emulator)', () => {
+    const service = getDataService();
+    let baselineTotal = 0;
+
+    before(async () => {
+        baselineTotal = (await service.getPagedIcons(1, 1)).total;
+        for (let i = 0; i < 5; i++) {
+            await seedIcon(i, `${RUN_TAG} ingredient ${i}`);
+        }
+    });
+
+    after(async () => {
+        await Promise.all(
+            SEEDED_IDS.map(id => db.collection(DB_COLLECTION_ICON_INDEX).doc(id).delete()),
+        );
+    });
+
+    it('total reflects the real collection size via the count() aggregation', async () => {
+        // Proves count() is supported and exact: seeding 5 icons moves the total by
+        // exactly 5, independent of which page was requested.
+        const total = (await service.getPagedIcons(1, 1)).total;
+        assert.strictEqual(total, baselineTotal + 5);
+
+        const fromLaterPage = (await service.getPagedIcons(3, 1)).total;
+        assert.strictEqual(fromLaterPage, total, 'total must not depend on the requested page');
+    });
+
+    it('a single full page does not advertise a phantom next page', async () => {
+        // The regression: total used to be (page * limit) + icons.length, so a set
+        // that fits on one page still reported two.
+        const total = baselineTotal + 5;
+        const res = await service.getPagedIcons(1, total);
+
+        assert.strictEqual(res.icons.length, total, 'the whole set must fit on one page');
+        assert.strictEqual(res.total, total);
+        assert.strictEqual(Math.ceil(res.total / total), 1);
+    });
+
+    it('walks pages without skipping or repeating documents', async () => {
+        const total = baselineTotal + 5;
+        const limit = 2;
+        const seen: string[] = [];
+
+        for (let page = 1; page <= Math.ceil(total / limit); page++) {
+            const res = await service.getPagedIcons(page, limit);
+            assert.strictEqual(res.total, total, `page ${page} must report the real total`);
+            seen.push(...res.icons.map((i: any) => i.id));
+        }
+
+        assert.strictEqual(seen.length, total, 'every document must appear exactly once');
+        assert.strictEqual(new Set(seen).size, total, 'no document may appear twice');
+        for (const id of SEEDED_IDS) {
+            assert.ok(seen.includes(id), `seeded icon ${id} must appear while paging`);
+        }
+    });
+
+    it('a page past the end is empty but still reports the real total', async () => {
+        const total = baselineTotal + 5;
+        const res = await service.getPagedIcons(total + 10, 1);
+
+        assert.deepStrictEqual(res.icons, []);
+        assert.strictEqual(res.total, total, 'an over-scrolled pager must be able to find its way back');
+    });
+
+    it('search totals count every match, not just the current page', async () => {
+        const first = await service.getPagedIcons(1, 2, RUN_TAG);
+        assert.strictEqual(first.total, 5, 'all 5 seeded icons match the run tag');
+        assert.strictEqual(first.icons.length, 2);
+        assert.strictEqual(Math.ceil(first.total / 2), 3);
+
+        const last = await service.getPagedIcons(3, 2, RUN_TAG);
+        assert.strictEqual(last.total, 5);
+        assert.strictEqual(last.icons.length, 1, 'the third page holds the remaining match');
+
+        const beyond = await service.getPagedIcons(4, 2, RUN_TAG);
+        assert.strictEqual(beyond.total, 5);
+        assert.deepStrictEqual(beyond.icons, []);
+
+        // Pages must partition the match set.
+        const second = await service.getPagedIcons(2, 2, RUN_TAG);
+        const ids = [...first.icons, ...second.icons, ...last.icons].map((i: any) => i.id);
+        assert.strictEqual(new Set(ids).size, 5);
+    });
+
+    it('a search with no matches reports a zero total', async () => {
+        const res = await service.getPagedIcons(1, 20, `${RUN_TAG}-no-such-ingredient`);
+
+        assert.deepStrictEqual(res.icons, []);
+        assert.strictEqual(res.total, 0);
+    });
+});

--- a/recipe-lanes/tests/icon-gallery-pagination.test.ts
+++ b/recipe-lanes/tests/icon-gallery-pagination.test.ts
@@ -1,0 +1,257 @@
+/*
+ * Regression tests for issue #280 — "fix pagination on icon_overview".
+ *
+ * The shared gallery pager derives its page count from the `total` returned by
+ * getPagedIcons (`Math.ceil(total / limit)`). The old implementation returned an
+ * *estimate* computed from the current page — `(page * limit) + icons.length` —
+ * which always overshot by a full page, so the pager offered a "next" page that
+ * did not exist and rendered empty. These tests pin `total` to the real size of
+ * the matching set on both the unfiltered and the search path.
+ *
+ * Pure tier: the Firestore handle is patched on the service instance
+ * (`service._db`), the same way tests/icon-search.test.ts does it, so no
+ * emulator is needed.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { FirebaseDataService } from '../lib/data-service';
+import { DB_COLLECTION_ICON_INDEX, ICON_SEARCH_SCAN_LIMIT } from '../lib/config';
+
+// ---------------------------------------------------------------------------
+// Fake Firestore
+// ---------------------------------------------------------------------------
+
+type FakeDoc = { id: string; data: () => Record<string, any> };
+
+interface RecordedCalls {
+    collections: string[];
+    orderBy: [string, string][];
+    offsets: number[];
+    limits: number[];
+    countCalls: number;
+}
+
+/**
+ * A minimal stand-in for the chained Firestore query builder. Each chaining call
+ * returns a *new* query object, so a builder can be branched (the unfiltered path
+ * reuses the ordered base query for both the page fetch and the count).
+ *
+ * `count()` reports the size of the whole collection regardless of offset/limit,
+ * matching Firestore's aggregation semantics.
+ */
+function makeFakeDb(docs: FakeDoc[]) {
+    const calls: RecordedCalls = { collections: [], orderBy: [], offsets: [], limits: [], countCalls: 0 };
+
+    const makeQuery = (state: { offset?: number; limit?: number }): any => ({
+        orderBy: (field: string, direction: string) => {
+            calls.orderBy.push([field, direction]);
+            return makeQuery(state);
+        },
+        offset: (n: number) => {
+            calls.offsets.push(n);
+            return makeQuery({ ...state, offset: n });
+        },
+        limit: (n: number) => {
+            calls.limits.push(n);
+            return makeQuery({ ...state, limit: n });
+        },
+        count: () => {
+            calls.countCalls += 1;
+            return { get: async () => ({ data: () => ({ count: docs.length }) }) };
+        },
+        get: async () => {
+            const start = state.offset ?? 0;
+            const end = state.limit === undefined ? docs.length : start + state.limit;
+            return { docs: docs.slice(start, end) };
+        },
+    });
+
+    return {
+        db: {
+            collection: (name: string) => {
+                calls.collections.push(name);
+                return makeQuery({});
+            },
+        },
+        calls,
+    };
+}
+
+const makeDoc = (index: number, name = `ingredient-${index}`): FakeDoc => ({
+    id: `icon-${index}`,
+    data: () => ({
+        ingredient_name: name,
+        visualDescription: name,
+        created_at: null,
+        // Embeddings are large and must never be shipped to the gallery client.
+        embedding: [0.1, 0.2, 0.3],
+        embedding_minilm: [0.4, 0.5],
+    }),
+});
+
+const makeDocs = (count: number, name?: (i: number) => string): FakeDoc[] =>
+    Array.from({ length: count }, (_, i) => makeDoc(i, name ? name(i) : undefined));
+
+function serviceWith(docs: FakeDoc[]) {
+    const fake = makeFakeDb(docs);
+    const service = new FirebaseDataService();
+    // @ts-expect-error — patching the internal Firestore handle for the test
+    service._db = fake.db;
+    return { service, calls: fake.calls };
+}
+
+// ---------------------------------------------------------------------------
+// Unfiltered pagination
+// ---------------------------------------------------------------------------
+
+describe('getPagedIcons — unfiltered pagination (#280)', () => {
+
+    it('reports the true collection size as total, not a page-derived estimate', async () => {
+        // Exactly one full page exists. The old estimate returned (1 * 20) + 20 = 40,
+        // which made the pager show "Page 1 of 2" and enable a next page that was empty.
+        const { service, calls } = serviceWith(makeDocs(20));
+
+        const res = await service.getPagedIcons(1, 20);
+
+        assert.strictEqual(res.total, 20, 'total must be the real number of icons');
+        assert.strictEqual(res.icons.length, 20);
+        assert.strictEqual(Math.ceil(res.total / 20), 1, 'a single full page must not advertise a second page');
+        assert.strictEqual(calls.countCalls, 1, 'the unfiltered path must use a count() aggregation');
+    });
+
+    it('queries icon_index newest-first and translates page/limit into offset/limit', async () => {
+        const { service, calls } = serviceWith(makeDocs(100));
+
+        const res = await service.getPagedIcons(3, 20);
+
+        assert.deepStrictEqual(calls.collections, [DB_COLLECTION_ICON_INDEX]);
+        assert.deepStrictEqual(calls.orderBy, [['created_at', 'desc']]);
+        assert.ok(calls.offsets.includes(40), 'page 3 at limit 20 must skip 40 documents');
+        assert.ok(calls.limits.includes(20), 'the page size must be pushed down to Firestore');
+        assert.deepStrictEqual(res.icons.map((i: any) => i.id), makeDocs(100).slice(40, 60).map(d => d.id));
+        assert.strictEqual(res.total, 100);
+    });
+
+    it('reports the full total on a partial last page', async () => {
+        // 25 icons, page 2 of 20 → 5 icons. Old estimate: (2 * 20) + 5 = 45 → 3 pages.
+        const { service } = serviceWith(makeDocs(25));
+
+        const res = await service.getPagedIcons(2, 20);
+
+        assert.strictEqual(res.icons.length, 5);
+        assert.strictEqual(res.total, 25);
+        assert.strictEqual(Math.ceil(res.total / 20), 2, 'the last page must be the last page');
+    });
+
+    it('still reports the real total when the requested page is past the end', async () => {
+        // The old code returned (page - 1) * limit here, so an over-scrolled pager
+        // reported a total that agreed with the bogus page it was already on and
+        // the user was stranded on an empty view.
+        const { service } = serviceWith(makeDocs(25));
+
+        const res = await service.getPagedIcons(5, 20);
+
+        assert.deepStrictEqual(res.icons, []);
+        assert.strictEqual(res.total, 25, 'an over-scrolled page must still report the real total');
+    });
+
+    it('strips embeddings from gallery results', async () => {
+        const { service } = serviceWith(makeDocs(1));
+
+        const res = await service.getPagedIcons(1, 20);
+
+        assert.strictEqual(res.icons.length, 1);
+        assert.ok(!('embedding' in res.icons[0]), 'embedding must not be sent to the gallery');
+        assert.ok(!('embedding_minilm' in res.icons[0]), 'embedding_minilm must not be sent to the gallery');
+        assert.strictEqual(res.icons[0].id, 'icon-0');
+    });
+
+    it('treats a whitespace-only query as no query', async () => {
+        // Previously `!query` was false for '   ' but `query.trim()` was falsy, so the
+        // request fell between the two branches: 1000 unpaged icons, unsliced.
+        const { service, calls } = serviceWith(makeDocs(50));
+
+        const res = await service.getPagedIcons(1, 20, '   ');
+
+        assert.strictEqual(res.icons.length, 20, 'a blank search must still be paged');
+        assert.strictEqual(res.total, 50);
+        assert.strictEqual(calls.countCalls, 1);
+    });
+
+    it('clamps a non-positive page to the first page', async () => {
+        const { service, calls } = serviceWith(makeDocs(30));
+
+        const res = await service.getPagedIcons(0, 20);
+
+        assert.deepStrictEqual(calls.offsets, [0], 'page 0 must not produce a negative offset');
+        assert.strictEqual(res.icons.length, 20);
+        assert.strictEqual(res.total, 30);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Search pagination
+// ---------------------------------------------------------------------------
+
+describe('getPagedIcons — search pagination (#280)', () => {
+
+    // 30 matching icons interleaved with 30 non-matching ones.
+    const searchDocs = () => makeDocs(60, i => (i % 2 === 0 ? `tomato-${i}` : `onion-${i}`));
+
+    it('reports the number of matches as total, not a page-derived estimate', async () => {
+        const { service } = serviceWith(searchDocs());
+
+        const res = await service.getPagedIcons(1, 20, 'tomato');
+
+        assert.strictEqual(res.total, 30, 'total must count every match, not just this page');
+        assert.strictEqual(res.icons.length, 20);
+        assert.strictEqual(Math.ceil(res.total / 20), 2);
+        assert.ok(res.icons.every((i: any) => i.ingredient_name.startsWith('tomato')));
+    });
+
+    it('slices the correct page out of the filtered set', async () => {
+        const { service } = serviceWith(searchDocs());
+
+        const res = await service.getPagedIcons(2, 20, 'tomato');
+
+        assert.strictEqual(res.icons.length, 10, 'page 2 holds the remaining 10 matches');
+        assert.strictEqual(res.total, 30);
+        assert.strictEqual(res.icons[0].id, 'icon-40');
+    });
+
+    it('does not count the whole collection on the search path', async () => {
+        // A count() here would return every icon in icon_index, not the matches,
+        // and put the pager straight back into phantom-page territory.
+        const { service, calls } = serviceWith(searchDocs());
+
+        await service.getPagedIcons(1, 20, 'tomato');
+
+        assert.strictEqual(calls.countCalls, 0);
+        assert.ok(calls.limits.includes(ICON_SEARCH_SCAN_LIMIT), 'search scans the newest icons in one window');
+        assert.deepStrictEqual(calls.offsets, [], 'search must not push an offset down to Firestore');
+    });
+
+    it('matches case-insensitively on visual description as well as ingredient name', async () => {
+        const docs: FakeDoc[] = [
+            { id: 'a', data: () => ({ ingredient_name: 'Onion', visualDescription: 'A ripe TOMATO', created_at: null }) },
+            { id: 'b', data: () => ({ ingredient_name: 'Tomato', visualDescription: 'red thing', created_at: null }) },
+            { id: 'c', data: () => ({ ingredient_name: 'Garlic', visualDescription: 'white bulb', created_at: null }) },
+        ];
+        const { service } = serviceWith(docs);
+
+        const res = await service.getPagedIcons(1, 20, '  ToMaTo  ');
+
+        assert.strictEqual(res.total, 2);
+        assert.deepStrictEqual(res.icons.map((i: any) => i.id), ['a', 'b']);
+    });
+
+    it('returns an empty page and a zero total when nothing matches', async () => {
+        const { service } = serviceWith(searchDocs());
+
+        const res = await service.getPagedIcons(1, 20, 'saffron');
+
+        assert.deepStrictEqual(res.icons, []);
+        assert.strictEqual(res.total, 0);
+    });
+});


### PR DESCRIPTION
Closes #280

## What & why

`getPagedIcons` (`recipe-lanes/lib/data-service.ts`) returned an **estimated** `total` derived from the page being requested:

```js
const totalEstimate = allIcons.length > 0 ? (page * limit) + allIcons.length : (page - 1) * limit;
```

The gallery pager turns that into a page count with `Math.ceil(total / limit)`, so the estimate always overshot by exactly one page. Concretely, with 20 icons and a page size of 20: page 1 reported `total = 40` → "Page 1 of 2" with the next arrow enabled → page 2 returned nothing, and the estimate then collapsed to `(2 - 1) * 20 = 20` → "Page 2 of 1", an empty grid, and a page number past the end of a set that now claimed to be shorter than where the user stood.

The fix returns the real size of the matching set:

- **unfiltered** — a Firestore `count()` aggregation on the *same* ordered query that pages the results, so `total` is exact and independent of `page`;
- **search** — the size of the filtered set. `icon_index` has no server-side text index, so search still scans the newest `ICON_SEARCH_SCAN_LIMIT` icons and filters in memory; only the total changes meaning.

Two smaller defects in the same function fell out of the rewrite:

- a **whitespace-only query** fell between `!query` and `query.trim()`: it took the search branch (no `offset`/`limit`) but failed the filter branch (no slice), returning up to 1000 unpaged icons. A single normalized `term` closes the gap.
- a **non-positive page** produced a negative Firestore offset. `page`/`limit` now come from a public, unauthenticated server action, so both are clamped.

The page size moves to one shared constant (`ICON_GALLERY_PAGE_SIZE` in `lib/config.ts`) used by both the client pager and the server query, so the two cannot silently drift — which is the class of bug being fixed here. `getPagedIcons` also now reads Firestore through `this._db` like the rest of `FirebaseDataService`; that is what lets the pure tier patch it.

`MemoryDataService.getPagedIcons` already returned a true total, so this brings the Firebase implementation in line with the contract the interface already implied.

## How verified

**Tests added** — both new files, covering the changed behavior directly:

- `recipe-lanes/tests/icon-gallery-pagination.test.ts` — **12 pure cases** (auto-discovered by `test:unit:pure`). Patches `service._db` with a fake chained query builder, the same technique `tests/icon-search.test.ts` already uses. Pins: total is the real collection size not a page-derived estimate; one full page does not advertise a phantom second page; a partial last page reports the full total; a page past the end still reports the real total; `page`/`limit` translate to the right `offset`/`limit`; embeddings stay stripped; whitespace-only queries are treated as no query; non-positive pages clamp to offset 0. On the search path: total counts every match, page 2 slices correctly, `count()` is *not* called (it would count the whole collection rather than the matches), matching is case-insensitive across `visualDescription` and `ingredient_name`, and a no-match search reports zero.
- `recipe-lanes/tests/icon-gallery-pagination-integration.test.ts` — **6 emulator cases**, registered in `scripts/unit-test-manifest.mjs`. This exists because a stub cannot prove the *real* query works: it seeds icons into `icon_index` under a per-run tag and asserts that `orderBy(...).count()` is supported and exact (seeding 5 moves the total by exactly 5), that the total does not vary with the page requested, that walking every page yields each document exactly once with no gaps or repeats, that an over-scrolled page is empty but still reports the real total, and that search totals count every match.

**Local pre-check** (from `recipe-lanes/`): `npm run lint` — 0 errors, no new warnings vs. `main`; `npm run typecheck` — clean; `npm run test:unit:pure` — passed via the pre-commit hook, which gates this commit.

**CI**: `fast-checks`, `integration`, and `e2e` should all execute — the diff touches `recipe-lanes/lib/**`, `recipe-lanes/components/**`, and `recipe-lanes/tests/**`, all inside the workflow's `code` path filter. I'll confirm they ran rather than skipped, and report the result on this PR.

No e2e test was added. The defect is entirely in a server function's return value, and the client's consumption of it is a single unchanged arithmetic line (`Math.ceil(total / ICON_GALLERY_PAGE_SIZE)`); the integration test exercises the real production path against the real emulator and asserts the user-visible property (page count, no phantom page, no skipped or repeated icons). Seeding 21+ icons to drive a browser pager would add meaningful e2e runtime for no additional coverage of the change. Flagging the call explicitly given the `docs/WORKLOG.md` 2026-07-04 lesson about unit-testing a subsystem while the real behavior stays broken — happy to add one if a reviewer disagrees.

## Risks / unsure about

- **`count()` support.** The unfiltered path now depends on Firestore's `count()` aggregation (firebase-admin ^13.6.0, firebase-tools ^15). The integration test is there precisely to prove this against the emulator rather than assume it. If it were unsupported, the `try/catch` would swallow it and the gallery would show an empty grid — a louder failure than today's, so worth watching the `integration` job.
- **Extra read per page load.** One count aggregation per unfiltered gallery page. Aggregations bill roughly one read per 1000 index entries, so this is negligible at current icon volumes.
- **Pre-existing, not addressed here.** `getPagedIconsAction` is public and unauthenticated, and Firestore `.offset(n)` bills `n` reads — so a caller passing a huge `page` can still run up reads. This PR clamps the low end but not the high end. It is a billing/abuse concern rather than the pagination bug, so per hard rule #5 it belongs in its own change; flagging it here so it is not lost.
- **Search totals are still bounded** by the `ICON_SEARCH_SCAN_LIMIT` (1000) scan window — unchanged behavior, but it means a search matching more than 1000 of the newest icons would still under-report. Fixing that needs a real text index, which is out of scope.

## Process note

`node .github/scripts/agent-claim.mjs claim 280` could not run in this environment: outbound HTTPS goes through an agent proxy, `GH_TOKEN`/`GITHUB_TOKEN` are proxy placeholders rather than real tokens, and direct `api.github.com` calls are refused with *"GitHub access is not enabled for this session"* — the GitHub MCP tools are the only working path. The claim protocol was honoured by hand instead: the claim comment on #280 carries the same hidden `<!-- agent-claim worker="…" -->` marker, `agent-claimed` was added, and after the settle window mine was the only live claim. `docs/WORKLOG.md` records this so the next worker does not read a 401 as "no claim needed".

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDGuwuCuUHnbG4niLPriah)_