### PR TITLE
fix(save): reconcile server-owned node fields on saveRecipe update (#221)

### DIFF
--- a/recipe-lanes/lib/data-service.ts
+++ b/recipe-lanes/lib/data-service.ts
@@ -26,7 +26,15 @@ import type { RecipeGraph, IconStats, ShortlistEntry } from './recipe-lanes/type
 import { DB_COLLECTION_INGREDIENTS, DB_COLLECTION_ICON_INDEX, DB_COLLECTION_QUEUE, DB_COLLECTION_RECIPES, ICON_GALLERY_PAGE_SIZE, ICON_SEARCH_SCAN_LIMIT } from './config';
 import { standardizeIngredientName, removeUndefined, computeStoredOwnerName } from './utils';
 // import { calculateWilsonLCB } from './utils';
-import { applyIconToNode, assignNodeShortlist, buildShortlistEntry, clearNodeShortlist, computeShortlistDelta, getEntryIcon, getIconPath, getIconStoragePaths, getIconThumbPath, getIconUrl, getNodeHydeQueries, getNodeIconId, getNodeIconUrl, getNodeIngredientName, getNodeShortlist, getNodeShortlistLength, getPendingImpressionIds, getPendingRejectionIds, getPendingImpressionTargets, getPendingRejectionTargets, getSeenIconIds, hasNodeIcon, iconIndexEntryToStats, markEntryImpressedAtIndex, markSeenEntriesImpressed, markSeenEntriesRejected, mutateNodesByIngredient, prependToShortlist, rankIconsByEmbedding, toRecipeIcon, setNodeStatusByIngredient, extractBatchIngredients } from './recipe-lanes/model-utils';
+import { applyIconToNode, assignNodeShortlist, buildShortlistEntry, clearNodeShortlist, computeShortlistDelta, getEntryIcon, getIconPath, getIconStoragePaths, getIconThumbPath, getIconUrl, getNodeHydeQueries, getNodeIconId, getNodeIconUrl, getNodeIngredientName, getNodeShortlist, getNodeShortlistLength, getPendingImpressionIds, getPendingRejectionIds, getPendingImpressionTargets, getPendingRejectionTargets, getSeenIconIds, hasNodeIcon, iconIndexEntryToStats, markEntryImpressedAtIndex, markSeenEntriesImpressed, markSeenEntriesRejected, mutateNodesByIngredient, prependToShortlist, rankIconsByEmbedding, restoreNodeShortlistFromServer, toRecipeIcon, setNodeStatusByIngredient, extractBatchIngredients } from './recipe-lanes/model-utils';
+import { SERVER_FIELDS } from './recipe-lanes/node-fields';
+
+// Issue #221: uniform server-owned scalar/cache fields reconciled onto every
+// saveRecipe update below. `iconShortlist` is excluded because it has its own,
+// more nuanced restore rule (see the reconciliation block in `saveRecipe`).
+// Derived from `SERVER_FIELDS` (lib/recipe-lanes/node-fields.ts) so a newly
+// added SERVER field is automatically protected here without a hand edit.
+const UNIFORM_SERVER_RECONCILE_FIELDS = SERVER_FIELDS.filter((f) => f !== 'iconShortlist');
 
 export interface DataService {
   getIngredientByName(name: string): Promise<{ id: string; data: any } | null>;
@@ -853,6 +861,49 @@ export class FirebaseDataService implements DataService {
               }
           });
           await Promise.allSettled(tasks);
