### PR TITLE
fix(save): buildGraphForSave unions store nodes with rendered nodes (#222)

### DIFF
--- a/recipe-lanes/components/recipe-lanes/hooks/useSaveAndFork.ts
+++ b/recipe-lanes/components/recipe-lanes/hooks/useSaveAndFork.ts
@@ -41,15 +41,16 @@ export function buildGraphForSave(
     const layouts = { ...(graph.layouts || {}) };
     layouts[mode] = currentNodes.map((n: any) => ({ id: n.id, x: n.position.x, y: n.position.y }));
 
-    const nodesWithPos = graph.nodes
-        .filter(n => currentNodes.some((rn: any) => rn.id === n.id))
-        .map(n => {
-            const rfn = currentNodes.find((rn: any) => rn.id === n.id)!;
-            const inputs = rfEdges
-                .filter((e: any) => e.target === n.id)
-                .map((e: any) => e.source);
-            return { ...n, x: rfn.position.x, y: rfn.position.y, inputs };
-        });
+    // Union, not intersect: a store node not currently rendered (in-flight
+    // adjust, not yet mounted) must survive the save unchanged, not be dropped.
+    const nodesWithPos = graph.nodes.map(n => {
+        const rfn = currentNodes.find((rn: any) => rn.id === n.id);
+        if (!rfn) return n;
+        const inputs = rfEdges
+            .filter((e: any) => e.target === n.id)
+            .map((e: any) => e.source);
+        return { ...n, x: rfn.position.x, y: rfn.position.y, inputs };
+    });
 
     return { ...graph, nodes: nodesWithPos, layouts, layoutMode: mode };
 }

--- a/recipe-lanes/lib/recipe-lanes/layout-notation.ts
+++ b/recipe-lanes/lib/recipe-lanes/layout-notation.ts
@@ -332,11 +332,10 @@ export function calculateNotationLayout(graph: RecipeGraph): NotationLayoutGraph
   // ── Catch-all sweep: EVERY graph node must be placed exactly once ────────
   // The passes above cover actions and ingredient leaves, but an ingredient
   // node with in-degree > 0 (possible via applyPatch / hand-edited JSON) is
-  // neither — and a node missing from the layout doesn't just fail to render:
-  // buildGraphForSave intersects graph.nodes with the rendered RF nodes, so
-  // saving in Notation mode would PERMANENTLY DELETE it from the recipe.
-  // This sweep makes "every node appears exactly once" unconditional, no
-  // matter how the placement passes above evolve.
+  // neither, and would silently fail to render. (It is no longer at risk of
+  // being deleted on save — buildGraphForSave unions rather than intersects
+  // since #222 — but it must still be placed.) This sweep makes "every node
+  // appears exactly once" unconditional as the passes above evolve.
   for (const node of graph.nodes) {
     if (placedIds.has(node.id)) continue;
     placedIds.add(node.id);

--- a/recipe-lanes/tests/layout-saving.test.ts
+++ b/recipe-lanes/tests/layout-saving.test.ts
@@ -166,6 +166,103 @@ describe('Layer A — buildGraphForSave', () => {
 });
 
 // ============================================================
+// LAYER A (issue #222) — buildGraphForSave must UNION, not intersect,
+// store nodes with rendered RF nodes, so an unrendered node isn't dropped.
+// ============================================================
+
+describe('Layer A (#222) — buildGraphForSave unions store nodes with rendered nodes', () => {
+
+    it('[A5] a store node absent from rfNodes survives, keeping its original x/y/inputs', () => {
+        const graph = makeGraph({
+            nodes: [
+                makeNode('n1', 0, 0),
+                { ...makeNode('n2', 100, 0), inputs: ['n1'] },
+                { ...makeNode('n3', 200, 0), inputs: ['n2'] }, // not rendered
+            ],
+        });
+
+        // Only n1 and n2 are currently mounted in ReactFlow; n3 is missing.
+        const result = buildGraphForSave(
+            graph,
+            'dagre',
+            [rfNode('n1', 10, 20), rfNode('n2', 30, 40)],
+            [{ source: 'n1', target: 'n2' }],
+        );
+
+        const n3 = result.nodes.find(n => n.id === 'n3');
+        assert.ok(n3, 'unrendered node n3 must survive in the saved graph');
+        assert.equal(n3?.x, 200, 'unrendered node keeps its original x');
+        assert.equal(n3?.y, 0, 'unrendered node keeps its original y');
+        assert.deepStrictEqual(n3?.inputs, ['n2'], 'unrendered node keeps its original inputs, not rfEdges-derived');
+    });
+
+    it('[A6] a rendered node still gets its RF position and rfEdges-derived inputs', () => {
+        const graph = makeGraph({
+            nodes: [
+                makeNode('n1', 0, 0),
+                { ...makeNode('n2', 100, 0), inputs: [] },
+                makeNode('n3', 200, 0),
+            ],
+        });
+
+        const result = buildGraphForSave(
+            graph,
+            'dagre',
+            [rfNode('n1', 10, 20), rfNode('n2', 30, 40)],
+            [{ source: 'n1', target: 'n2' }],
+        );
+
+        const n2 = result.nodes.find(n => n.id === 'n2');
+        assert.equal(n2?.x, 30, 'rendered node gets its RF x');
+        assert.equal(n2?.y, 40, 'rendered node gets its RF y');
+        assert.deepStrictEqual(n2?.inputs, ['n1'], 'rendered node inputs derived from rfEdges');
+    });
+
+    it('[A7] layouts[mode] contains ONLY the rendered nodes, not the unrendered one', () => {
+        const graph = makeGraph({
+            nodes: [makeNode('n1', 0, 0), makeNode('n2', 100, 0), makeNode('n3', 200, 0)],
+        });
+
+        const result = buildGraphForSave(
+            graph,
+            'dagre',
+            [rfNode('n1', 10, 20), rfNode('n2', 30, 40)],
+            [],
+        );
+
+        assert.deepStrictEqual(
+            result.layouts?.['dagre'],
+            [{ id: 'n1', x: 10, y: 20 }, { id: 'n2', x: 30, y: 40 }],
+            'layouts[mode] must only hold rendered nodes',
+        );
+        assert.ok(
+            !result.layouts?.['dagre'].some(l => l.id === 'n3'),
+            'unrendered node n3 must NOT appear in layouts[mode]',
+        );
+    });
+
+    it('[A8] node ordering in the result matches graph.nodes ordering', () => {
+        const graph = makeGraph({
+            nodes: [makeNode('n1', 0, 0), makeNode('n2', 100, 0), makeNode('n3', 200, 0)],
+        });
+
+        // n2 is unrendered this time — order must still follow graph.nodes.
+        const result = buildGraphForSave(
+            graph,
+            'dagre',
+            [rfNode('n1', 10, 20), rfNode('n3', 30, 40)],
+            [],
+        );
+
+        assert.deepStrictEqual(
+            result.nodes.map(n => n.id),
+            ['n1', 'n2', 'n3'],
+            'result.nodes ordering must match graph.nodes ordering',
+        );
+    });
+});
+
+// ============================================================
 // LAYER B — saveRecipeAction → getRecipe roundtrip
 // ============================================================
 


### PR DESCRIPTION
Closes #222. Fourth PR in the framework-first remediation (after #302 undo, #304 field-ownership map, #305 save reconciliation).

## The bug
`buildGraphForSave` decided which nodes to save by **intersecting** the store's graph with the nodes ReactFlow currently has rendered:

```js
graph.nodes.filter(n => currentNodes.some(rn => rn.id === n.id))
```

Any node in the store but not currently rendered — e.g. one just added by an in-flight adjust, or not yet mounted — was silently dropped from the saved graph. Autosave then deleted it from Firestore. Losing user data to a rendering race.

## The fix
Make it a **union**: map over `graph.nodes` instead of filtering it.

- Rendered node → unchanged behaviour: takes its ReactFlow position and `rfEdges`-derived `inputs`.
- Unrendered node → passes through untouched, keeping its store `x`/`y`/`inputs`. (Deliberately *not* re-deriving `inputs` from `rfEdges` — there are no edges for an unrendered node, so that would wrongly blank them.)

Untouched on purpose: `layouts[mode]` still contains only rendered nodes (an unrendered node has no rendered position to record), the synthetic `lane`/`notation-station` exclusion, and the pinned `graph.layouts` handling the function's NOTE warns against "fixing".

## Verification
New unit tests in `tests/layout-saving.test.ts` (which already covers this helper):
- An unrendered store node survives with its original `x`, `y`, and `inputs`.
- A rendered node still gets its RF position and `rfEdges`-derived inputs.
- `layouts[mode]` contains only the rendered nodes — the unrendered one must not appear.
- Node ordering matches `graph.nodes`.

Full pre-commit gate green, no `--no-verify`: lint + typecheck clean, **`test:unit:pure` 585/585**.

## Risks
Low. The change strictly *adds* nodes to the saved graph that were previously dropped; no node that was saved before is saved differently. The one judgement call is keeping an unrendered node's stored `inputs` rather than recomputing them — correct, since `rfEdges` has no information about a node that isn't on the canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
