### PR TITLE
fix(adjust): reconcile LLM result against the latest store graph (#219)

### DIFF
--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -686,8 +686,8 @@ const handleVisualize = async () => {
                 res.graph.originalText = recipeText;
 
                 // #219: same reconciliation as handleAdjust — see there.
-                const latest = useRecipeStore.getState().graph;
-                const merged = latest ? reconcileAdjustedGraph(res.graph, latest) : res.graph;
+                const { graph: latest, pendingDeletedIds } = useRecipeStore.getState();
+                const merged = latest ? reconcileAdjustedGraph(res.graph, latest, pendingDeletedIds) : res.graph;
 
                 setGraphWithUndo(merged);
                 addMessage({ role: 'user', content: 'Applied recipe text edits.' });
@@ -831,8 +831,8 @@ const handleVisualize = async () => {
           // #219: res.graph is derived from the pre-call graph, so it would erase
           // icon data the server wrote during the round-trip. getState() reads the
           // latest graph, not the stale `graph` closure.
-          const latest = useRecipeStore.getState().graph;
-          const merged = latest ? reconcileAdjustedGraph(res.graph, latest) : res.graph;
+          const { graph: latest, pendingDeletedIds } = useRecipeStore.getState();
+          const merged = latest ? reconcileAdjustedGraph(res.graph, latest, pendingDeletedIds) : res.graph;
 
           setGraphWithUndo(merged);
           addMessage({ role: 'assistant', content: (res as any).message || 'Done! The recipe has been updated.' });

--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -33,7 +33,7 @@ import { standardizeIngredientName, resolveBylineName } from '@/lib/utils';
 import { IngredientsSidebar } from '@/components/recipe-lanes/ui/ingredients-sidebar';
 import { TimelineView } from '@/components/recipe-lanes/timeline-view';
 import type { RecipeGraph, LayoutModeId, RecipeNode } from '@/lib/recipe-lanes/types';
-import { hasNodeIcon, preserveNodeShortlist, getNodeShortlistLength, getNodeIngredientName, getNodeHydeQueries, extractBatchIngredients, getNodeIcon, buildIngredientText } from '@/lib/recipe-lanes/model-utils';
+import { hasNodeIcon, preserveNodeShortlist, getNodeShortlistLength, getNodeIngredientName, getNodeHydeQueries, extractBatchIngredients, getNodeIcon, buildIngredientText, reconcileAdjustedGraph } from '@/lib/recipe-lanes/model-utils';
 import { useRecipeStore } from '@/lib/stores/recipe-store';
 import { LayoutMode } from '@/lib/recipe-lanes/layout';
 import { Wand2, ChefHat, ArrowRight, Code, MessageSquare, Send, LayoutDashboard, Kanban, GitGraph, Columns, AlignCenter, Network, Sparkles, CircleDot, Share2, Sprout, Move, RotateCw, Orbit, Type, Play, Pause, Pencil, RotateCcw, Globe, Lock, Plus, LayoutGrid, Star, User, ShoppingBasket, HelpCircle, Github, Camera, Eye, EyeOff } from 'lucide-react';
@@ -684,7 +684,12 @@ const handleVisualize = async () => {
                 // user just forged — and so the post-save snapshot repopulates
                 // the input with the SAME text (leaving the input box untouched).
                 res.graph.originalText = recipeText;
-                setGraphWithUndo(res.graph);
+
+                // #219: same reconciliation as handleAdjust — see there.
+                const latest = useRecipeStore.getState().graph;
+                const merged = latest ? reconcileAdjustedGraph(res.graph, latest) : res.graph;
+
+                setGraphWithUndo(merged);
                 addMessage({ role: 'user', content: 'Applied recipe text edits.' });
                 addMessage({ role: 'assistant', content: (res as any).message || 'Recipe updated from your edits.' });
                 setShowChat(true);
@@ -692,7 +697,7 @@ const handleVisualize = async () => {
                 setWarningDismissed(false);
 
                 // Fire-and-forget save — mirrors handleAdjust.
-                saveRecipeAction(res.graph, currentId).then(() => {
+                saveRecipeAction(merged, currentId).then(() => {
                     const allMessages = useRecipeStore.getState().messages;
                     localStorage.setItem(`chat_${currentId}`, JSON.stringify(allMessages));
                     saveChatHistoryAction(currentId, allMessages.map(m => ({ role: m.role, content: m.content, timestamp: m.timestamp })));
@@ -822,7 +827,14 @@ const handleVisualize = async () => {
               throw new Error(res.error || 'Failed to adjust graph.');
           }
           res.graph.title = recipeTitle;
-          setGraphWithUndo(res.graph);
+
+          // #219: res.graph is derived from the pre-call graph, so it would erase
+          // icon data the server wrote during the round-trip. getState() reads the
+          // latest graph, not the stale `graph` closure.
+          const latest = useRecipeStore.getState().graph;
+          const merged = latest ? reconcileAdjustedGraph(res.graph, latest) : res.graph;
+
+          setGraphWithUndo(merged);
           addMessage({ role: 'assistant', content: (res as any).message || 'Done! The recipe has been updated.' });
           setShowChat(true);
           setStatus('complete');
@@ -830,7 +842,7 @@ const handleVisualize = async () => {
           // Fire-and-forget — UI is already updated, don't block on the Firestore write
           const currentId = searchParams.get('id') || undefined;
           if (currentId) {
-              saveRecipeAction(res.graph, currentId).then(() => {
+              saveRecipeAction(merged, currentId).then(() => {
                   const allMessages = useRecipeStore.getState().messages;
                   localStorage.setItem(`chat_${currentId}`, JSON.stringify(allMessages));
                   saveChatHistoryAction(currentId, allMessages.map(m => ({ role: m.role, content: m.content, timestamp: m.timestamp })));

--- a/recipe-lanes/lib/recipe-lanes/model-utils.ts
+++ b/recipe-lanes/lib/recipe-lanes/model-utils.ts
@@ -209,7 +209,9 @@ export function reconcileAdjustedGraph(adjusted: RecipeGraph, latest: RecipeGrap
         return merged;
     });
 
-    return { ...adjusted, nodes };
+    // graph.layouts is client-owned too (a drag during the call writes
+    // latest.layouts[mode]); adjusted carries the stale pre-call copy.
+    return { ...adjusted, nodes, layouts: latest.layouts ?? adjusted.layouts };
 }
 
 /**

--- a/recipe-lanes/lib/recipe-lanes/model-utils.ts
+++ b/recipe-lanes/lib/recipe-lanes/model-utils.ts
@@ -195,10 +195,18 @@ function restoreField<K extends keyof RecipeNode>(target: RecipeNode, source: Re
  * are restored from `latest`. Nodes new to `adjusted` are kept; nodes the
  * adjust deleted stay deleted. Pure; preserves `adjusted`'s order.
  */
-export function reconcileAdjustedGraph(adjusted: RecipeGraph, latest: RecipeGraph): RecipeGraph {
+export function reconcileAdjustedGraph(
+    adjusted: RecipeGraph,
+    latest: RecipeGraph,
+    deletedIds: readonly string[] = [],
+): RecipeGraph {
     const latestById = new Map(latest.nodes.map((n) => [n.id, n]));
+    // A node deleted mid-call is absent from latest but present in adjusted;
+    // without this it would resurrect (and pendingDeletedIds would then
+    // starve it of icon updates).
+    const deleted = new Set(deletedIds);
 
-    const nodes = adjusted.nodes.map((node) => {
+    const nodes = adjusted.nodes.filter((n) => !deleted.has(n.id)).map((node) => {
         const latestNode = latestById.get(node.id);
         if (!latestNode) return node;
 

--- a/recipe-lanes/lib/recipe-lanes/model-utils.ts
+++ b/recipe-lanes/lib/recipe-lanes/model-utils.ts
@@ -17,6 +17,7 @@
 
 import { RecipeNode, IconStats, IconIndexEntry, ShortlistEntry, SearchTerm, RecipeGraph, IconStyleId, RecipePatch } from './types';
 import { standardizeIngredientName } from '../utils';
+import { SERVER_FIELDS, CLIENT_FIELDS } from './node-fields';
 
 /**
  * Returns the canonical ingredient name for a node — used for icon lookup and standardisation.
@@ -177,6 +178,38 @@ export function restoreNodeShortlistFromServer(node: RecipeNode, serverNode: Rec
     node.iconShortlist = serverNode.iconShortlist;
     node.shortlistIndex = serverNode.shortlistIndex;
     node.shortlistCycled = serverNode.shortlistCycled;
+}
+
+// Reconciled onto every adjust/forge result below: SERVER fields (icon data,
+// written by the server while the LLM call is in flight) plus CLIENT fields
+// (position/UI, which the user may have changed in the same window).
+const ADJUST_RESTORE_FIELDS: readonly (keyof RecipeNode)[] = [...SERVER_FIELDS, ...CLIENT_FIELDS];
+
+function restoreField<K extends keyof RecipeNode>(target: RecipeNode, source: RecipeNode, field: K): void {
+    if (source[field] !== undefined) target[field] = source[field];
+}
+
+/**
+ * Reconciles an adjust/forge LLM result against the latest store graph (#219).
+ * The LLM is authoritative for STRUCTURAL fields only, so SERVER/CLIENT fields
+ * are restored from `latest`. Nodes new to `adjusted` are kept; nodes the
+ * adjust deleted stay deleted. Pure; preserves `adjusted`'s order.
+ */
+export function reconcileAdjustedGraph(adjusted: RecipeGraph, latest: RecipeGraph): RecipeGraph {
+    const latestById = new Map(latest.nodes.map((n) => [n.id, n]));
+
+    const nodes = adjusted.nodes.map((node) => {
+        const latestNode = latestById.get(node.id);
+        if (!latestNode) return node;
+
+        const merged: RecipeNode = { ...node };
+        for (const field of ADJUST_RESTORE_FIELDS) {
+            restoreField(merged, latestNode, field);
+        }
+        return merged;
+    });
+
+    return { ...adjusted, nodes };
 }
 
 /**

--- a/recipe-lanes/tests/adjust-reconcile.test.ts
+++ b/recipe-lanes/tests/adjust-reconcile.test.ts
@@ -129,6 +129,16 @@ describe('reconcileAdjustedGraph (issue #219)', () => {
         assert.equal(result.nodes[0].text, 'edited', 'structural edit still applies');
     });
 
+    it('drops a node the user deleted mid-call (in deletedIds), but keeps genuinely new nodes', () => {
+        const latest = makeGraph([makeNode('a')]);
+        // 'b' was deleted during the call; 'c' is new from the LLM.
+        const adjusted = makeGraph([makeNode('a'), makeNode('b'), makeNode('c')]);
+
+        const result = reconcileAdjustedGraph(adjusted, latest, ['b']);
+
+        assert.deepEqual(result.nodes.map((n) => n.id), ['a', 'c']);
+    });
+
     it('falls back to the adjusted layouts when latest has none', () => {
         const latest = makeGraph([makeNode('a')]);
         const adjusted = makeGraph([makeNode('a')]);

--- a/recipe-lanes/tests/adjust-reconcile.test.ts
+++ b/recipe-lanes/tests/adjust-reconcile.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Pure unit tests for reconcileAdjustedGraph (issue #219).
+ *
+ * The LLM adjust/forge round-trip is slow. While it runs, the server writes
+ * icon data (shortlists/status/fastMatches) into the store, and the user can
+ * drag/cycle nodes. The LLM result is derived from the PRE-call graph, so
+ * applying it wholesale erases those concurrent writes. reconcileAdjustedGraph
+ * restores SERVER- and CLIENT-owned fields from the latest store graph while
+ * keeping the LLM's structural changes.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { RecipeGraph, RecipeNode, ShortlistEntry } from '../lib/recipe-lanes/types';
+import { reconcileAdjustedGraph, buildShortlistEntry, toRecipeIcon } from '../lib/recipe-lanes/model-utils';
+
+function makeNode(id: string, overrides: Partial<RecipeNode> = {}): RecipeNode {
+    return {
+        id,
+        laneId: 'lane-1',
+        text: `Node ${id}`,
+        visualDescription: `visual-${id}`,
+        type: 'ingredient',
+        ...overrides,
+    };
+}
+
+function makeGraph(nodes: RecipeNode[]): RecipeGraph {
+    return { lanes: [], nodes };
+}
+
+function makeShortlist(id: string): ShortlistEntry[] {
+    return [buildShortlistEntry(toRecipeIcon({ id, visualDescription: `icon-${id}` } as any), 'search')];
+}
+
+describe('reconcileAdjustedGraph (issue #219)', () => {
+    it('restores server-written icon fields while keeping the adjusted structural change', () => {
+        const shortlist = makeShortlist('srv-1');
+        const latest = makeGraph([
+            makeNode('a', {
+                text: 'old text',
+                iconShortlist: shortlist,
+                status: 'processing',
+                fastMatches: [{ icon_id: 'srv-1', score: 0.9 } as any],
+            }),
+        ]);
+        const adjusted = makeGraph([makeNode('a', { text: 'new text from LLM' })]);
+
+        const result = reconcileAdjustedGraph(adjusted, latest);
+        const node = result.nodes.find((n) => n.id === 'a')!;
+
+        assert.equal(node.text, 'new text from LLM', 'structural change from the adjust should apply');
+        assert.deepEqual(node.iconShortlist, shortlist, 'iconShortlist should be restored from latest');
+        assert.equal(node.status, 'processing', 'status should be restored from latest');
+        assert.deepEqual(node.fastMatches, [{ icon_id: 'srv-1', score: 0.9 }], 'fastMatches should be restored');
+    });
+
+    it('keeps the latest x/y when the user dragged the node during the call', () => {
+        const latest = makeGraph([makeNode('a', { x: 100, y: 200 })]);
+        const adjusted = makeGraph([makeNode('a', { x: 0, y: 0, text: 'renamed' })]);
+
+        const result = reconcileAdjustedGraph(adjusted, latest);
+        const node = result.nodes.find((n) => n.id === 'a')!;
+
+        assert.equal(node.x, 100, 'x should come from latest, not the adjusted graph');
+        assert.equal(node.y, 200, 'y should come from latest, not the adjusted graph');
+        assert.equal(node.text, 'renamed', 'structural change should still apply');
+    });
+
+    it('keeps a node new to the adjusted graph verbatim', () => {
+        const latest = makeGraph([makeNode('a')]);
+        const newNode = makeNode('b', { text: 'brand new node' });
+        const adjusted = makeGraph([makeNode('a'), newNode]);
+
+        const result = reconcileAdjustedGraph(adjusted, latest);
+        const node = result.nodes.find((n) => n.id === 'b');
+
+        assert.deepEqual(node, newNode, 'a node absent from latest should pass through unchanged');
+    });
+
+    it('keeps a node deleted by the adjust dropped', () => {
+        const latest = makeGraph([makeNode('a'), makeNode('b')]);
+        const adjusted = makeGraph([makeNode('a')]);
+
+        const result = reconcileAdjustedGraph(adjusted, latest);
+
+        assert.equal(result.nodes.length, 1);
+        assert.equal(result.nodes.find((n) => n.id === 'b'), undefined, 'deleted node should stay dropped');
+    });
+
+    it('preserves the local shortlistIndex from latest', () => {
+        const latest = makeGraph([makeNode('a', { iconShortlist: makeShortlist('x'), shortlistIndex: 2 })]);
+        const adjusted = makeGraph([makeNode('a', { text: 'edited' })]);
+
+        const result = reconcileAdjustedGraph(adjusted, latest);
+        const node = result.nodes.find((n) => n.id === 'a')!;
+
+        assert.equal(node.shortlistIndex, 2, 'shortlistIndex should survive reconciliation');
+    });
+});

--- a/recipe-lanes/tests/adjust-reconcile.test.ts
+++ b/recipe-lanes/tests/adjust-reconcile.test.ts
@@ -114,4 +114,28 @@ describe('reconcileAdjustedGraph (issue #219)', () => {
 
         assert.equal(node.shortlistIndex, 2, 'shortlistIndex should survive reconciliation');
     });
+
+    it('takes graph.layouts from latest, not the stale adjusted copy', () => {
+        // A drag mid-call writes latest.layouts[mode]; adjusted still holds the
+        // pre-call positions, which would otherwise revert the drag on restore.
+        const latest = makeGraph([makeNode('a')]);
+        latest.layouts = { notation: [{ id: 'a', x: 500, y: 600 }] };
+        const adjusted = makeGraph([makeNode('a', { text: 'edited' })]);
+        adjusted.layouts = { notation: [{ id: 'a', x: 10, y: 20 }] };
+
+        const result = reconcileAdjustedGraph(adjusted, latest);
+
+        assert.deepEqual(result.layouts, { notation: [{ id: 'a', x: 500, y: 600 }] });
+        assert.equal(result.nodes[0].text, 'edited', 'structural edit still applies');
+    });
+
+    it('falls back to the adjusted layouts when latest has none', () => {
+        const latest = makeGraph([makeNode('a')]);
+        const adjusted = makeGraph([makeNode('a')]);
+        adjusted.layouts = { notation: [{ id: 'a', x: 10, y: 20 }] };
+
+        const result = reconcileAdjustedGraph(adjusted, latest);
+
+        assert.deepEqual(result.layouts, { notation: [{ id: 'a', x: 10, y: 20 }] });
+    });
 });


### PR DESCRIPTION
Closes #219. Fifth and final PR of Phase 1 (after #302 undo, #304 field-ownership map, #305 save reconciliation, #309 buildGraphForSave union).

## The bug
"Icons vanish and re-forge." `handleAdjust` (and the recipe-text-edit flow) sends the graph **as it was when you hit the button** to the LLM, then applies the result wholesale:

```js
const res = await adjustRecipeAction(graph, prompt);   // slow round-trip
setGraphWithUndo(res.graph);                            // pre-call graph + LLM edits
saveRecipeAction(res.graph, currentId);                 // ...and persists it
```

The round-trip is slow, and the server writes icon data into the store the whole time it runs (shortlists, `status`, `fastMatches` arriving via Firestore snapshots). Because `res.graph` is derived from the *pre-call* graph, applying it erases every server write that landed during the call — and the fire-and-forget save then persists the erasure. Anything the user did during the wait (dragging a node, cycling an icon) was lost the same way.

## The fix
The LLM is authoritative for **structural** content only — it knows nothing about icons or where you dragged things. So both flows now reconcile the result against the *latest* store graph before using it:

```js
const latest = useRecipeStore.getState().graph;   // not the stale `graph` closure
const merged = latest ? reconcileAdjustedGraph(res.graph, latest) : res.graph;
```

`merged` is then used for **both** `setGraphWithUndo` and the save. The new pure helper `reconcileAdjustedGraph` keeps structural fields from the LLM result, and restores SERVER-owned icon fields plus CLIENT-owned position/UI fields from the live graph. Nodes new to the adjust are kept as-is; nodes the adjust deleted stay deleted; ordering is preserved.

Its field lists are **derived from `node-fields.ts`** (`SERVER_FIELDS` + `CLIENT_FIELDS`) rather than hand-written — the ownership map introduced in #304 is now doing its third job (merge → save → adjust), which is exactly the consolidation this framework work is for.

## Verification
New pure unit tests (`tests/adjust-reconcile.test.ts`, auto-discovered into the pure tier):
- Icon data written server-side during the call survives, while the adjust's structural edit still applies.
- A node dragged during the call keeps the latest `x`/`y`, not the LLM's stale coordinates.
- A node new in the adjusted graph is kept verbatim.
- A node the adjust deleted stays deleted.
- Local `shortlistIndex` survives.

**Mutation-checked**: neutering the helper makes 3 of the 5 new tests fail, so they genuinely catch the bug rather than passing vacuously.

Full pre-commit gate green, no `--no-verify`: lint + typecheck clean, **`test:unit:pure` 586/586**.

## Risks
- Both flows now depend on the store's graph being current at completion time. That is the same source `setGraphWithUndo` writes to, so there is no new source of truth — only the stale closure is bypassed.
- Only structural fields come from the LLM now. If a future adjust feature legitimately needs to set an icon or position field, it must go through the ownership map rather than around it — which is the intended constraint.
- No e2e added: the reconciliation is a pure function tested directly, and the surrounding flows are unchanged apart from which graph object they pass.

### Deep-review round (Fable)
A second, deeper review pass (full pipeline composition trace) produced verdict SHIP-WITH-NIT and one real gap, fixed here:
- **Mid-call deletes no longer resurrect**: a node deleted while the LLM call was in flight was absent from `latest`, so it passed through as if LLM-added and was saved back — then `pendingDeletedIds` starved it of icon updates until reload. `reconcileAdjustedGraph` now takes `pendingDeletedIds` and drops those nodes (new test).
- Scope note: only node fields and `layouts` are reconciled — other graph-level fields (title, serves) come from the adjust result, so a recipe *rename* made mid-call is still reverted. Deliberate: `handleAdjust` reapplies the title explicitly, and widening scope further belongs to the Phase-2 view-contract work.
- A pre-existing composition gap found during the trace (inputs-only adjusts never redraw edges and self-revert on next save) is filed as #312 — it's in main, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
