### PR TITLE
fix(store): exhaustive field-ownership map + mergeNode reconciliation (#220)

### DIFF
--- a/recipe-lanes/lib/recipe-lanes/node-fields.ts
+++ b/recipe-lanes/lib/recipe-lanes/node-fields.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Exhaustive ownership map for every `RecipeNode` field (issue #220).
+ *
+ * `mergeNode` (lib/stores/recipe-store.ts) used to decide "structurally
+ * identical" from a hand-picked subset of fields (text/quantity/unit/
+ * visualDescription + the shortlist key). Any field NOT in that subset —
+ * e.g. `status`, `laneId`, `duration` — could change on an incoming
+ * snapshot and be silently dropped by the fast path, because the merge
+ * never noticed. That is how #220 happened: `failRecipeIcon` writes
+ * `status: 'failed'` and nothing else, so the old comparison saw "nothing
+ * changed" and returned the stale node — infinite spinner.
+ *
+ * The fix: classify every field's ownership ONCE, here, and derive the
+ * merge algorithm from the map instead of an ad hoc field list. The
+ * `satisfies Record<keyof RecipeNode, FieldOwnership>` check below makes
+ * forgetting to classify a newly-added `RecipeNode` field a compile error.
+ *
+ * Ownership categories:
+ * - 'client': the client is the source of truth. A background server
+ *   snapshot must NOT overwrite the local value (e.g. rendered x/y — see
+ *   the design-principles comment in recipe-store.ts for why).
+ * - 'server': the server is the source of truth. An incoming value must
+ *   win, AND a change to one of these fields must trigger a merge even if
+ *   every other field is untouched (this is the #220 fix — status flips
+ *   like `pending` -> `failed` must not be swallowed by the fast path).
+ * - 'structural': recipe content/topology. Server-authored via
+ *   AI generation, but also locally editable (updateNode); either side's
+ *   change must be reflected.
+ *
+ * This map is also intended for a later PR's `saveRecipe` reconciliation,
+ * so keep it dependency-light — it imports only the `RecipeNode` type.
+ */
+
+import type { RecipeNode } from './types';
+
+export type FieldOwnership = 'client' | 'server' | 'structural';
+
+export const NODE_FIELD_OWNERSHIP = {
+    // Structural — recipe content/topology.
+    id: 'structural',
+    laneId: 'structural',
+    text: 'structural',
+    visualDescription: 'structural',
+    type: 'structural',
+    inputs: 'structural',
+    temperature: 'structural',
+    duration: 'structural',
+    quantity: 'structural',
+    unit: 'structural',
+    canonicalName: 'structural',
+    iconTheme: 'structural',
+
+    // Server — the server is authoritative; a change must always be
+    // reflected, even in isolation.
+    iconShortlist: 'server',
+    status: 'server',
+    fastMatches: 'server',
+    hydeQueries: 'server',
+    iconQuery: 'server',
+
+    // Client — the client is authoritative; a background snapshot must
+    // never clobber these.
+    x: 'client',
+    y: 'client',
+    rotation: 'client',
+    textPos: 'client',
+    shortlistIndex: 'client',
+    shortlistCycled: 'client',
+} as const satisfies Record<keyof RecipeNode, FieldOwnership>;
+
+type NodeFieldOwnershipMap = typeof NODE_FIELD_OWNERSHIP;
+
+function fieldsWithOwnership<O extends FieldOwnership>(
+    ownership: O,
+): readonly (keyof NodeFieldOwnershipMap & keyof RecipeNode)[] {
+    return (Object.keys(NODE_FIELD_OWNERSHIP) as (keyof NodeFieldOwnershipMap)[]).filter(
+        (field) => NODE_FIELD_OWNERSHIP[field] === ownership,
+    );
+}
+
+export const CLIENT_FIELDS: readonly (keyof RecipeNode)[] = fieldsWithOwnership('client');
+export const SERVER_FIELDS: readonly (keyof RecipeNode)[] = fieldsWithOwnership('server');
+export const STRUCTURAL_FIELDS: readonly (keyof RecipeNode)[] = fieldsWithOwnership('structural');

--- a/recipe-lanes/lib/stores/recipe-store.ts
+++ b/recipe-lanes/lib/stores/recipe-store.ts
@@ -45,6 +45,7 @@
 import { create } from 'zustand';
 import { RecipeGraph, RecipeNode, NodeLayout, IconStyleId, LineStyleId, LayoutModeId, BackgroundElementId, CanvasBackgroundId, ChatMessage } from '../recipe-lanes/types';
 import { getNodeShortlistKey, cycleShortlistNodes } from '../recipe-lanes/model-utils';
+import { STRUCTURAL_FIELDS, SERVER_FIELDS } from '../recipe-lanes/node-fields';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -256,58 +257,121 @@ interface RecipeActions {
 // Merge helpers
 // ---------------------------------------------------------------------------
 
+/** Shallow array equality: same length, `===` per element. undefined is treated as []. */
+function arraysShallowEqual(a: readonly unknown[] | undefined, b: readonly unknown[] | undefined): boolean {
+    const aArr = a ?? [];
+    const bArr = b ?? [];
+    if (aArr.length !== bArr.length) return false;
+    return aArr.every((v, i) => v === bArr[i]);
+}
+
+/**
+ * Value equality for fields too complex for `===` (objects / object arrays).
+ * JSON.stringify is a deliberately blunt instrument here: per the #220 spec,
+ * complex SERVER fields must err toward "equal" only when they truly are —
+ * a false "changed" only costs a spurious re-render, but a false "equal"
+ * reproduces the #220 bug (a real server change silently dropped).
+ * undefined and null are treated as equivalent "empty" states.
+ */
+function valuesEqual(a: unknown, b: unknown): boolean {
+    if (a === b) return true;
+    if (a == null && b == null) return true;
+    if (a == null || b == null) return false;
+    return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** Assigns `source[field]` onto `target[field]` with the field's own type preserved. */
+function copyField<K extends keyof RecipeNode>(target: RecipeNode, source: RecipeNode, field: K) {
+    target[field] = source[field];
+}
+
+/** True when a single STRUCTURAL field differs between existing and incoming. */
+function structuralFieldChanged(field: keyof RecipeNode, existing: RecipeNode, incoming: RecipeNode): boolean {
+    if (field === 'inputs') {
+        return !arraysShallowEqual(existing.inputs, incoming.inputs);
+    }
+    return existing[field] !== incoming[field];
+}
+
+/**
+ * True when a single SERVER field differs between existing and incoming.
+ * `iconShortlist` is compared via the shared shortlist-key check (the
+ * canonical shortlist value-key) rather than by reference or by re-deriving
+ * its own key, so this stays consistent with `shortlistChanged` below.
+ */
+function serverFieldChanged(
+    field: keyof RecipeNode,
+    existing: RecipeNode,
+    incoming: RecipeNode,
+    shortlistChanged: boolean,
+): boolean {
+    switch (field) {
+        case 'iconShortlist':
+            return shortlistChanged;
+        case 'hydeQueries':
+            return !arraysShallowEqual(existing.hydeQueries, incoming.hydeQueries);
+        case 'fastMatches':
+            return !valuesEqual(existing.fastMatches, incoming.fastMatches);
+        case 'iconQuery':
+            return !valuesEqual(existing.iconQuery, incoming.iconQuery);
+        default:
+            return existing[field] !== incoming[field];
+    }
+}
+
 /**
  * Merges one incoming node with the locally-held version.
  * Returns the existing reference unchanged when nothing meaningful differs,
  * so Zustand selectors subscribed to that node do not re-render.
+ *
+ * Driven by the field ownership map (lib/recipe-lanes/node-fields.ts, #220):
+ * a STRUCTURAL or SERVER field change always wins and always triggers a
+ * merge (a server-only change like `status: 'pending' -> 'failed'` must
+ * never be silently dropped — that was #220). CLIENT fields (x/y, rotation,
+ * shortlistIndex, ...) are intentionally excluded from the "did anything
+ * change" check: the client is their source of truth, so a background
+ * snapshot differing only in those fields must neither break node identity
+ * (that would re-render every node on every icon write) nor clobber the
+ * client's local value.
  */
 function mergeNode(existing: RecipeNode, incoming: RecipeNode): RecipeNode {
-    const existingShortlistKey = getNodeShortlistKey(existing);
-    const incomingShortlistKey = getNodeShortlistKey(incoming);
-    const shortlistChanged = existingShortlistKey !== incomingShortlistKey;
+    const shortlistChanged = getNodeShortlistKey(existing) !== getNodeShortlistKey(incoming);
 
-    // x/y are CLIENT-owned: the store mirrors the rendered positions
-    // (syncNodePositions after every layout pass), so a background snapshot
-    // whose x/y differ must neither break node identity (that re-renders
-    // every node on every icon write) nor clobber the mirror (a later history
-    // snapshot would then capture coordinates the user never saw). Saved
-    // positions are restored via graph.layouts at load, not via node x/y.
-    const structurallyIdentical =
-        existing.text === incoming.text &&
-        existing.quantity === incoming.quantity &&
-        existing.unit === incoming.unit &&
-        existing.visualDescription === incoming.visualDescription;
+    const structuralChanged = STRUCTURAL_FIELDS.some(field =>
+        structuralFieldChanged(field, existing, incoming),
+    );
+    const serverChanged = SERVER_FIELDS.some(field =>
+        serverFieldChanged(field, existing, incoming, shortlistChanged),
+    );
 
-    // Fast path: nothing changed → keep exact reference.
-    if (!shortlistChanged && structurallyIdentical) {
+    // Fast path: no STRUCTURAL or SERVER field changed → keep exact
+    // reference. CLIENT-field differences (x/y, rotation, ...) are
+    // deliberately ignored here.
+    if (!structuralChanged && !serverChanged) {
         return existing;
     }
 
-    // Icons-only update (resolveRecipeIcons writes back shortlists without touching
-    // structure): preserve all local fields, splice in only the icon-related ones.
-    // This prevents a server write from overwriting local position/text state.
-    if (shortlistChanged && structurallyIdentical) {
-        return {
-            ...existing,
-            iconShortlist: incoming.iconShortlist,
-            shortlistIndex: incoming.shortlistIndex ?? 0,
-            status: incoming.status,
-        };
-    }
+    const merged: RecipeNode = { ...existing };
+    for (const field of STRUCTURAL_FIELDS) copyField(merged, incoming, field);
+    for (const field of SERVER_FIELDS) copyField(merged, incoming, field);
 
-    return {
-        ...incoming,
-        // Keep the client-owned position mirror once it exists (see above);
-        // adopt the incoming coordinates only when there is no local mirror
-        // yet (e.g. a node this client has never rendered).
-        x: existing.x !== undefined ? existing.x : incoming.x,
-        y: existing.y !== undefined ? existing.y : incoming.y,
-        // When the shortlist was regenerated (forge), the server resets index
-        // to 0. Otherwise preserve whatever the user has locally.
-        shortlistIndex: shortlistChanged
-            ? (incoming.shortlistIndex ?? 0)
-            : existing.shortlistIndex,
-    };
+    // CLIENT fields stay from existing, with two exceptions:
+    // - x/y: keep the client-owned position mirror once it exists; adopt the
+    //   incoming coordinates only when there is no local mirror yet (e.g. a
+    //   node this client has never rendered). Saved positions are restored
+    //   via graph.layouts at load, not via node x/y.
+    merged.x = existing.x !== undefined ? existing.x : incoming.x;
+    merged.y = existing.y !== undefined ? existing.y : incoming.y;
+    // - shortlistIndex: reset to the incoming/server value when the
+    //   shortlist itself was regenerated (forge); otherwise preserve
+    //   whatever the user has locally (they may have cycled).
+    merged.shortlistIndex = shortlistChanged
+        ? (incoming.shortlistIndex ?? 0)
+        : existing.shortlistIndex;
+    // shortlistCycled is client-owned and intentionally left as-is (already
+    // copied from existing above) — resetting it is out of scope for #220.
+
+    return merged;
 }
 
 function mergeNodes(

--- a/recipe-lanes/tests/node-fields.test.ts
+++ b/recipe-lanes/tests/node-fields.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    NODE_FIELD_OWNERSHIP,
+    CLIENT_FIELDS,
+    SERVER_FIELDS,
+    STRUCTURAL_FIELDS,
+} from '../lib/recipe-lanes/node-fields';
+
+describe('node-fields ownership map (issue #220)', () => {
+    it('classifies exactly the expected CLIENT fields', () => {
+        assert.deepEqual(
+            [...CLIENT_FIELDS].sort(),
+            ['rotation', 'shortlistCycled', 'shortlistIndex', 'textPos', 'x', 'y'].sort(),
+        );
+    });
+
+    it('classifies exactly the expected SERVER fields', () => {
+        assert.deepEqual(
+            [...SERVER_FIELDS].sort(),
+            ['fastMatches', 'hydeQueries', 'iconQuery', 'iconShortlist', 'status'].sort(),
+        );
+    });
+
+    it('classifies exactly the expected STRUCTURAL fields', () => {
+        assert.deepEqual(
+            [...STRUCTURAL_FIELDS].sort(),
+            [
+                'canonicalName',
+                'duration',
+                'iconTheme',
+                'id',
+                'inputs',
+                'laneId',
+                'quantity',
+                'temperature',
+                'text',
+                'type',
+                'unit',
+                'visualDescription',
+            ].sort(),
+        );
+    });
+
+    it('has no field classified more than once (categories are disjoint)', () => {
+        const all = [...CLIENT_FIELDS, ...SERVER_FIELDS, ...STRUCTURAL_FIELDS];
+        assert.equal(all.length, new Set(all).size);
+    });
+
+    it('the three categories exactly cover every key in the map', () => {
+        const fromCategories = new Set([...CLIENT_FIELDS, ...SERVER_FIELDS, ...STRUCTURAL_FIELDS]);
+        const fromMap = new Set(Object.keys(NODE_FIELD_OWNERSHIP));
+        assert.deepEqual(fromCategories, fromMap);
+    });
+});

--- a/recipe-lanes/tests/recipe-store.test.ts
+++ b/recipe-lanes/tests/recipe-store.test.ts
@@ -594,4 +594,139 @@ describe('useRecipeStore', () => {
             assert.equal(useRecipeStore.getState().historyVersion, 0);
         });
     });
+
+    // Field-ownership-driven merge (issue #220): a server write that changes
+    // ONLY an uncompared field (e.g. failRecipeIcon setting status:'failed')
+    // used to hit mergeNode's fast path and be silently dropped, leaving the
+    // UI stuck on an infinite spinner. mergeNode is now driven exhaustively by
+    // lib/recipe-lanes/node-fields.ts's ownership map instead of a hand-picked
+    // field subset.
+    describe('mergeNode field ownership (issue #220)', () => {
+        it('(identity) keeps the same reference when only CLIENT fields (x/y) differ', () => {
+            const store = useRecipeStore.getState();
+            const node = makeNode('a', { x: 1, y: 1, status: 'pending' });
+            store.mergeSnapshot(makeGraph([node]));
+            const before = useRecipeStore.getState().graph!.nodes[0];
+
+            store.mergeSnapshot(makeGraph([{ ...node, x: 999, y: 999 }]));
+            const after = useRecipeStore.getState().graph!.nodes[0];
+
+            assert.strictEqual(after, before, 'STRUCTURAL and SERVER fields unchanged -> same reference');
+        });
+
+        it('(array identity) mergeSnapshot with an all-identical node array returns the same array reference', () => {
+            const store = useRecipeStore.getState();
+            const nodeA = makeNode('a');
+            const nodeB = makeNode('b');
+            store.mergeSnapshot(makeGraph([nodeA, nodeB]));
+            const before = useRecipeStore.getState().graph!.nodes;
+
+            store.mergeSnapshot(makeGraph([{ ...nodeA }, { ...nodeB }]));
+            const after = useRecipeStore.getState().graph!.nodes;
+
+            assert.strictEqual(after, before, 'identical incoming array -> same array reference');
+        });
+
+        it('(server change reflected) a status-only change is reflected, and every other node keeps identity', () => {
+            const store = useRecipeStore.getState();
+            const nodeA = makeNode('a', { status: 'pending' });
+            const nodeB = makeNode('b');
+            const nodeC = makeNode('c');
+            store.mergeSnapshot(makeGraph([nodeA, nodeB, nodeC]));
+            const beforeB = useRecipeStore.getState().graph!.nodes.find(n => n.id === 'b')!;
+            const beforeC = useRecipeStore.getState().graph!.nodes.find(n => n.id === 'c')!;
+
+            store.mergeSnapshot(makeGraph([{ ...nodeA, status: 'failed' }, nodeB, nodeC]));
+
+            const state = useRecipeStore.getState();
+            const afterA = state.graph!.nodes.find(n => n.id === 'a')!;
+            assert.equal(afterA.status, 'failed', 'status change must be reflected');
+            assert.strictEqual(state.graph!.nodes.find(n => n.id === 'b')!, beforeB);
+            assert.strictEqual(state.graph!.nodes.find(n => n.id === 'c')!, beforeC);
+        });
+
+        it('(structural change reflected) a laneId-only change is reflected', () => {
+            const store = useRecipeStore.getState();
+            const node = makeNode('a', { laneId: 'lane-1' });
+            store.mergeSnapshot(makeGraph([node]));
+
+            store.mergeSnapshot(makeGraph([{ ...node, laneId: 'lane-2' }]));
+
+            assert.equal(useRecipeStore.getState().graph!.nodes[0].laneId, 'lane-2');
+        });
+
+        it('(structural change reflected) an inputs-only change is reflected', () => {
+            const store = useRecipeStore.getState();
+            const node = makeNode('a', { inputs: ['x'] });
+            store.mergeSnapshot(makeGraph([node]));
+
+            store.mergeSnapshot(makeGraph([{ ...node, inputs: ['x', 'y'] }]));
+
+            assert.deepEqual(useRecipeStore.getState().graph!.nodes[0].inputs, ['x', 'y']);
+        });
+
+        it('(structural change reflected) a duration-only change is reflected', () => {
+            const store = useRecipeStore.getState();
+            const node = makeNode('a', { duration: '5 min' });
+            store.mergeSnapshot(makeGraph([node]));
+
+            store.mergeSnapshot(makeGraph([{ ...node, duration: '10 min' }]));
+
+            assert.equal(useRecipeStore.getState().graph!.nodes[0].duration, '10 min');
+        });
+
+        it('(client-owned preserved) an x/y-only change keeps the existing reference (client owns position)', () => {
+            const store = useRecipeStore.getState();
+            const node = makeNode('a', { x: 5, y: 5 });
+            store.mergeSnapshot(makeGraph([node]));
+            const before = useRecipeStore.getState().graph!.nodes[0];
+
+            store.mergeSnapshot(makeGraph([{ ...node, x: 50, y: 50 }]));
+
+            assert.strictEqual(useRecipeStore.getState().graph!.nodes[0], before);
+        });
+
+        it('(shortlist index preserved) local shortlistIndex survives a merge when the shortlist key is unchanged', () => {
+            const store = useRecipeStore.getState();
+            const entries = [makeEntry('icon-1'), makeEntry('icon-2')];
+            const node = makeNode('a', { iconShortlist: entries, shortlistIndex: 0, status: 'pending' });
+            store.mergeSnapshot(makeGraph([node]));
+
+            // User cycles to index 1 locally.
+            store.cycleShortlist('a');
+            assert.equal(useRecipeStore.getState().graph!.nodes[0].shortlistIndex, 1);
+
+            // Server writes back a status change; shortlist is unchanged.
+            store.mergeSnapshot(makeGraph([{ ...node, status: 'failed' }]));
+
+            const after = useRecipeStore.getState().graph!.nodes[0];
+            assert.equal(after.status, 'failed', 'server change is reflected');
+            assert.equal(after.shortlistIndex, 1, 'local cycle position survives an unrelated server merge');
+        });
+
+        it('(shortlist regeneration resets index) a regenerated shortlist resets shortlistIndex to the incoming value', () => {
+            const store = useRecipeStore.getState();
+            const originalEntries = [makeEntry('icon-1')];
+            const node = makeNode('a', { iconShortlist: originalEntries, shortlistIndex: 0 });
+            store.mergeSnapshot(makeGraph([node]));
+            store.cycleShortlist('a');
+
+            const newEntries = [makeEntry('icon-99'), makeEntry('icon-1')];
+            store.mergeSnapshot(makeGraph([makeNode('a', { iconShortlist: newEntries, shortlistIndex: 0 })]));
+
+            assert.equal(useRecipeStore.getState().graph!.nodes[0].shortlistIndex, 0);
+        });
+
+        it('(x/y adoption) incoming x/y are adopted when the existing node has no local mirror', () => {
+            const store = useRecipeStore.getState();
+            const node = makeNode('a', { status: 'pending' });
+            store.mergeSnapshot(makeGraph([node])); // x/y undefined locally
+
+            store.mergeSnapshot(makeGraph([{ ...node, status: 'failed', x: 7, y: 8 }]));
+
+            const after = useRecipeStore.getState().graph!.nodes[0];
+            assert.equal(after.x, 7);
+            assert.equal(after.y, 8);
+        });
+    });
 });