+
+          // Issue #221: the client always saves the WHOLE graph, and the write
+          // below uses `set(..., { merge: true })`. Firestore's merge:true
+          // merges maps but replaces arrays wholesale, so `graph.nodes` is
+          // last-writer-wins. Meanwhile the server writes node fields in the
+          // background — `resolveRecipeIcons` sets `fastMatches`/`hydeQueries`/
+          // `iconQuery`/`iconShortlist`, `queueIconForGeneration` sets `status`.
+          // A client save built from a graph fetched before those background
+          // writes landed would otherwise silently erase them (e.g. clobbered
+          // `fastMatches` forces `handleHydrateFastMatches` back onto the
+          // expensive full search). Reconcile each node against the doc we
+          // just read — by definition the freshest server state — before the
+          // write. This must run AFTER the impression/rejection delta loop
+          // above: that loop early-returns for shortlist-less nodes, and the
+          // shortlist restore case here only fires for shortlist-less client
+          // nodes, so the two never fight over the same node.
+          (graph.nodes || []).forEach((n: any) => {
+              const oldNode = oldNodesById.get(n.id);
+              // A node new to this doc has no server state to reconcile against —
+              // the client is the only source of truth for it.
+              if (!oldNode) return;
+
+              // Uniform rule for server-owned scalar/cache fields: the doc's
+              // value wins whenever it's defined, since it was read moments ago
+              // in this same call and the client's copy may be stale.
+              for (const field of UNIFORM_SERVER_RECONCILE_FIELDS) {
+                  if (oldNode[field] !== undefined) {
+                      n[field] = oldNode[field];
+                  }
+              }
+
+              // iconShortlist is special: unlike the fields above, the client
+              // CAN be authoritative for it (the delta loop + assignNodeShortlist
+              // above own that path whenever the client node has a shortlist).
+              // Only restore the server's shortlist when the client node has
+              // none — i.e. the client graph is stale/never had one — and the
+              // server has one to offer. When the client does have a shortlist,
+              // leave iconShortlist/shortlistIndex/shortlistCycled untouched so
+              // the client-trusted index (per the comment above) keeps working.
+              // (restoreNodeShortlistFromServer is a no-op in that case.)
+              restoreNodeShortlistFromServer(n, oldNode);
+          });
+
           // Maybe allow a non-merging option?
           await db.collection(DB_COLLECTION_RECIPES).doc(existingId).set(removeUndefined(data), { merge: true });
           return existingId;