### PR DESCRIPTION
Closes #220. Second PR in the framework-first remediation (after #302, single undo owner).

## The bug, in one sentence
When a background Firestore snapshot changed **only** a field that `mergeNode` didn't happen to compare — most importantly `status` — the merge decided "nothing changed" and threw the update away. So when icon generation failed (`failRecipeIcon` writes `status:'failed'` and nothing else), the app never saw it: the node span forever, and the next client save wrote `pending` back over the server's `failed`.

The root cause is that `mergeNode` hand-picked ~4 fields (`text/quantity/unit/visualDescription` + a shortlist key) to decide "structurally identical," out of ~20 fields on a node. Every field not in that list was invisible to the merge.

## The fix
Instead of a hand-picked list, **declare every field's owner once** and drive the merge from that declaration.

- New `lib/recipe-lanes/node-fields.ts`: classifies each `RecipeNode` field as
  - **CLIENT** (`x, y, rotation, textPos, shortlistIndex, shortlistCycled`) — the client is the source of truth; a background snapshot must never clobber these.
  - **SERVER** (`iconShortlist, status, fastMatches, hydeQueries, iconQuery`) — the server is authoritative; a change must always be reflected, even in isolation. **This is the #220 fix.**
  - **STRUCTURAL** (the rest) — recipe content/topology.
  - A `satisfies Record<keyof RecipeNode, FieldOwnership>` check means **adding a future field without classifying it is a compile error** — the class of bug that caused #220 can't silently recur.