--- a/recipe-lanes/lib/recipe-lanes/model-utils.ts
+++ b/recipe-lanes/lib/recipe-lanes/model-utils.ts
@@ -160,6 +160,26 @@ export function clearNodeShortlist(node: RecipeNode): void {
 }
 
 /**
+ * Restores `serverNode`'s shortlist state (iconShortlist + shortlistIndex +
+ * shortlistCycled) onto `node` IN PLACE — but ONLY when `node` currently has
+ * no shortlist and `serverNode` has one. No-op otherwise.
+ *
+ * Used by saveRecipe's server-state reconciliation (issue #221): a stale
+ * client save whose node lost its shortlist must not erase the server's
+ * copy. When the client node DOES have a shortlist, this leaves it (and its
+ * index/cycled flag) completely alone — that path is owned by the client's
+ * own save data plus the impression/rejection delta logic above, not this
+ * restore.
+ */
+export function restoreNodeShortlistFromServer(node: RecipeNode, serverNode: RecipeNode): void {
+    if (getNodeShortlistLength(node) > 0) return;
+    if (getNodeShortlistLength(serverNode) === 0) return;
+    node.iconShortlist = serverNode.iconShortlist;
+    node.shortlistIndex = serverNode.shortlistIndex;
+    node.shortlistCycled = serverNode.shortlistCycled;
+}
+
+/**
  * Returns all ShortlistEntries the user has seen in the current cycle:
  * - If shortlistCycled is true: all entries in the shortlist
  * - Otherwise: entries 0 through shortlistIndex inclusive

--- a/recipe-lanes/scripts/unit-test-manifest.mjs
+++ b/recipe-lanes/scripts/unit-test-manifest.mjs
@@ -51,6 +51,7 @@ export const INTEGRATION_TESTS = [
   'icon-index.test.ts',
   'icon-queue-config.test.ts',
   'impression-rejection.test.ts',
+  'save-reconciliation.test.ts',
 ];
 
 // tests/ lives one level up from scripts/. Resolve relative to THIS file so the

--- a/recipe-lanes/tests/save-reconciliation.test.ts
+++ b/recipe-lanes/tests/save-reconciliation.test.ts
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Integration tests for the saveRecipe server-state reconciliation (issue #221).
+ *
+ * The client always saves the whole graph, and the update path writes it with
+ * `set(..., { merge: true })`. Firestore's merge:true replaces arrays wholesale,
+ * so `graph.nodes` is last-writer-wins. The server concurrently writes node
+ * fields in the background (icon resolution: fastMatches/hydeQueries/iconQuery/
+ * iconShortlist; queueing: status). A client save built from a graph fetched
+ * before those background writes landed must not silently erase them.
+ *
+ * These tests seed the "server wrote fields the client doesn't know about" state
+ * directly via the admin SDK (deterministic, no need to run the real icon
+ * pipeline), then call saveRecipe with a stale client graph and assert the
+ * server-owned fields survive while client-owned/new-node fields still win
+ * where they're supposed to.
+ */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { db } from '../lib/firebase-admin';
+import { getDataService } from '../lib/data-service';
+import { setAIService } from '../lib/ai-service';
+import { MockAIService } from '../lib/ai-service.mock';
+import { setAuthService, MockAuthService } from '../lib/auth-service';
+import { buildShortlistEntry } from '../lib/recipe-lanes/model-utils';
+import { DB_COLLECTION_RECIPES } from '../lib/config';
+import type { IconStats, ShortlistEntry } from '../lib/recipe-lanes/types';
+
+setAIService(new MockAIService());
+setAuthService(new MockAuthService());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeIcon(id: string, visualDescription: string): IconStats {
+    return { id, visualDescription, impressions: 0, rejections: 0 };
+}
+
+function makeShortlist(prefix: string, visualDescription: string): ShortlistEntry[] {
+    return [
+        buildShortlistEntry(makeIcon(`${prefix}-1`, visualDescription), 'search'),
+        buildShortlistEntry(makeIcon(`${prefix}-2`, visualDescription), 'search'),
+    ];
+}
+
+const createdRecipeIds: string[] = [];
+
+/** Creates a recipe doc directly via the admin SDK, simulating server-written state. */
+async function createRecipeDoc(graph: any): Promise<string> {
+    const doc = await db.collection(DB_COLLECTION_RECIPES).add({
+        graph,
+        visibility: 'private',
+        created_at: new Date(),
+        updated_at: new Date(),
+    });
+    createdRecipeIds.push(doc.id);
+    return doc.id;
+}
+
+async function fetchGraph(recipeId: string): Promise<any> {
+    const doc = await db.collection(DB_COLLECTION_RECIPES).doc(recipeId).get();
+    return doc.data()?.graph;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('saveRecipe server-state reconciliation (#221)', () => {
+
+    afterEach(async () => {
+        // Integration tier shares one global Firestore — clean up after ourselves.
+        await Promise.all(
+            createdRecipeIds.splice(0).map((id) => db.collection(DB_COLLECTION_RECIPES).doc(id).delete()),
+        );
+    });
+
+    it('preserves server-written iconShortlist/fastMatches/hydeQueries/iconQuery/status when the client save is stale', async () => {
+        const visualDescription = `stale-node-${Date.now()}`;
+        const serverShortlist = makeShortlist('srv', visualDescription);
+
+        const recipeId = await createRecipeDoc({
+            title: 'test',
+            lanes: [{ id: 'l1', label: 'Prep', type: 'prep' }],
+            nodes: [{
+                id: 'n1',
+                laneId: 'l1',
+                text: visualDescription,
+                visualDescription,
+                type: 'ingredient',
+                iconShortlist: serverShortlist,
+                shortlistIndex: 1,
+                shortlistCycled: true,
+                fastMatches: [{ icon_id: 'srv-1', score: 0.9 }],
+                hydeQueries: ['a hyde query'],
+                iconQuery: { queryUsed: 'server query', method: 'hyde' },
+                status: 'processing',
+            }],
+        });
+
+        // Stale client graph: fetched before the server's background writes landed,
+        // so this node lacks all of the server-owned fields above.
+        const staleClientGraph = {
+            title: 'test',
+            lanes: [{ id: 'l1', label: 'Prep', type: 'prep' }],
+            nodes: [{
+                id: 'n1',
+                laneId: 'l1',
+                text: visualDescription,
+                visualDescription,
+                type: 'ingredient',
+                x: 42,
+                y: 7,
+            }],
+        };
+
+        await getDataService().saveRecipe(staleClientGraph as any, recipeId);
+
+        const savedGraph = await fetchGraph(recipeId);
+        const savedNode = savedGraph.nodes.find((n: any) => n.id === 'n1');
+
+        assert.equal(savedNode.iconShortlist?.length, 2, 'iconShortlist should survive the stale save');
+        assert.equal(savedNode.shortlistIndex, 1, 'shortlistIndex should be restored alongside the shortlist');
+        assert.equal(savedNode.shortlistCycled, true, 'shortlistCycled should be restored alongside the shortlist');
+        assert.deepEqual(savedNode.fastMatches, [{ icon_id: 'srv-1', score: 0.9 }], 'fastMatches should survive');
+        assert.deepEqual(savedNode.hydeQueries, ['a hyde query'], 'hydeQueries should survive');
+        assert.deepEqual(savedNode.iconQuery, { queryUsed: 'server query', method: 'hyde' }, 'iconQuery should survive');
+        assert.equal(savedNode.status, 'processing', 'status should survive');
+        // Client-owned fields from the stale save should still win.
+        assert.equal(savedNode.x, 42, 'client x should still be applied');
+        assert.equal(savedNode.y, 7, 'client y should still be applied');
+    });
+
+    it('honours the client shortlistIndex when the client node already has a shortlist', async () => {
+        const visualDescription = `moved-index-${Date.now()}`;
+        const shortlist = makeShortlist('mv', visualDescription);
+
+        const recipeId = await createRecipeDoc({
+            title: 'test',
+            lanes: [{ id: 'l1', label: 'Prep', type: 'prep' }],
+            nodes: [{
+                id: 'n1',
+                laneId: 'l1',
+                text: visualDescription,
+                visualDescription,
+                type: 'ingredient',
+                iconShortlist: shortlist,
+                shortlistIndex: 0,
+            }],
+        });
+
+        // Client has the same shortlist but has cycled forward to index 1 — this is
+        // the normal "user pressed reroll" case and must be honoured, not clobbered
+        // by the server's stale index.
+        const clientGraph = {
+            title: 'test',
+            lanes: [{ id: 'l1', label: 'Prep', type: 'prep' }],
+            nodes: [{
+                id: 'n1',
+                laneId: 'l1',
+                text: visualDescription,
+                visualDescription,
+                type: 'ingredient',
+                iconShortlist: shortlist,
+                shortlistIndex: 1,
+            }],
+        };
+
+        await getDataService().saveRecipe(clientGraph as any, recipeId);
+
+        const savedGraph = await fetchGraph(recipeId);
+        const savedNode = savedGraph.nodes.find((n: any) => n.id === 'n1');
+
+        assert.equal(savedNode.shortlistIndex, 1, 'client-trusted shortlistIndex should be honoured');
+    });
+
+    it('leaves a node new to the doc completely untouched', async () => {
+        const visualDescription = `existing-${Date.now()}`;
+        const newNodeDescription = `brand-new-${Date.now()}`;
+
+        const recipeId = await createRecipeDoc({
+            title: 'test',
+            lanes: [{ id: 'l1', label: 'Prep', type: 'prep' }],
+            nodes: [{
+                id: 'n1',
+                laneId: 'l1',
+                text: visualDescription,
+                visualDescription,
+                type: 'ingredient',
+            }],
+        });
+
+        const clientGraph = {
+            title: 'test',
+            lanes: [{ id: 'l1', label: 'Prep', type: 'prep' }],
+            nodes: [
+                {
+                    id: 'n1',
+                    laneId: 'l1',
+                    text: visualDescription,
+                    visualDescription,
+                    type: 'ingredient',
+                },
+                {
+                    id: 'n2',
+                    laneId: 'l1',
+                    text: newNodeDescription,
+                    visualDescription: newNodeDescription,
+                    type: 'ingredient',
+                    status: 'pending',
+                    x: 10,
+                    y: 20,
+                },
+            ],
+        };
+
+        await getDataService().saveRecipe(clientGraph as any, recipeId);
+
+        const savedGraph = await fetchGraph(recipeId);
+        const savedNewNode = savedGraph.nodes.find((n: any) => n.id === 'n2');
+
+        assert.ok(savedNewNode, 'new node should be present in the saved doc');
+        assert.equal(savedNewNode.status, 'pending', 'new node client-provided status should be kept');
+        assert.equal(savedNewNode.x, 10, 'new node client-provided x should be kept');
+        assert.equal(savedNewNode.y, 20, 'new node client-provided y should be kept');
+    });
+});


### PR DESCRIPTION
Closes #221. Third PR in the framework-first remediation (after #302 single undo, #304 field-ownership map). Builds directly on #304's `node-fields.ts` — that map is now doing its second job, exactly as intended.

## The bug, in one sentence
The client always saves the **whole** graph, and Firestore's `set(..., {merge:true})` merges maps but **replaces arrays wholesale** — so `graph.nodes` is last-writer-wins, and any client save built from a graph slightly older than a background server write silently erased that write.

The server writes node fields in the background all the time: `resolveRecipeIcons` sets `iconShortlist`/`fastMatches`/`hydeQueries`/`iconQuery`, `queueIconForGeneration` sets `status`. The visible symptom in the issue: once `fastMatches` got clobbered, `handleHydrateFastMatches` silently degraded to the expensive full icon search.

Note this is the **sink-side** half of the same race #304 fixed on the read side. #304 made the client *learn* server fields correctly from a snapshot; this PR stops a save that was already in flight (built before that snapshot) from overwriting them. Both halves are needed.

## The fix
Reconcile each incoming node against the existing doc — which `saveRecipe` already read moments earlier in the same call, making it by definition the freshest server state — just before the write:

- **Uniform rule for server-owned scalar/cache fields** (`status`, `fastMatches`, `hydeQueries`, `iconQuery`): the doc's value wins whenever it is defined. This list is **derived from `SERVER_FIELDS`** (from #304's ownership map) minus `iconShortlist`, so any SERVER field added to the map in future is protected here automatically, with no hand edit.
- **`iconShortlist` keeps its own, narrower rule**: restore the server's shortlist (along with its `shortlistIndex`/`shortlistCycled`) **only** when the client's node has no shortlist at all — i.e. the client graph is stale. When the client *does* have a shortlist, the existing `computeShortlistDelta`/`assignNodeShortlist` path stays solely in charge and the **client-trusted `shortlistIndex` keeps working**, exactly as the pre-existing comment in this function promises. The reconciliation runs *after* the delta loop, which early-returns for shortlist-less nodes — so the two paths provably never fight over the same node.
- **Nodes new to the doc are left completely untouched** (the client is their only source of truth), and CLIENT-owned (`x`/`y`/`rotation`/`textPos`) and STRUCTURAL fields are never overwritten.

## Verification (real evidence)
New **emulator integration** test `tests/save-reconciliation.test.ts` (registered in the integration tier manifest), covering the issue's acceptance criteria — this is the cross-subsystem check the audit warned was missing:
- Server state written to Firestore → a **stale** client save lacking those fields → the doc still has `iconShortlist`, `fastMatches`, `hydeQueries`, `iconQuery`, `status`; and the client's `x`/`y` are still applied (proving CLIENT fields aren't caught in the reconciliation).
- A client that **does** hold the shortlist with a moved `shortlistIndex` → the client's index is honoured.
- A node new to the doc keeps its client-provided values.

Run against the emulators together with `tests/impression-rejection.test.ts` (the guard on the shortlist/delta path): **8 tests, 8 pass, 0 fail**.
Full pre-commit gate green, no `--no-verify`: lint + typecheck clean, **`test:unit:pure` 579/579**.

## Risks
- The uniform rule means a client value for `status`/`fastMatches`/`hydeQueries`/`iconQuery` on an **existing** node can no longer win over a defined server value. I checked this is safe: the only client-originated `status` write is `status:'pending'` on **newly added** nodes (`model-utils.ts` `addNodes` path), and new nodes are explicitly excluded from reconciliation. No app-level caller sets status on an existing node.
- Reconciliation mutates the incoming node objects in place, consistent with the existing `assignNodeShortlist` behaviour in this same function (and `data.graph` is the same object reference, so the mutation reaches the write).

### Known residual (surfaced by review, not fixed here)
A stale-but-**non-empty** client `iconShortlist` can still clobber a fresher server shortlist: the restore only fires when the client's shortlist is *empty*, and `iconShortlist` is excluded from the uniform rule to keep the delta path intact. Concretely — the server regenerates a shortlist while a save carrying the older one is in flight and the user didn't cycle (so no delta) → the stale array is written. This is narrower than the bug fixed here (the empty case, which is covered and tested) and is mitigated by #304 keeping the client's shortlist fresh via `mergeNode`, but it is a genuine residual of the same race. I left it out deliberately rather than risk the impression/rejection delta contract in this PR — worth a follow-up issue if you want #221's shortlist field fully airtight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