- `mergeNode` now derives its comparison and its merge from that map: any STRUCTURAL or SERVER change wins and triggers a merge; CLIENT fields are preserved against snapshots.

The identity fast-path (unchanged node → same object reference, so per-node selectors don't re-render) and the array-identity return are **unchanged**. One incidental improvement: the old full-merge path spread the *incoming* node, which could clobber locally-owned `rotation`/`textPos`/`shortlistCycled` on any structural change; those are now correctly preserved.

The map is also the foundation for the next PR (#221, `saveRecipe` server-owned reconciliation).

## Verification (real evidence)
Invariant tests were written **first**, against the real store (no mocks on the merge path):
- **Object identity** — merging a node whose STRUCTURAL+SERVER fields all match returns the *same reference* (`assert.strictEqual`), even when CLIENT fields (x/y) differ.
- **Array identity** — an all-identical incoming array returns the same array reference.
- **The #220 case** — an incoming node differing **only** in `status` (`pending`→`failed`) is reflected, and every *other* node keeps its identity.
- Structural-only change (`laneId`/`inputs`/`duration`) reflected; x/y client-ownership preserved; `shortlistIndex` survives an unrelated merge but resets when the shortlist is regenerated.
- `node-fields.test.ts` pins exhaustive coverage + disjointness of the ownership map.

Full pre-commit gate passed locally (no `--no-verify`): lint + typecheck clean, **`test:unit:pure` → 579 tests, 579 pass, 0 fail**.

## Risks / what this PR does NOT do
- **No end-to-end forge-failure browser test.** The issue's acceptance also lists one e2e/emulator check (force `failRecipeIcon` → node shows the failed state in the browser). The diagnosed defect is entirely inside `mergeNode`, and the unit tests exercise the exact failure input against the real merge — so the dropped-update bug is proven fixed. What's *not* covered here is the full chain (CF write → snapshot delivery → the failed-node **render**), a pre-existing path this PR doesn't modify. I recommend a follow-up e2e for that render path; flagging rather than bundling it to keep this PR to one concern.
- `valuesEqual` for the two complex SERVER fields (`fastMatches`, `iconQuery`) uses `JSON.stringify` comparison. It deliberately errs toward "equal" only when truly equal: a false "changed" costs a spurious re-render (harmless), a false "equal" would reproduce #220 (must never happen) — so the blunt instrument fails safe in the correct direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
