### PR TITLE
feat(icons): icon credits + icon editor modal (phase 1 of paid generation)

### DIFF
--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -61,3 +61,17 @@ The claim protocol itself is fine and was honoured by hand for #280: post the cl
 **For future runs:** if `agent-claim.mjs` exits 1 with a 401/403, do not treat it as "no claim needed" and do not skip the claim — fall back to staking it via MCP as above. Making the script proxy-aware (an undici `ProxyAgent`, or `NODE_USE_ENV_PROXY`) would only help if the proxy allowed `api.github.com` for this session, which it does not.
 
 **Confirmed independently on #281** (same day, different run): identical 401 from `agent-claim.mjs`, resolved the same way — claim staked by hand via MCP with the same marker. Two runs raced #281; the earliest claim comment won and the loser resigned, so the protocol worked as designed even with the script unusable.
+
+---
+
+## 2026-08-21 — Icon credits + icon editor modal (phase 1 of paid icon generation)
+
+**Feature (owner-directed).** First slice of the "users pay for icon generation" plan that `recipe-lanes/docs/icon-shortlist-plan.md` sketched ("Forge is the credit-gated upsell"). Two changes shipped together:
+
+1. **Icon credits.** New Admin-SDK-only collection `user_credits/{uid}` (`lib/user-credits.ts`): `balance` / `granted` / `spent`, with a lazy **starter grant** (`STARTER_ICON_CREDITS = 10`) seeded transactionally on first touch — no backfill. `forgeIconAction` now requires sign-in and spends `FORGE_CREDIT_COST = 1` per generation (transactional spend, refund if the enqueue fails, `creditsRemaining` returned to the UI). The daily cap (`checkForgeAllowed`) stays as an abuse backstop. Purchase flow is deliberately NOT built yet. **Placement rationale:** the balance must not live on `users/{uid}` — firestore.rules gives users full write access to their own user doc, so it would be self-editable; `user_credits` follows the `icon_forge_usage` no-rules-block precedent. Anonymous users can no longer forge regardless of `allowAnonForge` (credits need an account); `allowAnonForge` still governs the recipe-creation generation gates.
+
+2. **Icon editor modal replaces cycle+forge buttons.** The per-node reroll (`RefreshCw`) and forge (`Hammer`) buttons — on RF nodes, timeline nodes, the SVG timeline, and the ingredients sidebar — are replaced by a single pencil "Edit icon" button opening `components/icon-shortlist-modal.tsx`: the whole shortlist as a grid (click to pick — new store action `setShortlistIndex`), plus the credit-gated "Generate a new icon" button with the live balance. Modal state lives in the store (`iconEditorNodeId`) because the openers sit deep inside ReactFlow while the modal renders at page level.
+
+**Impression semantics.** Opening the modal shows every shortlist entry at once, so it must count as an impression for each — but NOT as a rejection (unlike cycling past). New client-owned node flag `shortlistSeenAll` (registered in the #220 ownership map): `stampShortlistFlags` now stamps `hasImpressed` on all entries when it is set, while rejections keep the existing selected-index contiguity rules. Existing `shortlistCycled` semantics are untouched. Selection/seen state still reaches Firestore only with the next save — per `STATE_AND_PERSISTENCE.md`, no per-interaction write was reintroduced.
+
+**Tests.** `tests/shortlist-seen-all.test.ts` + `tests/recipe-store-icon-editor.test.ts` (pure), `tests/user-credits.test.ts` (integration: starter grant, atomic spend/insufficient/refund, forge gate incl. refund-on-failure). Next phase (per owner): generation offers multiple options and a chosen icon becomes a named donation from the generating user.

--- a/recipe-lanes/app/actions.ts
+++ b/recipe-lanes/app/actions.ts
@@ -33,7 +33,9 @@ import { db } from '@/lib/firebase-admin';
 import { DB_COLLECTION_RECIPES, DB_COLLECTION_QUEUE } from '@/lib/config';
 import { unifiedIconSearch, serverBatchIconSearch } from '@/lib/search-orchestrator';
 import { getIconQueueConfig, setIconQueueConfig, getUserForgeCountToday, incrementUserForgeCount } from '@/lib/icon-queue-config';
+import { getUserCredits, spendIconCredits, refundIconCredits } from '@/lib/user-credits';
 import type { IconQueueConfig } from '@/lib/config';
+import { FORGE_CREDIT_COST, STARTER_ICON_CREDITS } from '@/lib/config';
 
 // Input Validation Schemas
 const IngredientSchema = z.string().min(1).max(100);
@@ -61,15 +63,59 @@ export async function forgeIconAction(recipeId: string, ingredientName: string, 
     try {
         const session = await getAuthService().verifyAuth();
         const userId = session?.uid;
+        // Generation costs icon credits, and credits belong to an account —
+        // anonymous forging is no longer possible regardless of allowAnonForge
+        // (which still governs the recipe-creation generation paths).
+        if (!userId) {
+            return {
+                success: false,
+                error: `Sign in to generate icons — new accounts get ${STARTER_ICON_CREDITS} free icon credits.`,
+            };
+        }
+        // Daily cap stays as an abuse backstop on top of the credit balance.
         const forgeBlock = await checkForgeAllowed(userId);
         if (forgeBlock) return { success: false, error: forgeBlock };
-        if (userId) incrementUserForgeCount(userId).catch(e =>
+
+        const spend = await spendIconCredits(userId, FORGE_CREDIT_COST);
+        if (!spend.ok) {
+            return {
+                success: false,
+                error: 'You are out of icon credits.',
+                creditsRemaining: spend.balance,
+            };
+        }
+        incrementUserForgeCount(userId).catch(e =>
             console.warn('[forgeIconAction] forge count increment failed (non-fatal):', e)
         );
         // Forge: reject current and queue brand-new generation (no index search — skip embedFn)
-        return getDataService().rejectRecipeIcon(recipeId, ingredientName, currentIconId, userId);
+        const res = await getDataService().rejectRecipeIcon(recipeId, ingredientName, currentIconId, userId);
+        if (!res.success) {
+            // The generation never got enqueued — give the credit back.
+            await refundIconCredits(userId, FORGE_CREDIT_COST).catch(e =>
+                console.warn('[forgeIconAction] credit refund failed:', e)
+            );
+            return { ...res, creditsRemaining: spend.balance + FORGE_CREDIT_COST };
+        }
+        return { ...res, creditsRemaining: spend.balance };
     } catch (e: any) {
-        return { success: false, error: e.message };
+        return { success: false, error: e.message as string, creditsRemaining: undefined as number | undefined };
+    }
+}
+
+/**
+ * Returns the signed-in user's icon-credit balance, seeding the starter grant
+ * for accounts that have never touched credits. Anonymous callers get
+ * signedIn=false and a zero balance.
+ */
+export async function getIconCreditsAction(): Promise<{ signedIn: boolean; balance: number }> {
+    try {
+        const session = await getAuthService().verifyAuth();
+        if (!session?.uid) return { signedIn: false, balance: 0 };
+        const credits = await getUserCredits(session.uid);
+        return { signedIn: true, balance: credits.balance };
+    } catch (e) {
+        console.warn('[getIconCreditsAction] failed:', e);
+        return { signedIn: false, balance: 0 };
     }
 }
 

--- a/recipe-lanes/app/lanes/page.tsx
+++ b/recipe-lanes/app/lanes/page.tsx
@@ -24,13 +24,14 @@ import { useAuth } from '@/components/auth-provider';
 import { LogoutButton } from '@/components/logout-button';
 import ReactFlowDiagram, { ReactFlowDiagramHandle } from '@/components/recipe-lanes/react-flow-diagram';
 import { ReactFlowProvider } from 'reactflow';
-import { createVisualRecipeAction, createVisualRecipeFromImageAction, adjustRecipeAction, saveRecipeAction, saveChatHistoryAction, checkExistingCopiesAction, debugLogAction, applyIconSearchResultsAction, forgeIconAction } from '@/app/actions';
+import { createVisualRecipeAction, createVisualRecipeFromImageAction, adjustRecipeAction, saveRecipeAction, saveChatHistoryAction, checkExistingCopiesAction, debugLogAction, applyIconSearchResultsAction, forgeIconAction, getIconCreditsAction } from '@/app/actions';
 import { ChatPanel } from '@/components/recipe-lanes/chat-panel';
 import { MAX_RECIPE_INPUT_CHARS, MAX_ADJUST_INSTRUCTION_CHARS } from '@/lib/recipe-lanes/limits';
 import { buildRecipeEditInstruction } from '@/lib/recipe-lanes/recipe-edit-diff';
 import { iconSearchMethods, defaultIconSearchMethod, hydrateClientSide } from '@/lib/icon-search-registry';
 import { standardizeIngredientName, resolveBylineName } from '@/lib/utils';
 import { IngredientsSidebar } from '@/components/recipe-lanes/ui/ingredients-sidebar';
+import { IconShortlistModal, IconCreditsInfo } from '@/components/icon-shortlist-modal';
 import { TimelineView } from '@/components/recipe-lanes/timeline-view';
 import type { RecipeGraph, LayoutModeId, RecipeNode } from '@/lib/recipe-lanes/types';
 import { hasNodeIcon, preserveNodeShortlist, getNodeShortlistLength, getNodeIngredientName, getNodeHydeQueries, extractBatchIngredients, getNodeIcon, buildIngredientText } from '@/lib/recipe-lanes/model-utils';
@@ -64,7 +65,8 @@ function RecipeLanesContent() {
   const graph = useRecipeStore(s => s.graph);
   const ownerId = useRecipeStore(s => s.ownerId);
   const ownerName = useRecipeStore(s => s.ownerName);
-  const { mergeSnapshot, setGraph, setGraphWithUndo, undo, updateNode, cycleShortlist, reset: resetRecipeStore, addMessage, clearMessages } = useRecipeStore.getState();
+  const { mergeSnapshot, setGraph, setGraphWithUndo, undo, updateNode, reset: resetRecipeStore, addMessage, clearMessages, openIconEditor, closeIconEditor, setShortlistIndex } = useRecipeStore.getState();
+  const iconEditorNodeId = useRecipeStore(s => s.iconEditorNodeId);
   const canUndo = useRecipeStore(s => s.undoPast.length > 0);
   const messageCount = useRecipeStore(s => s.messages.length);
   
@@ -78,6 +80,8 @@ function RecipeLanesContent() {
   const [showJson, setShowJson] = useState(false);
   const [forgingIds, setForgingIds] = useState<Set<string>>(new Set());
   const [showIngredients, setShowIngredients] = useState(false);
+  // Icon-credit balance shown in the icon editor modal; null until loaded.
+  const [iconCredits, setIconCredits] = useState<IconCreditsInfo | null>(null);
   const [iconSearchStatus, setIconSearchStatus] = useState<'idle' | 'running' | 'done' | 'error'>('idle');
   const [iconSearchMethodId, setIconSearchMethodId] = useState(defaultIconSearchMethod.id);
   const [iconSearchElapsed, setIconSearchElapsed] = useState<number | null>(null);
@@ -355,16 +359,20 @@ const saveAndHandleFork = async (graphToSave: RecipeGraph) => {
   };
 
   const handleForgeIcon = async (node: RecipeNode) => {
-      // Reject the current icon and queue a brand-new AI icon. Server-side
-      // checkForgeAllowed enforces the rate limit / anon gate; we surface its error.
+      // Spend a credit and queue a brand-new AI icon. Server-side the action
+      // enforces sign-in, the credit balance, and the daily cap; we surface
+      // its error and keep the displayed balance in sync from the response.
       if (!recipeId) {
-          showNotification('Save the recipe first to forge icons.');
+          showNotification('Save the recipe first to generate icons.');
           return;
       }
       setForgingIds(prev => new Set(prev).add(node.id));
       try {
           const res = await forgeIconAction(recipeId, getNodeIngredientName(node), getNodeIcon(node)?.id);
-          showNotification(res?.success ? 'Forging a new icon…' : (res?.error || 'Forge failed.'));
+          showNotification(res?.success ? 'Generating a new icon…' : (res?.error || 'Icon generation failed.'));
+          if (typeof res?.creditsRemaining === 'number') {
+              setIconCredits({ signedIn: true, balance: res.creditsRemaining });
+          }
       } finally {
           setForgingIds(prev => {
               const next = new Set(prev);
@@ -373,6 +381,14 @@ const saveAndHandleFork = async (graphToSave: RecipeGraph) => {
           });
       }
   };
+
+  // Load the credit balance whenever the icon editor opens or auth changes.
+  useEffect(() => {
+      if (!iconEditorNodeId) return;
+      let cancelled = false;
+      getIconCreditsAction().then(res => { if (!cancelled) setIconCredits(res); });
+      return () => { cancelled = true; };
+  }, [iconEditorNodeId, user]);
 
   const handleToggleJson = () => {
       if (!showJson && diagramRef.current) {
@@ -1327,11 +1343,27 @@ const handleVisualize = async () => {
                     onClose={() => setShowIngredients(false)}
                     onUpdateServes={handleUpdateServes}
                     onEditNode={handleEditNode}
-                    onCycleShortlist={cycleShortlist}
-                    onForge={handleForgeIcon}
-                    forgingIds={forgingIds}
+                    onEditIcon={openIconEditor}
                 />
             )}
+
+            {/* Icon editor modal — opened from node/sidebar pencil buttons via the store. */}
+            {(() => {
+                if (!iconEditorNodeId || !graph) return null;
+                const editorNode = graph.nodes.find(n => n.id === iconEditorNodeId);
+                if (!editorNode) return null;
+                return (
+                    <IconShortlistModal
+                        node={editorNode}
+                        onClose={closeIconEditor}
+                        onSelect={(index) => setShortlistIndex(iconEditorNodeId, index)}
+                        onGenerate={() => handleForgeIcon(editorNode)}
+                        isGenerating={forgingIds.has(iconEditorNodeId)}
+                        credits={iconCredits}
+                        onSignIn={signIn}
+                    />
+                );
+            })()}
 
             <div className="flex-1 relative">
                 <LoadingScreen phase={loadingPhase} />

--- a/recipe-lanes/components/icon-shortlist-modal.tsx
+++ b/recipe-lanes/components/icon-shortlist-modal.tsx
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { X, Sparkles, Coins } from 'lucide-react';
+import { RecipeNode } from '@/lib/recipe-lanes/types';
+import {
+  getNodeIngredientName,
+  getNodeShortlistLength,
+  getNodeIconUrlAt,
+  getNodeIconStatus,
+  isIconSearchMatchedAt,
+  currentShortlistIndex,
+} from '@/lib/recipe-lanes/model-utils';
+import { STARTER_ICON_CREDITS, FORGE_CREDIT_COST } from '@/lib/config';
+
+export interface IconCreditsInfo {
+  signedIn: boolean;
+  balance: number;
+}
+
+interface IconShortlistModalProps {
+  node: RecipeNode;
+  onClose: () => void;
+  /** Make the shortlist entry at `index` the node's current icon. */
+  onSelect: (index: number) => void;
+  /** Spend a credit and queue a brand-new icon generation for this node. */
+  onGenerate: () => void;
+  /** True while the generate request is in flight. */
+  isGenerating: boolean;
+  /** Current credit state, or null while it is still loading. */
+  credits: IconCreditsInfo | null;
+  onSignIn: () => void;
+}
+
+/**
+ * The icon editor: shows a node's whole icon shortlist at once (which counts
+ * as an impression for every entry — the store flags shortlistSeenAll when
+ * opening), lets the user pick one directly, and hosts the credit-gated
+ * "generate new icon" button that replaced the old forge hammer.
+ */
+export function IconShortlistModal({
+  node,
+  onClose,
+  onSelect,
+  onGenerate,
+  isGenerating,
+  credits,
+  onSignIn,
+}: IconShortlistModalProps) {
+  const title = getNodeIngredientName(node);
+  const length = getNodeShortlistLength(node);
+  const selectedIndex = currentShortlistIndex(node);
+  const nodeStatus = getNodeIconStatus(node);
+  const generationPending = nodeStatus === 'pending' || nodeStatus === 'processing';
+  const busy = isGenerating || generationPending;
+
+  const canAfford = credits !== null && credits.signedIn && credits.balance >= FORGE_CREDIT_COST;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+      onClick={onClose}
+      data-testid="icon-editor-modal"
+    >
+      <div
+        className="relative w-full max-w-md bg-white border border-zinc-200 rounded-xl shadow-2xl overflow-y-auto max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between gap-4 p-4 border-b border-zinc-100">
+          <div className="min-w-0">
+            <h2 className="text-sm font-bold text-zinc-800 uppercase tracking-wide truncate">{title}</h2>
+            <p className="text-[11px] text-zinc-400 mt-0.5">Pick an icon, or generate a new one.</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="shrink-0 p-1 rounded text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 transition-colors"
+            aria-label="Close"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Shortlist grid */}
+        <div className="p-4">
+          {length > 0 ? (
+            <div className="grid grid-cols-4 gap-2">
+              {Array.from({ length }, (_, i) => {
+                const url = getNodeIconUrlAt(node, i);
+                const isSelected = i === selectedIndex;
+                return (
+                  <button
+                    key={i}
+                    onClick={() => onSelect(i)}
+                    className={`relative aspect-square rounded-lg border-2 p-1 flex items-center justify-center transition-all bg-zinc-50 hover:bg-zinc-100 ${
+                      isSelected
+                        ? 'border-blue-500 ring-2 ring-blue-200'
+                        : 'border-zinc-200 hover:border-zinc-300'
+                    }`}
+                    title={isSelected ? 'Current icon' : 'Use this icon'}
+                    aria-pressed={isSelected}
+                    data-testid={`icon-editor-entry-${i}`}
+                  >
+                    {url ? (
+                      <img
+                        src={url}
+                        alt=""
+                        className="w-full h-full object-contain mix-blend-multiply"
+                        style={{ imageRendering: 'pixelated' }}
+                      />
+                    ) : (
+                      <span className="text-xl">🥕</span>
+                    )}
+                    {isIconSearchMatchedAt(node, i) && (
+                      <span
+                        className="absolute bottom-1 right-1 w-[5px] h-[5px] rounded-full bg-amber-400 pointer-events-none"
+                        title="Icon matched by search"
+                      />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="py-6 text-center text-xs text-zinc-400">
+              {generationPending ? 'An icon is being generated…' : 'No icons yet for this step.'}
+            </div>
+          )}
+        </div>
+
+        {/* Generate section */}
+        <div className="p-4 border-t border-zinc-100 bg-zinc-50/60 rounded-b-xl space-y-2">
+          {credits?.signedIn ? (
+            <>
+              <button
+                onClick={onGenerate}
+                disabled={busy || !canAfford}
+                className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-amber-500 hover:bg-amber-600 disabled:bg-zinc-200 disabled:text-zinc-400 text-white text-sm font-semibold transition-colors disabled:cursor-not-allowed"
+                data-testid="icon-editor-generate"
+              >
+                <Sparkles className={`w-4 h-4 ${busy ? 'animate-pulse' : ''}`} />
+                {busy
+                  ? 'Generating…'
+                  : `Generate a new icon (${FORGE_CREDIT_COST} credit${FORGE_CREDIT_COST === 1 ? '' : 's'})`}
+              </button>
+              <div
+                className="flex items-center justify-center gap-1.5 text-[11px] text-zinc-500"
+                data-testid="icon-editor-credits"
+              >
+                <Coins className="w-3.5 h-3.5 text-amber-500" />
+                {credits.balance} icon credit{credits.balance === 1 ? '' : 's'} left
+                {!canAfford && !busy && (
+                  <span className="text-red-500 font-medium ml-1">— you are out of credits</span>
+                )}
+              </div>
+            </>
+          ) : credits === null ? (
+            <div className="text-center text-[11px] text-zinc-400 py-2">Loading credits…</div>
+          ) : (
+            <button
+              onClick={onSignIn}
+              className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-zinc-800 hover:bg-zinc-700 text-white text-sm font-semibold transition-colors"
+              data-testid="icon-editor-signin"
+            >
+              <Sparkles className="w-4 h-4" />
+              Sign in to get {STARTER_ICON_CREDITS} free icon credits
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/recipe-lanes/components/recipe-lanes/nodes/minimal-node-classic.tsx
+++ b/recipe-lanes/components/recipe-lanes/nodes/minimal-node-classic.tsx
@@ -17,15 +17,13 @@
 
 import React from 'react';
 import { Handle, Position } from 'reactflow';
-import { RefreshCw, X, Hammer } from 'lucide-react';
+import { Pencil, X } from 'lucide-react';
 import { RecipeNode } from '../../../lib/recipe-lanes/types';
 import { getNodeIngredientName, getNodeIconStatus } from '../../../lib/recipe-lanes/model-utils';
 
 interface MinimalNodeViewProps {
     data: RecipeNode;
     selected?: boolean;
-    isRerolling: boolean;
-    isForging: boolean;
     /** Whether the cook has ticked this step off (#281). */
     isCompleted?: boolean;
     isPivotMode: boolean;
@@ -34,8 +32,7 @@ interface MinimalNodeViewProps {
     /** Whether the current shortlist entry was resolved via search rather than generation. */
     isSearchMatched: boolean;
     handlers: {
-        onReroll: (e: React.MouseEvent) => void;
-        onForge: (e: React.MouseEvent) => void;
+        onEditIcon: (e: React.MouseEvent) => void;
         onDelete: (e: React.MouseEvent) => void;
         onToggleCompleted: (e: React.MouseEvent) => void;
         onPointerDownCapture: (e: React.PointerEvent) => void;
@@ -46,7 +43,7 @@ interface MinimalNodeViewProps {
 }
 
 export const MinimalNodeClassic: React.FC<MinimalNodeViewProps> = ({
-    data, selected, isRerolling, isForging, isCompleted, isPivotMode, iconUrl, isSearchMatched, handlers
+    data, selected, isCompleted, isPivotMode, iconUrl, isSearchMatched, handlers
 }) => {
     const isIngredient = data.type === 'ingredient';
     const textPos = data.textPos || 'bottom';
@@ -107,7 +104,7 @@ export const MinimalNodeClassic: React.FC<MinimalNodeViewProps> = ({
                     <img
                         src={iconUrl}
                         alt=""
-                        className={`${imageSize} object-contain drop-shadow-md mix-blend-multiply ${isRerolling ? 'opacity-50' : ''}`}
+                        className={`${imageSize} object-contain drop-shadow-md mix-blend-multiply`}
                         style={{ imageRendering: 'pixelated', ...(isCompleted ? { opacity: 0.45 } : {}) }}
                     />
                 ) : (
@@ -121,24 +118,14 @@ export const MinimalNodeClassic: React.FC<MinimalNodeViewProps> = ({
                     )
                 )}
                 
-                {/* Reroll Button */}
+                {/* Edit Icon Button — opens the icon editor modal (shortlist + generate). */}
                 <button
-                    onClick={handlers.onReroll}
-                    disabled={isRerolling || isForging}
-                    className={`nodrag absolute -top-2 -right-2 bg-zinc-100 rounded-full p-1 shadow-md border border-zinc-200 text-zinc-500 hover:text-blue-500 transition-all z-50 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 ${isRerolling ? '!opacity-100 block cursor-not-allowed' : ''}`}
-                    title="Cycle shortlist"
+                    onClick={handlers.onEditIcon}
+                    className="nodrag absolute -top-2 -right-2 bg-zinc-100 rounded-full p-1 shadow-md border border-zinc-200 text-zinc-500 hover:text-blue-500 transition-all z-50 opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
+                    title="Edit icon"
+                    data-testid="node-edit-icon"
                 >
-                    <RefreshCw className={`w-3 h-3 ${isRerolling ? 'animate-spin text-blue-500' : ''}`} />
-                </button>
-
-                {/* Forge Button */}
-                <button
-                    onClick={handlers.onForge}
-                    disabled={isRerolling || isForging}
-                    className={`nodrag absolute -bottom-2 -right-2 bg-zinc-100 rounded-full p-1 shadow-md border border-zinc-200 text-zinc-500 hover:text-amber-500 transition-all z-50 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 ${isForging ? '!opacity-100 block cursor-not-allowed' : ''}`}
-                    title="Forge new icon"
-                >
-                    <Hammer className={`w-3 h-3 ${isForging ? 'text-amber-500' : ''}`} />
+                    <Pencil className="w-3 h-3" />
                 </button>
 
                 {/* Delete Button */}

--- a/recipe-lanes/components/recipe-lanes/nodes/minimal-node-modern.tsx
+++ b/recipe-lanes/components/recipe-lanes/nodes/minimal-node-modern.tsx
@@ -17,15 +17,13 @@
 
 import React from 'react';
 import { Handle, Position } from 'reactflow';
-import { RefreshCw, X, Hammer } from 'lucide-react';
+import { Pencil, X } from 'lucide-react';
 import { RecipeNode } from '../../../lib/recipe-lanes/types';
 import { getNodeIngredientName, getNodeTheme } from '../../../lib/recipe-lanes/model-utils';
 
 interface MinimalNodeViewProps {
     data: RecipeNode;
     selected?: boolean;
-    isRerolling: boolean;
-    isForging: boolean;
     /** Whether the cook has ticked this step off (#281). */
     isCompleted?: boolean;
     isPivotMode: boolean;
@@ -34,8 +32,7 @@ interface MinimalNodeViewProps {
     /** Whether the current shortlist entry was resolved via search rather than generation. */
     isSearchMatched: boolean;
     handlers: {
-        onReroll: (e: React.MouseEvent) => void;
-        onForge: (e: React.MouseEvent) => void;
+        onEditIcon: (e: React.MouseEvent) => void;
         onDelete: (e: React.MouseEvent) => void;
         onToggleCompleted: (e: React.MouseEvent) => void;
         onPointerDownCapture: (e: React.PointerEvent) => void;
@@ -55,7 +52,7 @@ const parseNodeText = (text: string) => {
 };
 
 export const MinimalNodeModern: React.FC<MinimalNodeViewProps> = ({
-    data, selected, isRerolling, isForging, isCompleted, isPivotMode, iconUrl, isSearchMatched, handlers
+    data, selected, isCompleted, isPivotMode, iconUrl, isSearchMatched, handlers
 }) => {
     const isIngredient = data.type === 'ingredient';
     const themeVariant = getNodeTheme(data) === 'modern_clean' ? 'modern_clean' : 'modern';
@@ -89,7 +86,7 @@ export const MinimalNodeModern: React.FC<MinimalNodeViewProps> = ({
                                         {iconUrl ? (
                                             <img
                                                 src={iconUrl}
-                                                alt=""                                className={`w-full h-full object-contain drop-shadow-md rendering-pixelated ${isRerolling ? 'opacity-50' : ''}`}
+                                                alt=""                                className={`w-full h-full object-contain drop-shadow-md rendering-pixelated`}
                                 style={{ imageRendering: 'pixelated', ...(isCompleted ? { opacity: 0.45 } : {}) }}
                             />
                         ) : (
@@ -106,11 +103,8 @@ export const MinimalNodeModern: React.FC<MinimalNodeViewProps> = ({
 
                         {/* Controls */}
                         <div className="absolute -top-2 -right-4 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity z-50">
-                            <button onClick={handlers.onReroll} disabled={isRerolling || isForging} className="bg-white/80 rounded-full p-1 shadow hover:text-blue-500">
-                                <RefreshCw className={`w-3 h-3 ${isRerolling ? 'animate-spin' : ''}`} />
-                            </button>
-                            <button onClick={handlers.onForge} disabled={isRerolling || isForging} className="bg-white/80 rounded-full p-1 shadow hover:text-amber-500" title="Forge new icon">
-                                <Hammer className={`w-3 h-3 ${isForging ? 'text-amber-500' : ''}`} />
+                            <button onClick={handlers.onEditIcon} className="bg-white/80 rounded-full p-1 shadow hover:text-blue-500" title="Edit icon" data-testid="node-edit-icon">
+                                <Pencil className="w-3 h-3" />
                             </button>
                             <button onClick={handlers.onDelete} className="bg-white/80 rounded-full p-1 shadow hover:text-red-500">
                                 <X className="w-3 h-3" />
@@ -172,7 +166,7 @@ export const MinimalNodeModern: React.FC<MinimalNodeViewProps> = ({
                             <img
                                 src={iconUrl}
                                 alt=""
-                                className={`w-full h-full object-contain drop-shadow-md rendering-pixelated ${isRerolling ? 'opacity-50' : ''}`}
+                                className={`w-full h-full object-contain drop-shadow-md rendering-pixelated`}
                                 style={{ imageRendering: 'pixelated', ...(isCompleted ? { opacity: 0.45 } : {}) }}
                             />
                         ) : (
@@ -181,11 +175,8 @@ export const MinimalNodeModern: React.FC<MinimalNodeViewProps> = ({
 
                         {/* Controls */}
                         <div className="absolute -top-2 -right-4 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity z-50">
-                            <button onClick={handlers.onReroll} disabled={isRerolling || isForging} className="bg-white/80 rounded-full p-1 shadow hover:text-blue-500">
-                                <RefreshCw className={`w-3 h-3 ${isRerolling ? 'animate-spin' : ''}`} />
-                            </button>
-                            <button onClick={handlers.onForge} disabled={isRerolling || isForging} className="bg-white/80 rounded-full p-1 shadow hover:text-amber-500" title="Forge new icon">
-                                <Hammer className={`w-3 h-3 ${isForging ? 'text-amber-500' : ''}`} />
+                            <button onClick={handlers.onEditIcon} className="bg-white/80 rounded-full p-1 shadow hover:text-blue-500" title="Edit icon" data-testid="node-edit-icon">
+                                <Pencil className="w-3 h-3" />
                             </button>
                             <button onClick={handlers.onDelete} className="bg-white/80 rounded-full p-1 shadow hover:text-red-500">
                                 <X className="w-3 h-3" />
@@ -281,7 +272,7 @@ export const MinimalNodeModern: React.FC<MinimalNodeViewProps> = ({
                       <img
                           src={iconUrl}
                           alt=""
-                          className={`w-full h-full object-contain drop-shadow-xl rendering-pixelated ${isRerolling ? 'opacity-50' : ''}`}
+                          className={`w-full h-full object-contain drop-shadow-xl rendering-pixelated`}
                           style={{ imageRendering: 'pixelated', ...(isCompleted ? { opacity: 0.45 } : {}) }}
                       />
                   ) : (
@@ -290,11 +281,8 @@ export const MinimalNodeModern: React.FC<MinimalNodeViewProps> = ({
 
                   {/* Controls */}
                   <div className="absolute top-0 right-4 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity z-50">
-                      <button onClick={handlers.onReroll} disabled={isRerolling || isForging} className="bg-white/80 rounded-full p-1 shadow hover:text-blue-500" title="Cycle shortlist">
-                          <RefreshCw className={`w-3 h-3 ${isRerolling ? 'animate-spin' : ''}`} />
-                      </button>
-                      <button onClick={handlers.onForge} disabled={isRerolling || isForging} className="bg-white/80 rounded-full p-1 shadow hover:text-amber-500" title="Forge new icon">
-                          <Hammer className={`w-3 h-3 ${isForging ? 'text-amber-500' : ''}`} />
+                      <button onClick={handlers.onEditIcon} className="bg-white/80 rounded-full p-1 shadow hover:text-blue-500" title="Edit icon" data-testid="node-edit-icon">
+                          <Pencil className="w-3 h-3" />
                       </button>
                       <button onClick={handlers.onDelete} className="bg-white/80 rounded-full p-1 shadow hover:text-red-500">
                           <X className="w-3 h-3" />

--- a/recipe-lanes/components/recipe-lanes/nodes/minimal-node.tsx
+++ b/recipe-lanes/components/recipe-lanes/nodes/minimal-node.tsx
@@ -16,17 +16,11 @@
  */
 
 import React, { memo, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
 import { MinimalNodeClassic } from './minimal-node-classic';
 import { MinimalNodeModern } from './minimal-node-modern';
 import { CLASSIC_CONTAINER, MODERN_CONTAINER, getLeafScaleOrigin } from '../../../lib/recipe-lanes/edge-anchors';
-import { forgeIconAction } from '@/app/actions';
 import {
-    getNodeIngredientName,
     getNodeTheme,
-    getNodeIconId,
-    getNodeShortlistLength,
-    getNodeShortlistKey,
     getNodeIconUrlAt,
     isIconSearchMatchedAt,
     currentShortlistIndex,
@@ -36,7 +30,6 @@ import { useRecipeStore } from '@/lib/stores/recipe-store';
 export const MinimalNode: React.FC<any> = ({
     data, selected, isConnectable, id, dragging
 }) => {
-  const [isForging, setIsForging] = useState(false);
   const [isPivotMode, setIsPivotMode] = useState(false);
   const longPressTimer = React.useRef<NodeJS.Timeout | null>(null);
 
@@ -52,14 +45,11 @@ export const MinimalNode: React.FC<any> = ({
           }
       }
   }, [dragging, data]);
-  const searchParams = useSearchParams();
-  const recipeId = searchParams.get('id');
-
   // Subscribe to this node in the recipe store.
-  // cycleShortlist writes shortlistIndex directly onto graph.nodes[i], so this
-  // selector re-renders only when this specific node changes.
+  // setShortlistIndex writes shortlistIndex directly onto graph.nodes[i], so
+  // this selector re-renders only when this specific node changes.
   const storeNode = useRecipeStore(s => s.graph?.nodes.find(n => n.id === id));
-  const cycleShortlist = useRecipeStore(s => s.cycleShortlist);
+  const openIconEditor = useRecipeStore(s => s.openIconEditor);
   // Global "leaf node size" setting (#155): scale leaf nodes (no incoming edge).
   // `data.isLeaf` is computed once during layout in react-flow-diagram.
   const leafNodeScale = useRecipeStore(s => s.leafNodeScale);
@@ -72,20 +62,9 @@ export const MinimalNode: React.FC<any> = ({
   const node = storeNode ?? data;
   const iconTheme = getNodeTheme(data);
 
-  const shortlistKey = getNodeShortlistKey(node);
   const currentIndex = Math.max(0, currentShortlistIndex(node));
   const iconUrl = getNodeIconUrlAt(node, currentIndex);
   const isSearchMatched = isIconSearchMatchedAt(node, currentIndex);
-
-  // ---------------------------------------------------------------------------
-  // Forge state: cleared when a forge result arrives via Firestore snapshot,
-  // which causes mergeSnapshot to reset shortlistIndex and update the store node.
-  // ---------------------------------------------------------------------------
-  const [prevShortlistKey, setPrevShortlistKey] = useState(shortlistKey);
-  if (shortlistKey !== prevShortlistKey) {
-      setPrevShortlistKey(shortlistKey);
-      if (isForging) setIsForging(false);
-  }
 
   const touchStartPos = React.useRef<{x: number, y: number} | null>(null);
 
@@ -125,9 +104,9 @@ export const MinimalNode: React.FC<any> = ({
       if (data.onDelete) data.onDelete();
   };
 
-  const handleReroll = (e: React.MouseEvent) => {
+  const handleEditIcon = (e: React.MouseEvent) => {
       e.stopPropagation();
-      cycleShortlist(id);
+      openIconEditor(id);
   };
 
   const handleToggleCompleted = (e: React.MouseEvent) => {
@@ -135,28 +114,8 @@ export const MinimalNode: React.FC<any> = ({
       toggleNodeCompleted(id);
   };
 
-  const handleForge = async (e: React.MouseEvent) => {
-      e.stopPropagation();
-      setIsForging(true);
-      const ingredientName = getNodeIngredientName(data);
-      console.log(`[Forge] node="${data.text}" ingredientName="${ingredientName}" recipeId="${recipeId}"`);
-      try {
-          const result = await forgeIconAction(recipeId || '', ingredientName, getNodeIconId(data) || '');
-          if (result && !result.success) {
-              console.error("Forge failed:", result.error);
-              useRecipeStore.getState().addMessage({ role: 'assistant', content: `Forge failed: ${result.error}` });
-              setIsForging(false);
-          }
-      } catch (err: any) {
-          console.error("Forge exception:", err);
-          useRecipeStore.getState().addMessage({ role: 'assistant', content: `Forge error: ${err?.message ?? err}` });
-          setIsForging(false);
-      }
-  };
-
   const handlers = {
-      onReroll: handleReroll,
-      onForge: handleForge,
+      onEditIcon: handleEditIcon,
       onDelete: handleDelete,
       onToggleCompleted: handleToggleCompleted,
       onPointerDownCapture: handlePointerDown,
@@ -166,8 +125,8 @@ export const MinimalNode: React.FC<any> = ({
   };
 
   const inner = (iconTheme === 'modern' || iconTheme === 'modern_clean')
-      ? <MinimalNodeModern data={data} selected={selected} isRerolling={false} isForging={isForging} isCompleted={isCompleted} isPivotMode={isPivotMode} iconUrl={iconUrl} isSearchMatched={isSearchMatched} handlers={handlers} />
-      : <MinimalNodeClassic data={data} selected={selected} isRerolling={false} isForging={isForging} isCompleted={isCompleted} isPivotMode={isPivotMode} iconUrl={iconUrl} isSearchMatched={isSearchMatched} handlers={handlers} />;
+      ? <MinimalNodeModern data={data} selected={selected} isCompleted={isCompleted} isPivotMode={isPivotMode} iconUrl={iconUrl} isSearchMatched={isSearchMatched} handlers={handlers} />
+      : <MinimalNodeClassic data={data} selected={selected} isCompleted={isCompleted} isPivotMode={isPivotMode} iconUrl={iconUrl} isSearchMatched={isSearchMatched} handlers={handlers} />;
 
   // Scale leaf nodes down when the global slider is below 100%. The transform
   // origin is pinned to the HANDLE point (top-center of the icon container) so

--- a/recipe-lanes/components/recipe-lanes/nodes/timeline-node.tsx
+++ b/recipe-lanes/components/recipe-lanes/nodes/timeline-node.tsx
@@ -9,18 +9,13 @@
 
 'use client';
 
-import React, { memo, useState } from 'react';
+import React, { memo } from 'react';
 import { Handle, Position } from 'reactflow';
-import { useSearchParams } from 'next/navigation';
 import { useRecipeStore } from '@/lib/stores/recipe-store';
 import {
-    getNodeIngredientName,
-    getNodeIconId,
-    getNodeShortlistKey,
     getNodeIconUrlAt,
     currentShortlistIndex,
 } from '@/lib/recipe-lanes/model-utils';
-import { forgeIconAction } from '@/app/actions';
 
 const NODE_R   = 20;              // must match TL.NODE_R
 const DIAMETER = NODE_R * 2;     // 40px
@@ -43,12 +38,8 @@ const BTN: React.CSSProperties = {
 };
 
 const TimelineNode: React.FC<any> = ({ data, selected, id }) => {
-    const [isForging, setIsForging]   = useState(false);
-    const searchParams                = useSearchParams();
-    const recipeId                    = searchParams.get('id');
-
     const storeNode      = useRecipeStore(s => s.graph?.nodes.find(n => n.id === id));
-    const cycleShortlist = useRecipeStore(s => s.cycleShortlist);
+    const openIconEditor = useRecipeStore(s => s.openIconEditor);
     const leafNodeScale  = useRecipeStore(s => s.leafNodeScale);
     // "Tick off" steps (#281): whether this node has been marked done by the cook.
     const isCompleted         = useRecipeStore(s => s.completedNodeIds.includes(id));
@@ -57,38 +48,14 @@ const TimelineNode: React.FC<any> = ({ data, selected, id }) => {
 
     const currentIndex = Math.max(0, currentShortlistIndex(node));
     const iconUrl      = getNodeIconUrlAt(node, currentIndex);
-    const shortlistKey = getNodeShortlistKey(node);
-
-    // Clear forge state when the shortlist key changes (forge result arrived)
-    const [prevKey, setPrevKey] = useState(shortlistKey);
-    if (shortlistKey !== prevKey) {
-        setPrevKey(shortlistKey);
-        if (isForging) setIsForging(false);
-    }
 
     const isIngredient = data.type === 'ingredient';
     const lineColor    = data.lineColor ?? '#D4D4D8';
     const borderColor  = selected ? '#6366f1' : lineColor;
 
-    const handleReroll = (e: React.MouseEvent) => {
+    const handleEditIcon = (e: React.MouseEvent) => {
         e.stopPropagation();
-        cycleShortlist(id);
-    };
-
-    const handleForge = async (e: React.MouseEvent) => {
-        e.stopPropagation();
-        if (isForging) return;
-        setIsForging(true);
-        try {
-            const res = await forgeIconAction(
-                recipeId ?? '',
-                getNodeIngredientName(data),
-                getNodeIconId(data) ?? '',
-            );
-            if (res && !res.success) setIsForging(false);
-        } catch {
-            setIsForging(false);
-        }
+        openIconEditor(id);
     };
 
     const handleDelete = (e: React.MouseEvent) => {
@@ -198,27 +165,14 @@ const TimelineNode: React.FC<any> = ({ data, selected, id }) => {
                 )}
             </div>
 
-            {/* Hover buttons — reroll (↺), forge (⚒), delete (×) */}
+            {/* Hover buttons — edit icon (✎), delete (×) */}
             <button
-                onClick={handleReroll}
+                onClick={handleEditIcon}
                 className="nodrag opacity-0 group-hover:opacity-100 transition-opacity"
                 style={{ ...BTN, top: -9, left: -9, background: '#3b82f6' }}
-                title="Cycle shortlist"
-            >↺</button>
-
-            <button
-                onClick={handleForge}
-                className="nodrag opacity-0 group-hover:opacity-100 transition-opacity"
-                style={{
-                    ...BTN,
-                    top: -9,
-                    left: '50%',
-                    transform: 'translateX(-50%)',
-                    background: isForging ? '#f59e0b' : '#92400e',
-                    cursor: isForging ? 'not-allowed' : 'pointer',
-                }}
-                title="Forge new icon"
-            >{isForging ? '…' : '⚒'}</button>
+                title="Edit icon"
+                data-testid="node-edit-icon"
+            >✎</button>
 
             <button
                 onClick={handleDelete}

--- a/recipe-lanes/components/recipe-lanes/timeline-view.tsx
+++ b/recipe-lanes/components/recipe-lanes/timeline-view.tsx
@@ -20,17 +20,15 @@
 import React, {
   useMemo, useState, useRef, useCallback, useEffect, useLayoutEffect, useTransition,
 } from 'react';
-import { useSearchParams } from 'next/navigation';
 import { Play, Pause, RotateCcw, ZoomIn, ZoomOut, Maximize2, Undo2 } from 'lucide-react';
 import {
   buildTimelineLayout, TL,
   type TLNode, type TLEdge, type TLLane,
 } from '@/lib/recipe-lanes/timeline-layout';
 import {
-  getNodeIconUrlAt, getNodeIngredientName, getNodeIconId, getNodeShortlistKey, currentShortlistIndex,
+  getNodeIconUrlAt, currentShortlistIndex,
 } from '@/lib/recipe-lanes/model-utils';
 import { useRecipeStore } from '@/lib/stores/recipe-store';
-import { forgeIconAction } from '@/app/actions';
 import type { RecipeGraph, RecipeNode } from '@/lib/recipe-lanes/types';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -74,29 +72,22 @@ function spurPath(x1: number, y1: number, x2: number, y2: number): string {
   return `M ${x1} ${y1 + TL.NODE_R} L ${x2} ${y2 - TL.NODE_R}`;
 }
 
-// ── Node controls (↺ reroll, ⚒ forge, × delete) ───────────────────────────
-function NodeControls({ cx, cy, isForging, onReroll, onForge, onDelete }: {
-  cx: number; cy: number; isForging: boolean;
-  onReroll: (e: React.MouseEvent) => void;
-  onForge:  (e: React.MouseEvent) => void;
+// ── Node controls (✎ edit icon, × delete) ─────────────────────────────────
+function NodeControls({ cx, cy, onEditIcon, onDelete }: {
+  cx: number; cy: number;
+  onEditIcon: (e: React.MouseEvent) => void;
   onDelete: (e: React.MouseEvent) => void;
 }) {
   const y = cy - TL.NODE_R;
   return (
     <g onMouseDown={e => e.stopPropagation()}>
-      <g onClick={onReroll} style={{ cursor: 'pointer' }}>
-        <circle cx={cx - 18} cy={y} r={8} fill="#3b82f6" stroke="white" strokeWidth={1.5}/>
-        <text x={cx - 18} y={y} textAnchor="middle" dominantBaseline="middle" fontSize={11} fill="white">↺</text>
-      </g>
-      <g onClick={onForge} style={{ cursor: isForging ? 'not-allowed' : 'pointer' }}>
-        <circle cx={cx} cy={y} r={8} fill={isForging ? '#f59e0b' : '#92400e'} stroke="white" strokeWidth={1.5}/>
-        <text x={cx} y={y} textAnchor="middle" dominantBaseline="middle" fontSize={10} fill="white">
-          {isForging ? '…' : '⚒'}
-        </text>
+      <g onClick={onEditIcon} style={{ cursor: 'pointer' }} data-testid="node-edit-icon">
+        <circle cx={cx - 12} cy={y} r={8} fill="#3b82f6" stroke="white" strokeWidth={1.5}/>
+        <text x={cx - 12} y={y} textAnchor="middle" dominantBaseline="middle" fontSize={9} fill="white">✎</text>
       </g>
       <g onClick={onDelete} style={{ cursor: 'pointer' }} data-testid="node-delete">
-        <circle cx={cx + 18} cy={y} r={8} fill="#ef4444" stroke="white" strokeWidth={1.5}/>
-        <text x={cx + 18} y={y} textAnchor="middle" dominantBaseline="middle" fontSize={11} fill="white">×</text>
+        <circle cx={cx + 12} cy={y} r={8} fill="#ef4444" stroke="white" strokeWidth={1.5}/>
+        <text x={cx + 12} y={y} textAnchor="middle" dominantBaseline="middle" fontSize={11} fill="white">×</text>
       </g>
     </g>
   );
@@ -106,17 +97,16 @@ function NodeControls({ cx, cy, isForging, onReroll, onForge, onDelete }: {
 interface NodeProps {
   node: TLNode; cx: number; cy: number;
   lineColor: string; playbackMin: number | null;
-  isHovered: boolean; isSelected: boolean; isForging: boolean;
+  isHovered: boolean; isSelected: boolean;
   onMouseDown:  (e: React.MouseEvent) => void;
   onMouseEnter: () => void; onMouseLeave: () => void;
-  onReroll: (e: React.MouseEvent) => void;
-  onForge:  (e: React.MouseEvent) => void;
+  onEditIcon: (e: React.MouseEvent) => void;
   onDelete: () => void;
 }
 
 // ── Action node ───────────────────────────────────────────────────────────────
-function ActionNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSelected, isForging,
-  onMouseDown, onMouseEnter, onMouseLeave, onReroll, onForge, onDelete }: NodeProps) {
+function ActionNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSelected,
+  onMouseDown, onMouseEnter, onMouseLeave, onEditIcon, onDelete }: NodeProps) {
   const { data } = node;
   const iconUrl = getNodeIconUrlAt(data, Math.max(0, currentShortlistIndex(data)));
   const clipId  = `tl-a-${node.id.replace(/\W/g, '')}`;
@@ -160,8 +150,8 @@ function ActionNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSelecte
         </text>
       )}
       {isHovered && (
-        <NodeControls cx={cx} cy={cy} isForging={isForging}
-          onReroll={onReroll} onForge={onForge}
+        <NodeControls cx={cx} cy={cy}
+          onEditIcon={onEditIcon}
           onDelete={e => { e.stopPropagation(); onDelete(); }}/>
       )}
     </g>
@@ -169,8 +159,8 @@ function ActionNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSelecte
 }
 
 // ── Ingredient node ───────────────────────────────────────────────────────────
-function IngredientNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSelected, isForging,
-  onMouseDown, onMouseEnter, onMouseLeave, onReroll, onForge, onDelete }: NodeProps) {
+function IngredientNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSelected,
+  onMouseDown, onMouseEnter, onMouseLeave, onEditIcon, onDelete }: NodeProps) {
   const { data } = node;
   const iconUrl = getNodeIconUrlAt(data, Math.max(0, currentShortlistIndex(data)));
   const clipId  = `tl-i-${node.id.replace(/\W/g, '')}`;
@@ -200,8 +190,8 @@ function IngredientNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSel
         textAnchor="middle" fontSize={8} fill="#52525b"
         fontFamily="ui-sans-serif, system-ui, sans-serif">{data.text}</text>
       {isHovered && (
-        <NodeControls cx={cx} cy={cy} isForging={isForging}
-          onReroll={onReroll} onForge={onForge}
+        <NodeControls cx={cx} cy={cy}
+          onEditIcon={onEditIcon}
           onDelete={e => { e.stopPropagation(); onDelete(); }}/>
       )}
     </g>
@@ -210,9 +200,7 @@ function IngredientNode({ node, cx, cy, lineColor, playbackMin, isHovered, isSel
 
 // ── Main ──────────────────────────────────────────────────────────────────────
 export function TimelineView({ graph, onSave }: { graph: RecipeGraph, onSave?: (graph: RecipeGraph) => void }) {
-  const searchParams   = useSearchParams();
-  const recipeId       = searchParams.get('id');
-  const cycleShortlist      = useRecipeStore(s => s.cycleShortlist);
+  const openIconEditor      = useRecipeStore(s => s.openIconEditor);
   const deleteNodeWithUndo  = useRecipeStore(s => s.deleteNodeWithUndo);
   const commitNodePositions = useRecipeStore(s => s.commitNodePositions);
 
@@ -250,44 +238,6 @@ export function TimelineView({ graph, onSave }: { graph: RecipeGraph, onSave?: (
   // replacing the old local stack's unmarkNodesDeleted dance.
   const undo    = useRecipeStore(s => s.undo);
   const canUndo = useRecipeStore(s => s.undoPast.length > 0);
-
-  // ── Forge state ───────────────────────────────────────────────────────────
-  const [forgingIds, setForgingIds]   = useState<Set<string>>(new Set());
-  const forgingIdsRef                 = useRef(forgingIds);
-  const prevShortlistKeysRef          = useRef<Map<string, string>>(new Map());
-  useEffect(() => { forgingIdsRef.current = forgingIds; }, [forgingIds]);
-
-  // Clear forge when shortlist key changes (forge result arrived)
-  useEffect(() => {
-    const curr = forgingIdsRef.current;
-    if (!curr.size) return;
-    const toRemove: string[] = [];
-    for (const id of curr) {
-      const node   = graph.nodes.find(n => n.id === id);
-      const prev   = prevShortlistKeysRef.current.get(id);
-      const newKey = node ? getNodeShortlistKey(node) : 'gone';
-      if (prev !== undefined && prev !== newKey) toRemove.push(id);
-      if (node) prevShortlistKeysRef.current.set(id, newKey);
-    }
-    if (toRemove.length) {
-      queueMicrotask(() => {
-        setForgingIds(p => { const n = new Set(p); toRemove.forEach(id => n.delete(id)); return n; });
-      });
-    }
-  }, [graph.nodes]); // intentionally excludes forgingIds
-
-  const handleForge = useCallback(async (nodeId: string, data: RecipeNode) => {
-    if (forgingIdsRef.current.has(nodeId)) return;
-    prevShortlistKeysRef.current.set(nodeId, getNodeShortlistKey(data));
-    setForgingIds(p => new Set([...p, nodeId]));
-    try {
-      const res = await forgeIconAction(recipeId ?? '', getNodeIngredientName(data), getNodeIconId(data) ?? '');
-      if (res && !res.success)
-        setForgingIds(p => { const n = new Set(p); n.delete(nodeId); return n; });
-    } catch {
-      setForgingIds(p => { const n = new Set(p); n.delete(nodeId); return n; });
-    }
-  }, [recipeId]);
 
   // ── Selection ─────────────────────────────────────────────────────────────
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -700,12 +650,10 @@ export function TimelineView({ graph, onSave }: { graph: RecipeGraph, onSave?: (
                 node, cx: pos.cx, cy: pos.cy, lineColor: color, playbackMin,
                 isHovered:  hoveredNodeId === node.id,
                 isSelected: selectedIds.has(node.id),
-                isForging:  forgingIds.has(node.id),
                 onMouseDown:  e => onNodeMouseDown(e, node),
                 onMouseEnter: () => setHoveredNodeId(node.id),
                 onMouseLeave: () => setHoveredNodeId(id => id === node.id ? null : id),
-                onReroll: e => { e.stopPropagation(); cycleShortlist(node.id); },
-                onForge:  e => { e.stopPropagation(); handleForge(node.id, node.data); },
+                onEditIcon: e => { e.stopPropagation(); openIconEditor(node.id); },
                 onDelete: () => deleteNode(node.id),
               };
               return node.kind === 'ingredient'

--- a/recipe-lanes/components/recipe-lanes/ui/ingredients-sidebar.tsx
+++ b/recipe-lanes/components/recipe-lanes/ui/ingredients-sidebar.tsx
@@ -18,8 +18,8 @@
 /* eslint-disable @next/next/no-img-element */
 import React, { useState, useEffect, useRef } from 'react';
 import { RecipeGraph, RecipeNode } from '@/lib/recipe-lanes/types';
-import { ChefHat, X, Users, RefreshCw, Hammer } from 'lucide-react';
-import { getNodeIconUrl, getNodeShortlistLength, computeIngredientRowPatch } from '@/lib/recipe-lanes/model-utils';
+import { ChefHat, X, Users, Pencil } from 'lucide-react';
+import { getNodeIconUrl, computeIngredientRowPatch } from '@/lib/recipe-lanes/model-utils';
 
 interface IngredientsSidebarProps {
   graph: RecipeGraph;
@@ -27,12 +27,8 @@ interface IngredientsSidebarProps {
   onUpdateServes: (newServes: number) => void;
   /** Commit a partial field patch to an ingredient (undoable store write). */
   onEditNode?: (nodeId: string, patch: Partial<RecipeNode>) => void;
-  /** Advance the node's icon shortlist by one (no-op if the shortlist is empty). */
-  onCycleShortlist?: (nodeId: string) => void;
-  /** Reject the current icon and queue a brand-new AI icon for this ingredient. */
-  onForge?: (node: RecipeNode) => void;
-  /** Node ids with an in-flight forge request (drives the per-row spinner). */
-  forgingIds?: Set<string>;
+  /** Open the icon editor modal (shortlist picker + credit-gated generate). */
+  onEditIcon?: (nodeId: string) => void;
 }
 
 type Draft = { qty: string; unit: string; name: string };
@@ -51,9 +47,7 @@ export function IngredientsSidebar({
   onClose,
   onUpdateServes,
   onEditNode,
-  onCycleShortlist,
-  onForge,
-  forgingIds,
+  onEditIcon,
 }: IngredientsSidebarProps) {
   const serves = graph.serves || graph.baseServes || 1;
   const baseServes = graph.baseServes || 1;
@@ -135,39 +129,26 @@ export function IngredientsSidebar({
             {ingredientNodes.map(node => {
                 const displayQty = node.quantity != null ? Math.round(node.quantity * scale * 100) / 100 : '';
                 const iconUrl = getNodeIconUrl(node);
-                const isForging = forgingIds?.has(node.id) ?? false;
-                const canCycle = getNodeShortlistLength(node) > 0;
                 const label = node.canonicalName || node.text;
 
                 return (
                     <div key={node.id} className="flex items-start gap-3 group">
-                        {/* Left column: icon with the cycle / forge buttons stacked beneath it. */}
+                        {/* Left column: icon with the edit-icon button beneath it. */}
                         <div className="flex flex-col items-center gap-1 shrink-0 w-10">
                             {iconUrl ? (
                                 <img src={iconUrl} className="w-10 h-10 object-contain mix-blend-multiply bg-zinc-50 rounded-lg p-1 border border-zinc-100" alt="" />
                             ) : (
                                 <div className="w-10 h-10 flex items-center justify-center bg-zinc-100 rounded-lg text-xl">🥕</div>
                             )}
-                            {onCycleShortlist && (
+                            {onEditIcon && (
                                 <button
-                                    onClick={() => onCycleShortlist(node.id)}
-                                    disabled={!canCycle}
-                                    className="p-1 rounded hover:bg-zinc-100 text-zinc-400 hover:text-zinc-700 disabled:opacity-30 disabled:cursor-not-allowed"
-                                    title={canCycle ? 'Cycle icon' : 'No other icons yet'}
-                                    aria-label={`Cycle icon for ${label}`}
+                                    onClick={() => onEditIcon(node.id)}
+                                    className="p-1 rounded hover:bg-zinc-100 text-zinc-400 hover:text-zinc-700"
+                                    title="Edit icon"
+                                    aria-label={`Edit icon for ${label}`}
+                                    data-testid="sidebar-edit-icon"
                                 >
-                                    <RefreshCw className="w-3.5 h-3.5" />
-                                </button>
-                            )}
-                            {onForge && (
-                                <button
-                                    onClick={() => onForge(node)}
-                                    disabled={isForging}
-                                    className="p-1 rounded hover:bg-zinc-100 text-zinc-400 hover:text-amber-600 disabled:opacity-40 disabled:cursor-not-allowed"
-                                    title="Forge new icon"
-                                    aria-label={`Forge new icon for ${label}`}
-                                >
-                                    <Hammer className={`w-3.5 h-3.5 ${isForging ? 'animate-pulse' : ''}`} />
+                                    <Pencil className="w-3.5 h-3.5" />
                                 </button>
                             )}
                         </div>

--- a/recipe-lanes/firestore.rules
+++ b/recipe-lanes/firestore.rules
@@ -46,5 +46,10 @@ service cloud.firestore {
     match /feedback/{feedbackId} {
       allow create: if true;
     }
+
+    // Icon credits (user_credits) are Admin-SDK-only, like icon_forge_usage:
+    // no rules block = default deny. Do NOT move balances onto users/{uid} —
+    // that doc is owner-writable, so a balance there would be self-editable.
+    // Reads go through the getIconCreditsAction server action instead.
   }
 }

--- a/recipe-lanes/lib/config.ts
+++ b/recipe-lanes/lib/config.ts
@@ -81,3 +81,16 @@ export function withIconQueueConfigDefaults(raw: any): IconQueueConfig {
 export function dayKey(d: Date = new Date()): string {
   return d.toISOString().slice(0, 10);
 }
+
+// --- Icon credits ---------------------------------------------------------
+// Per-user spendable balance that gates icon generation (forge). Purchasing
+// credits comes later; for now every account receives a free starter grant,
+// applied lazily on first read (see lib/user-credits.ts).
+
+export const DB_COLLECTION_USER_CREDITS = 'user_credits';
+
+/** Credits granted to every account the first time its balance is read. */
+export const STARTER_ICON_CREDITS = 10;
+
+/** Credits one icon generation (forge) costs. */
+export const FORGE_CREDIT_COST = 1;

--- a/recipe-lanes/lib/recipe-lanes/model-utils.ts
+++ b/recipe-lanes/lib/recipe-lanes/model-utils.ts
@@ -149,14 +149,24 @@ export function setNodeIcon(node: RecipeNode, _icon: IconStats) {
  */
 export function assignNodeShortlist(node: RecipeNode, entries: ShortlistEntry[], index?: number): void {
     node.iconShortlist = entries;
-    if (index !== undefined) node.shortlistIndex = index;
+    if (index !== undefined) {
+        node.shortlistIndex = index;
+        // An explicit index means the shortlist CONTENTS changed (search
+        // apply, forge prepend) — the new list has not been fully shown or
+        // cycled, so the seen-everything flags must not leak onto entries the
+        // user never saw. The index-less call (saveRecipe persisting
+        // impression flags back) leaves them alone.
+        node.shortlistCycled = undefined;
+        node.shortlistSeenAll = undefined;
+    }
 }
 
-/** Clears all shortlist state from the node (shortlist, index, and cycled flag). */
+/** Clears all shortlist state from the node (shortlist, index, and seen flags). */
 export function clearNodeShortlist(node: RecipeNode): void {
     node.iconShortlist = undefined;
     node.shortlistIndex = undefined;
     node.shortlistCycled = undefined;
+    node.shortlistSeenAll = undefined;
 }
 
 /**
@@ -177,6 +187,7 @@ export function restoreNodeShortlistFromServer(node: RecipeNode, serverNode: Rec
     node.iconShortlist = serverNode.iconShortlist;
     node.shortlistIndex = serverNode.shortlistIndex;
     node.shortlistCycled = serverNode.shortlistCycled;
+    node.shortlistSeenAll = serverNode.shortlistSeenAll;
 }
 
 /**
@@ -323,10 +334,14 @@ export interface ShortlistDelta {
  * unchanged so their existing flags are preserved — cycling back should not
  * inadvertently clear rejections on icons the user hasn't reached yet.
  */
-function stampShortlistFlags(shortlist: ShortlistEntry[], shortlistIndex: number, shortlistCycled?: boolean): ShortlistEntry[] {
+function stampShortlistFlags(shortlist: ShortlistEntry[], shortlistIndex: number, shortlistCycled?: boolean, shortlistSeenAll?: boolean): ShortlistEntry[] {
     const upTo = shortlistCycled ? shortlist.length : shortlistIndex + 1;
     return shortlist.map((e, i) => {
-        if (i >= upTo) return e; // unseen: preserve as-is
+        if (i >= upTo) {
+            // Not cycled/selected past. Shown all at once in the icon editor
+            // modal → impression only; otherwise unseen: preserve as-is.
+            return shortlistSeenAll && !getEntryHasImpressed(e) ? { ...e, hasImpressed: true } : e;
+        }
         return {
             ...e,
             hasImpressed: true,
@@ -343,7 +358,7 @@ export function computeShortlistDelta(
     const empty: ShortlistDelta = { toImpres: [], toReject: [], toUnreject: [], updatedShortlist: rawShortlist ?? [] };
     if (!rawShortlist || rawShortlist.length === 0) return empty;
 
-    const newShortlist = stampShortlistFlags(rawShortlist, newNode.shortlistIndex ?? 0, newNode.shortlistCycled);
+    const newShortlist = stampShortlistFlags(rawShortlist, newNode.shortlistIndex ?? 0, newNode.shortlistCycled, newNode.shortlistSeenAll);
 
     const ingId = (icon: IconStats) =>
         icon.visualDescription ? standardizeIngredientName(icon.visualDescription) : "WTF";
@@ -477,6 +492,35 @@ export function cycleShortlistNodes(graph: RecipeGraph, nodeId: string): RecipeN
         if (length === 0) return n;
         const next = ((n.shortlistIndex ?? 0) + 1) % length;
         return { ...n, shortlistIndex: next };
+    });
+}
+
+/**
+ * Returns a new nodes array where the node with `nodeId` has its
+ * `shortlistIndex` set to `index` (icon editor modal pick). Out-of-bounds
+ * indices and unchanged picks are no-ops that keep every node reference.
+ */
+export function setShortlistIndexNodes(graph: RecipeGraph, nodeId: string, index: number): RecipeNode[] {
+    return graph.nodes.map(n => {
+        if (n.id !== nodeId) return n;
+        if (!Number.isInteger(index) || index < 0 || index >= getNodeShortlistLength(n)) return n;
+        if ((n.shortlistIndex ?? 0) === index) return n;
+        return { ...n, shortlistIndex: index };
+    });
+}
+
+/**
+ * Returns a new nodes array where the node with `nodeId` is flagged as having
+ * had its whole shortlist shown at once (icon editor modal opened). Save-time
+ * stamping turns this into an impression for every entry — see
+ * stampShortlistFlags. No-op (reference-preserving) when already flagged or
+ * the shortlist is empty.
+ */
+export function markShortlistSeenAllNodes(graph: RecipeGraph, nodeId: string): RecipeNode[] {
+    return graph.nodes.map(n => {
+        if (n.id !== nodeId) return n;
+        if (n.shortlistSeenAll || getNodeShortlistLength(n) === 0) return n;
+        return { ...n, shortlistSeenAll: true };
     });
 }
 

--- a/recipe-lanes/lib/recipe-lanes/node-fields.ts
+++ b/recipe-lanes/lib/recipe-lanes/node-fields.ts
@@ -83,6 +83,7 @@ export const NODE_FIELD_OWNERSHIP = {
     textPos: 'client',
     shortlistIndex: 'client',
     shortlistCycled: 'client',
+    shortlistSeenAll: 'client',
 } as const satisfies Record<keyof RecipeNode, FieldOwnership>;
 
 type NodeFieldOwnershipMap = typeof NODE_FIELD_OWNERSHIP;

--- a/recipe-lanes/lib/recipe-lanes/types.ts
+++ b/recipe-lanes/lib/recipe-lanes/types.ts
@@ -113,6 +113,10 @@ export interface RecipeNode {
   iconShortlist?: ShortlistEntry[];
   shortlistIndex?: number;   // current position in iconShortlist, 0-based
   shortlistCycled?: boolean; // true once the user has wrapped all the way around the shortlist
+  // True once the whole shortlist has been shown at once (icon editor modal).
+  // Save-time stamping records an impression for every entry, but — unlike
+  // shortlistCycled — no rejections for entries beyond the selected index.
+  shortlistSeenAll?: boolean;
   iconQuery?: {
     queryUsed: string;
     method: string;

--- a/recipe-lanes/lib/stores/recipe-store.ts
+++ b/recipe-lanes/lib/stores/recipe-store.ts
@@ -44,7 +44,7 @@
 
 import { create } from 'zustand';
 import { RecipeGraph, RecipeNode, NodeLayout, IconStyleId, LineStyleId, LayoutModeId, BackgroundElementId, CanvasBackgroundId, ChatMessage } from '../recipe-lanes/types';
-import { getNodeShortlistKey, cycleShortlistNodes } from '../recipe-lanes/model-utils';
+import { getNodeShortlistKey, cycleShortlistNodes, setShortlistIndexNodes, markShortlistSeenAllNodes } from '../recipe-lanes/model-utils';
 import { STRUCTURAL_FIELDS, SERVER_FIELDS } from '../recipe-lanes/node-fields';
 
 // ---------------------------------------------------------------------------
@@ -105,6 +105,12 @@ interface RecipeState {
      * to everyone else viewing a shared recipe.
      */
     completedNodeIds: string[];
+    /**
+     * Node ID whose icon editor modal is open, or null. Local UI state only —
+     * lives here (not in page state) because the open buttons sit on deeply
+     * nested node components while the modal renders at page level.
+     */
+    iconEditorNodeId: string | null;
 }
 
 interface RecipeActions {
@@ -134,6 +140,24 @@ interface RecipeActions {
      * All other nodes keep their existing object reference.
      */
     cycleShortlist: (nodeId: string) => void;
+
+    /**
+     * Sets shortlistIndex on the named node to a specific position (icon
+     * editor pick). Same locality/no-dirty semantics as cycleShortlist:
+     * no undo entry, no autosave — impressions flow to Firestore with the
+     * next save, exactly like cycling.
+     */
+    setShortlistIndex: (nodeId: string, index: number) => void;
+
+    /**
+     * Opens the icon editor modal for a node. Showing the whole shortlist at
+     * once counts as an impression for every entry, so this also stamps
+     * shortlistSeenAll on the node (recorded server-side at next save).
+     */
+    openIconEditor: (nodeId: string) => void;
+
+    /** Closes the icon editor modal. */
+    closeIconEditor: () => void;
 
     /**
      * Applies a local graph mutation (serves scaling, JSON edit, etc.).
@@ -368,6 +392,12 @@ function mergeNode(existing: RecipeNode, incoming: RecipeNode): RecipeNode {
     merged.shortlistIndex = shortlistChanged
         ? (incoming.shortlistIndex ?? 0)
         : existing.shortlistIndex;
+    // - shortlistSeenAll: same rule — a regenerated shortlist (forge/search)
+    //   has NOT been fully shown, so adopt the incoming value (the server
+    //   clears it on reassignment); otherwise keep the local flag.
+    merged.shortlistSeenAll = shortlistChanged
+        ? incoming.shortlistSeenAll
+        : existing.shortlistSeenAll;
     // shortlistCycled is client-owned and intentionally left as-is (already
     // copied from existing above) — resetting it is out of scope for #220.
 
@@ -520,6 +550,7 @@ const initialState: RecipeState = {
     messages: [],
     pendingDeletedIds: [],
     completedNodeIds: [],
+    iconEditorNodeId: null,
 };
 
 export const useRecipeStore = create<RecipeState & RecipeActions>((set, get) => ({
@@ -685,6 +716,34 @@ export const useRecipeStore = create<RecipeState & RecipeActions>((set, get) => 
 
         set({ graph: { ...state.graph, nodes } });
     },
+
+    setShortlistIndex: (nodeId, index) => {
+        const state = get();
+        if (!state.graph) return;
+
+        const nodes = setShortlistIndexNodes(state.graph, nodeId, index);
+        if (nodes.every((n, i) => n === state.graph!.nodes[i])) return;
+
+        set({ graph: { ...state.graph, nodes } });
+    },
+
+    openIconEditor: (nodeId) => {
+        const state = get();
+        // Opening shows every shortlist entry at once — flag the node so the
+        // next save records an impression for each entry (stampShortlistFlags).
+        if (state.graph) {
+            const nodes = markShortlistSeenAllNodes(state.graph, nodeId);
+            const changed = nodes.some((n, i) => n !== state.graph!.nodes[i]);
+            set({
+                iconEditorNodeId: nodeId,
+                ...(changed && { graph: { ...state.graph, nodes } }),
+            });
+            return;
+        }
+        set({ iconEditorNodeId: nodeId });
+    },
+
+    closeIconEditor: () => set({ iconEditorNodeId: null }),
 
     addMessage: ({ role, content }) => set((state) => ({
         messages: [...state.messages, {

--- a/recipe-lanes/lib/user-credits.ts
+++ b/recipe-lanes/lib/user-credits.ts
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Per-user icon-credit balances (`user_credits/{uid}`), Admin-SDK-only.
+//
+// The balance deliberately does NOT live on `users/{uid}`: firestore.rules
+// gives a signed-in user full write access to their own user doc, so any
+// balance stored there would be trivially self-editable. `user_credits` has
+// no rules block (default deny), matching the `icon_forge_usage` precedent.
+//
+// There is no purchase flow yet. Every account is seeded with
+// STARTER_ICON_CREDITS the first time its balance is touched, inside the
+// same transaction that reads it — no backfill needed.
+//
+// Injectable service (setUserCreditsService) following the
+// data-service/auth-service pattern, so the emulator-free pure test tier can
+// exercise forgeIconAction against MemoryUserCreditsService.
+
+import { FieldValue } from 'firebase-admin/firestore';
+import { db } from './firebase-admin';
+import { DB_COLLECTION_USER_CREDITS, STARTER_ICON_CREDITS } from './config';
+
+export interface UserCredits {
+    /** Spendable balance. */
+    balance: number;
+    /** Lifetime credits granted (starter grant + future purchases/awards). */
+    granted: number;
+    /** Lifetime credits spent. */
+    spent: number;
+}
+
+export interface SpendResult {
+    ok: boolean;
+    /** Balance after the spend (or the unchanged balance when ok is false). */
+    balance: number;
+}
+
+export interface UserCreditsService {
+    /** Reads the balance, seeding the starter grant on first touch. */
+    getCredits(uid: string): Promise<UserCredits>;
+    /**
+     * Atomically spends `cost` credits (starter grant seeded first for a
+     * brand-new account). ok=false leaves the balance untouched.
+     */
+    spend(uid: string, cost: number): Promise<SpendResult>;
+    /**
+     * Returns `cost` credits, e.g. when a spend succeeded but the forge it
+     * paid for failed to enqueue. Best-effort compensation — callers should
+     * log (not throw) on failure.
+     */
+    refund(uid: string, cost: number): Promise<void>;
+}
+
+function assertValidCost(op: string, cost: number): void {
+    if (!Number.isInteger(cost) || cost <= 0) {
+        throw new Error(`${op}: invalid cost ${cost}`);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Firestore implementation (production)
+// ---------------------------------------------------------------------------
+
+function toUserCredits(raw: FirebaseFirestore.DocumentData | undefined): UserCredits {
+    return {
+        balance: typeof raw?.balance === 'number' ? raw.balance : 0,
+        granted: typeof raw?.granted === 'number' ? raw.granted : 0,
+        spent: typeof raw?.spent === 'number' ? raw.spent : 0,
+    };
+}
+
+function starterDoc(uid: string) {
+    return {
+        uid,
+        balance: STARTER_ICON_CREDITS,
+        granted: STARTER_ICON_CREDITS,
+        spent: 0,
+        created_at: FieldValue.serverTimestamp(),
+        updated_at: FieldValue.serverTimestamp(),
+    };
+}
+
+export class FirestoreUserCreditsService implements UserCreditsService {
+    private ref(uid: string) {
+        return db.collection(DB_COLLECTION_USER_CREDITS).doc(uid);
+    }
+
+    async getCredits(uid: string): Promise<UserCredits> {
+        return db.runTransaction(async (t) => {
+            const ref = this.ref(uid);
+            const snap = await t.get(ref);
+            if (!snap.exists) {
+                t.set(ref, starterDoc(uid));
+                return { balance: STARTER_ICON_CREDITS, granted: STARTER_ICON_CREDITS, spent: 0 };
+            }
+            return toUserCredits(snap.data());
+        });
+    }
+
+    async spend(uid: string, cost: number): Promise<SpendResult> {
+        assertValidCost('spend', cost);
+        return db.runTransaction(async (t) => {
+            const ref = this.ref(uid);
+            const snap = await t.get(ref);
+            const current = snap.exists ? toUserCredits(snap.data()) : toUserCredits(starterDoc(uid));
+            if (current.balance < cost) {
+                // Still persist the starter grant for a first-touch account.
+                if (!snap.exists) t.set(ref, starterDoc(uid));
+                return { ok: false, balance: current.balance };
+            }
+            if (snap.exists) {
+                t.update(ref, {
+                    balance: FieldValue.increment(-cost),
+                    spent: FieldValue.increment(cost),
+                    updated_at: FieldValue.serverTimestamp(),
+                });
+            } else {
+                t.set(ref, {
+                    ...starterDoc(uid),
+                    balance: STARTER_ICON_CREDITS - cost,
+                    spent: cost,
+                });
+            }
+            return { ok: true, balance: current.balance - cost };
+        });
+    }
+
+    async refund(uid: string, cost: number): Promise<void> {
+        assertValidCost('refund', cost);
+        await this.ref(uid).set(
+            {
+                uid,
+                balance: FieldValue.increment(cost),
+                spent: FieldValue.increment(-cost),
+                updated_at: FieldValue.serverTimestamp(),
+            },
+            { merge: true },
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory implementation (pure test tier)
+// ---------------------------------------------------------------------------
+
+export class MemoryUserCreditsService implements UserCreditsService {
+    private accounts = new Map<string, UserCredits>();
+
+    private account(uid: string): UserCredits {
+        let acc = this.accounts.get(uid);
+        if (!acc) {
+            acc = { balance: STARTER_ICON_CREDITS, granted: STARTER_ICON_CREDITS, spent: 0 };
+            this.accounts.set(uid, acc);
+        }
+        return acc;
+    }
+
+    async getCredits(uid: string): Promise<UserCredits> {
+        return { ...this.account(uid) };
+    }
+
+    async spend(uid: string, cost: number): Promise<SpendResult> {
+        assertValidCost('spend', cost);
+        const acc = this.account(uid);
+        if (acc.balance < cost) return { ok: false, balance: acc.balance };
+        acc.balance -= cost;
+        acc.spent += cost;
+        return { ok: true, balance: acc.balance };
+    }
+
+    async refund(uid: string, cost: number): Promise<void> {
+        assertValidCost('refund', cost);
+        const acc = this.account(uid);
+        acc.balance += cost;
+        acc.spent -= cost;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton / factory (mirrors data-service / auth-service)
+// ---------------------------------------------------------------------------
+
+let currentService: UserCreditsService | null = null;
+
+export function getUserCreditsService(): UserCreditsService {
+    if (!currentService) currentService = new FirestoreUserCreditsService();
+    return currentService;
+}
+
+export function setUserCreditsService(service: UserCreditsService): void {
+    currentService = service;
+}
+
+// Thin function wrappers kept for call-site brevity.
+
+export async function getUserCredits(uid: string): Promise<UserCredits> {
+    return getUserCreditsService().getCredits(uid);
+}
+
+export async function spendIconCredits(uid: string, cost: number): Promise<SpendResult> {
+    return getUserCreditsService().spend(uid, cost);
+}
+
+export async function refundIconCredits(uid: string, cost: number): Promise<void> {
+    return getUserCreditsService().refund(uid, cost);
+}

--- a/recipe-lanes/scripts/unit-test-manifest.mjs
+++ b/recipe-lanes/scripts/unit-test-manifest.mjs
@@ -52,6 +52,7 @@ export const INTEGRATION_TESTS = [
   'icon-queue-config.test.ts',
   'impression-rejection.test.ts',
   'save-reconciliation.test.ts',
+  'user-credits.test.ts',
 ];
 
 // tests/ lives one level up from scripts/. Resolve relative to THIS file so the

--- a/recipe-lanes/tests/icon-pipeline.test.ts
+++ b/recipe-lanes/tests/icon-pipeline.test.ts
@@ -12,6 +12,7 @@ import { memoryStore } from '../lib/store';
 import { setAIService } from '../lib/ai-service';
 import { MockAIService } from '../lib/ai-service.mock';
 import { setAuthService, MockAuthService } from '../lib/auth-service';
+import { setUserCreditsService, MemoryUserCreditsService } from '../lib/user-credits';
 import { buildShortlistEntry, getNodeIconUrl, getNodeIconId } from '../lib/recipe-lanes/model-utils';
 import type { IconStats, ShortlistEntry } from '../lib/recipe-lanes/types';
 
@@ -220,6 +221,8 @@ describe('forgeIconAction vs rejectIcon — searchFn wiring', () => {
         setDataService(spyService);
         setAIService(new MockAIService());
         setAuthService(new MockAuthService());
+        // forgeIconAction spends icon credits; keep the pure tier off Firestore.
+        setUserCreditsService(new MemoryUserCreditsService());
     });
 
     it('forgeIconAction calls rejectRecipeIcon WITHOUT searchFn', async () => {

--- a/recipe-lanes/tests/lifecycle.test.ts
+++ b/recipe-lanes/tests/lifecycle.test.ts
@@ -32,6 +32,7 @@ import { MockAIService } from '../lib/ai-service.mock';
 import { getDataService, setDataService, MemoryDataService } from '../lib/data-service';
 import { memoryStore } from '../lib/store';
 import { setAuthService, MockAuthService } from '../lib/auth-service';
+import { setUserCreditsService, MemoryUserCreditsService } from '../lib/user-credits';
 import { getNodeIconId } from '../lib/recipe-lanes/model-utils';
 
 /** Read the current icon id on a recipe node (synchronous — MemoryDataService resolves inline). */
@@ -47,6 +48,8 @@ describe('Recipe & Icon Lifecycle', () => {
         setDataService(new MemoryDataService());
         setAIService(new MockAIService());
         setAuthService(new MockAuthService());
+        // forgeIconAction spends icon credits; keep the pure tier off Firestore.
+        setUserCreditsService(new MemoryUserCreditsService());
     });
 
     it('should follow the full creation and icon-resolution flow', async () => {

--- a/recipe-lanes/tests/node-fields.test.ts
+++ b/recipe-lanes/tests/node-fields.test.ts
@@ -28,7 +28,7 @@ describe('node-fields ownership map (issue #220)', () => {
     it('classifies exactly the expected CLIENT fields', () => {
         assert.deepEqual(
             [...CLIENT_FIELDS].sort(),
-            ['rotation', 'shortlistCycled', 'shortlistIndex', 'textPos', 'x', 'y'].sort(),
+            ['rotation', 'shortlistCycled', 'shortlistIndex', 'shortlistSeenAll', 'textPos', 'x', 'y'].sort(),
         );
     });
 

--- a/recipe-lanes/tests/recipe-store-icon-editor.test.ts
+++ b/recipe-lanes/tests/recipe-store-icon-editor.test.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Icon editor modal state + shortlist selection in the store. Same
+// load-bearing guarantees as cycleShortlist: no dirty flag, no undo entry,
+// per-node reference preservation, and client-owned fields surviving
+// mergeSnapshot.
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { useRecipeStore } from '../lib/stores/recipe-store';
+import { buildShortlistEntry } from '../lib/recipe-lanes/model-utils';
+import { RecipeGraph, RecipeNode, ShortlistEntry } from '../lib/recipe-lanes/types';
+
+function makeEntries(n: number): ShortlistEntry[] {
+    return Array.from({ length: n }, (_, i) =>
+        buildShortlistEntry({ id: `icon-${i}`, visualDescription: 'Carrot' }, 'generated'),
+    );
+}
+
+function makeNode(id: string, overrides: Partial<RecipeNode> = {}): RecipeNode {
+    return {
+        id,
+        laneId: 'lane-1',
+        text: `Node ${id}`,
+        visualDescription: `visual-${id}`,
+        type: 'ingredient',
+        ...overrides,
+    };
+}
+
+function makeGraph(nodes: RecipeNode[]): RecipeGraph {
+    return { lanes: [], nodes };
+}
+
+function seedGraph(nodes: RecipeNode[]) {
+    useRecipeStore.getState().mergeSnapshot(makeGraph(nodes));
+    useRecipeStore.getState().setDirty(false);
+}
+
+const state = () => useRecipeStore.getState();
+
+describe('useRecipeStore — icon editor', () => {
+    beforeEach(() => state().reset());
+
+    describe('openIconEditor / closeIconEditor', () => {
+        it('tracks the open node id and clears it on close', () => {
+            seedGraph([makeNode('n1', { iconShortlist: makeEntries(2) })]);
+            state().openIconEditor('n1');
+            assert.equal(state().iconEditorNodeId, 'n1');
+            state().closeIconEditor();
+            assert.equal(state().iconEditorNodeId, null);
+        });
+
+        it('stamps shortlistSeenAll on the opened node without dirty or undo', () => {
+            const other = makeNode('n2');
+            seedGraph([makeNode('n1', { iconShortlist: makeEntries(3) }), other]);
+            const before = state().graph!;
+
+            state().openIconEditor('n1');
+
+            const node = state().graph!.nodes.find(n => n.id === 'n1')!;
+            assert.equal(node.shortlistSeenAll, true);
+            assert.equal(state().isDirty, false, 'opening the editor must not dirty the recipe');
+            assert.equal(state().undoPast.length, 0, 'opening the editor must not push undo history');
+            // Other node keeps its reference so its selector does not re-render.
+            assert.equal(state().graph!.nodes.find(n => n.id === 'n2'), before.nodes.find(n => n.id === 'n2'));
+        });
+
+        it('opens even for a node without a shortlist (no seenAll stamp)', () => {
+            seedGraph([makeNode('n1')]);
+            const before = state().graph!;
+
+            state().openIconEditor('n1');
+
+            assert.equal(state().iconEditorNodeId, 'n1');
+            assert.equal(state().graph, before, 'graph must be untouched when there is nothing to stamp');
+        });
+
+        it('reset() clears the open editor', () => {
+            seedGraph([makeNode('n1', { iconShortlist: makeEntries(2) })]);
+            state().openIconEditor('n1');
+            state().reset();
+            assert.equal(state().iconEditorNodeId, null);
+        });
+    });
+
+    describe('setShortlistIndex', () => {
+        it('sets the picked index without dirty or undo', () => {
+            seedGraph([makeNode('n1', { iconShortlist: makeEntries(4), shortlistIndex: 0 })]);
+
+            state().setShortlistIndex('n1', 2);
+
+            assert.equal(state().graph!.nodes[0].shortlistIndex, 2);
+            assert.equal(state().isDirty, false);
+            assert.equal(state().undoPast.length, 0);
+        });
+
+        it('ignores out-of-bounds picks and keeps the graph reference', () => {
+            seedGraph([makeNode('n1', { iconShortlist: makeEntries(2), shortlistIndex: 1 })]);
+            const before = state().graph;
+
+            state().setShortlistIndex('n1', 5);
+
+            assert.equal(state().graph, before);
+            assert.equal(state().graph!.nodes[0].shortlistIndex, 1);
+        });
+    });
+
+    describe('mergeSnapshot interplay', () => {
+        it('preserves shortlistSeenAll and the picked index when the shortlist is unchanged', () => {
+            seedGraph([makeNode('n1', { iconShortlist: makeEntries(3), shortlistIndex: 0 })]);
+            state().openIconEditor('n1');
+            state().setShortlistIndex('n1', 2);
+
+            // Background snapshot with the same shortlist but a server-side
+            // status change (forces the merge path, not the fast path).
+            state().mergeSnapshot(makeGraph([
+                makeNode('n1', { iconShortlist: makeEntries(3), shortlistIndex: 0, status: 'failed' }),
+            ]));
+
+            const node = state().graph!.nodes[0];
+            assert.equal(node.shortlistSeenAll, true, 'client-owned seenAll must survive the snapshot');
+            assert.equal(node.shortlistIndex, 2, 'locally picked index must survive the snapshot');
+            assert.equal(node.status, 'failed', 'server field must still merge');
+        });
+
+        it('resets shortlistSeenAll when the incoming shortlist was regenerated', () => {
+            seedGraph([makeNode('n1', { iconShortlist: makeEntries(3), shortlistIndex: 0 })]);
+            state().openIconEditor('n1');
+
+            // Forge result: different shortlist contents, server cleared the flag.
+            const forged = [
+                buildShortlistEntry({ id: 'icon-new', visualDescription: 'Carrot' }, 'generated'),
+                ...makeEntries(3),
+            ];
+            state().mergeSnapshot(makeGraph([
+                makeNode('n1', { iconShortlist: forged, shortlistIndex: 0 }),
+            ]));
+
+            const node = state().graph!.nodes[0];
+            assert.equal(node.shortlistSeenAll, undefined, 'stale seenAll must not leak onto a new shortlist');
+            assert.equal(node.shortlistIndex, 0);
+        });
+    });
+});

--- a/recipe-lanes/tests/shortlist-seen-all.test.ts
+++ b/recipe-lanes/tests/shortlist-seen-all.test.ts
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// shortlistSeenAll (icon editor modal): opening the modal shows the WHOLE
+// shortlist at once, which must count as an impression for every entry —
+// but, unlike shortlistCycled, must NOT count as a rejection for entries
+// beyond the selected index.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    computeShortlistDelta,
+    buildShortlistEntry,
+    setShortlistIndexNodes,
+    markShortlistSeenAllNodes,
+    assignNodeShortlist,
+    getEntryHasImpressed,
+    getEntryHasRejected,
+} from '../lib/recipe-lanes/model-utils';
+import { RecipeGraph, RecipeNode, ShortlistEntry } from '../lib/recipe-lanes/types';
+
+function makeEntries(n: number): ShortlistEntry[] {
+    return Array.from({ length: n }, (_, i) =>
+        buildShortlistEntry({ id: `icon-${i}`, visualDescription: `Carrot` }, 'generated'),
+    );
+}
+
+function makeNode(overrides: Partial<RecipeNode> = {}): RecipeNode {
+    return {
+        id: 'n1',
+        laneId: 'lane-1',
+        text: '2 Carrots',
+        visualDescription: 'Carrot',
+        type: 'ingredient',
+        ...overrides,
+    };
+}
+
+function makeGraph(nodes: RecipeNode[]): RecipeGraph {
+    return { lanes: [], nodes };
+}
+
+describe('computeShortlistDelta with shortlistSeenAll', () => {
+    it('records an impression for every entry, rejections only up to the selected index', () => {
+        const oldNode = makeNode({ iconShortlist: makeEntries(4), shortlistIndex: 0 });
+        const newNode = makeNode({
+            iconShortlist: makeEntries(4),
+            shortlistIndex: 1,
+            shortlistSeenAll: true,
+        });
+
+        const delta = computeShortlistDelta(oldNode, newNode);
+
+        // All four entries were shown in the modal → all impressed.
+        assert.deepEqual(delta.toImpres.map(d => d.id).sort(), ['icon-0', 'icon-1', 'icon-2', 'icon-3']);
+        // Only icon-0 was passed over for the selection at index 1; icons 2-3
+        // were merely shown, never rejected.
+        assert.deepEqual(delta.toReject.map(d => d.id), ['icon-0']);
+        assert.deepEqual(delta.toUnreject, []);
+
+        // The updated shortlist carries the flags for the next diff.
+        assert.ok(delta.updatedShortlist.every(e => getEntryHasImpressed(e)));
+        assert.equal(getEntryHasRejected(delta.updatedShortlist[2]), false);
+        assert.equal(getEntryHasRejected(delta.updatedShortlist[3]), false);
+    });
+
+    it('with selection kept at index 0, impresses the rest without any rejections', () => {
+        const oldNode = makeNode({ iconShortlist: makeEntries(3), shortlistIndex: 0 });
+        const newNode = makeNode({
+            iconShortlist: makeEntries(3),
+            shortlistIndex: 0,
+            shortlistSeenAll: true,
+        });
+
+        const delta = computeShortlistDelta(oldNode, newNode);
+
+        assert.deepEqual(delta.toImpres.map(d => d.id).sort(), ['icon-0', 'icon-1', 'icon-2']);
+        assert.deepEqual(delta.toReject, []);
+    });
+
+    it('is idempotent: a second save after flags landed produces an empty delta', () => {
+        const first = computeShortlistDelta(
+            makeNode({ iconShortlist: makeEntries(3), shortlistIndex: 0 }),
+            makeNode({ iconShortlist: makeEntries(3), shortlistIndex: 0, shortlistSeenAll: true }),
+        );
+
+        const savedNode = makeNode({
+            iconShortlist: first.updatedShortlist,
+            shortlistIndex: 0,
+            shortlistSeenAll: true,
+        });
+        const second = computeShortlistDelta(savedNode, savedNode);
+
+        assert.deepEqual(second.toImpres, []);
+        assert.deepEqual(second.toReject, []);
+        assert.deepEqual(second.toUnreject, []);
+    });
+
+    it('does not disturb shortlistCycled semantics (cycled still rejects all non-selected)', () => {
+        const oldNode = makeNode({ iconShortlist: makeEntries(3), shortlistIndex: 0 });
+        const newNode = makeNode({
+            iconShortlist: makeEntries(3),
+            shortlistIndex: 1,
+            shortlistCycled: true,
+        });
+
+        const delta = computeShortlistDelta(oldNode, newNode);
+
+        assert.deepEqual(delta.toImpres.map(d => d.id).sort(), ['icon-0', 'icon-1', 'icon-2']);
+        assert.deepEqual(delta.toReject.map(d => d.id).sort(), ['icon-0', 'icon-2']);
+    });
+});
+
+describe('setShortlistIndexNodes', () => {
+    it('sets the index on the target node only, preserving other node references', () => {
+        const other = makeNode({ id: 'n2' });
+        const target = makeNode({ iconShortlist: makeEntries(3), shortlistIndex: 0 });
+        const graph = makeGraph([target, other]);
+
+        const nodes = setShortlistIndexNodes(graph, 'n1', 2);
+
+        assert.equal(nodes[0].shortlistIndex, 2);
+        assert.notEqual(nodes[0], target);
+        assert.equal(nodes[1], other);
+    });
+
+    it('ignores out-of-bounds and non-integer indices', () => {
+        const target = makeNode({ iconShortlist: makeEntries(3), shortlistIndex: 1 });
+        const graph = makeGraph([target]);
+
+        for (const bad of [-1, 3, 99, 1.5, NaN]) {
+            const nodes = setShortlistIndexNodes(graph, 'n1', bad);
+            assert.equal(nodes[0], target, `index ${bad} must be a no-op`);
+        }
+    });
+
+    it('is a reference-preserving no-op when the index is unchanged', () => {
+        const target = makeNode({ iconShortlist: makeEntries(3), shortlistIndex: 1 });
+        const graph = makeGraph([target]);
+
+        const nodes = setShortlistIndexNodes(graph, 'n1', 1);
+        assert.equal(nodes[0], target);
+    });
+});
+
+describe('assignNodeShortlist clears stale seen flags', () => {
+    it('an indexed (re)assignment resets shortlistSeenAll and shortlistCycled', () => {
+        const node = makeNode({
+            iconShortlist: makeEntries(3),
+            shortlistIndex: 1,
+            shortlistSeenAll: true,
+            shortlistCycled: true,
+        });
+
+        // Forge/search replace the shortlist with an explicit index — the new
+        // list has not been shown, so the seen-everything flags must clear.
+        assignNodeShortlist(node, makeEntries(4), 0);
+
+        assert.equal(node.shortlistSeenAll, undefined);
+        assert.equal(node.shortlistCycled, undefined);
+        assert.equal(node.shortlistIndex, 0);
+    });
+
+    it('the index-less flag-persistence call leaves the seen flags alone', () => {
+        const node = makeNode({
+            iconShortlist: makeEntries(3),
+            shortlistIndex: 1,
+            shortlistSeenAll: true,
+        });
+
+        assignNodeShortlist(node, makeEntries(3));
+
+        assert.equal(node.shortlistSeenAll, true);
+        assert.equal(node.shortlistIndex, 1);
+    });
+});
+
+describe('markShortlistSeenAllNodes', () => {
+    it('flags the target node', () => {
+        const target = makeNode({ iconShortlist: makeEntries(2) });
+        const nodes = markShortlistSeenAllNodes(makeGraph([target]), 'n1');
+        assert.equal(nodes[0].shortlistSeenAll, true);
+    });
+
+    it('is a no-op for a node without a shortlist or already flagged', () => {
+        const bare = makeNode({ id: 'n1' });
+        assert.equal(markShortlistSeenAllNodes(makeGraph([bare]), 'n1')[0], bare);
+
+        const flagged = makeNode({ iconShortlist: makeEntries(2), shortlistSeenAll: true });
+        assert.equal(markShortlistSeenAllNodes(makeGraph([flagged]), 'n1')[0], flagged);
+    });
+});

--- a/recipe-lanes/tests/user-credits.test.ts
+++ b/recipe-lanes/tests/user-credits.test.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Icon credits: starter grant, atomic spend/refund, and the credit gate on
+// forgeIconAction. Emulator-backed (writes user_credits via firebase-admin).
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { getUserCredits, spendIconCredits, refundIconCredits } from '../lib/user-credits';
+import { forgeIconAction, getIconCreditsAction } from '../app/actions';
+import { setAuthService, AuthSession } from '../lib/auth-service';
+import { setDataService, MemoryDataService } from '../lib/data-service';
+import { db } from '../lib/firebase-admin';
+import {
+    DB_COLLECTION_USER_CREDITS,
+    DB_COLLECTION_CONFIG,
+    ICON_QUEUE_CONFIG_DOC,
+    STARTER_ICON_CREDITS,
+} from '../lib/config';
+
+class MockAuth {
+    constructor(private user: AuthSession | null) {}
+    async verifyAuth() { return this.user; }
+}
+
+// Records forge calls without touching Firestore recipes.
+class SpyDataService extends MemoryDataService {
+    forgeCalls = 0;
+    forgeResult: { success: boolean; error?: string } = { success: true };
+    async rejectRecipeIcon(): Promise<{ success: boolean; error?: string }> {
+        this.forgeCalls++;
+        return this.forgeResult;
+    }
+}
+
+const uid = () => `credits-user-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+const creditsRef = (u: string) => db.collection(DB_COLLECTION_USER_CREDITS).doc(u);
+
+describe('user-credits — balance accounting', () => {
+    it('seeds the starter grant on first read', async () => {
+        const u = uid();
+        const credits = await getUserCredits(u);
+        assert.strictEqual(credits.balance, STARTER_ICON_CREDITS);
+        assert.strictEqual(credits.granted, STARTER_ICON_CREDITS);
+        assert.strictEqual(credits.spent, 0);
+
+        // The grant is persisted, not just returned.
+        const doc = await creditsRef(u).get();
+        assert.strictEqual(doc.data()?.balance, STARTER_ICON_CREDITS);
+    });
+
+    it('does not double-grant on a second read', async () => {
+        const u = uid();
+        await getUserCredits(u);
+        const again = await getUserCredits(u);
+        assert.strictEqual(again.balance, STARTER_ICON_CREDITS);
+        assert.strictEqual(again.granted, STARTER_ICON_CREDITS);
+    });
+
+    it('spends atomically and refuses an insufficient balance', async () => {
+        const u = uid();
+        const first = await spendIconCredits(u, 1);
+        assert.deepStrictEqual(first, { ok: true, balance: STARTER_ICON_CREDITS - 1 });
+
+        const drain = await spendIconCredits(u, STARTER_ICON_CREDITS - 1);
+        assert.strictEqual(drain.ok, true);
+        assert.strictEqual(drain.balance, 0);
+
+        const broke = await spendIconCredits(u, 1);
+        assert.deepStrictEqual(broke, { ok: false, balance: 0 });
+
+        const credits = await getUserCredits(u);
+        assert.strictEqual(credits.balance, 0);
+        assert.strictEqual(credits.spent, STARTER_ICON_CREDITS);
+    });
+
+    it('refund restores the balance and lifetime counters', async () => {
+        const u = uid();
+        await spendIconCredits(u, 2);
+        await refundIconCredits(u, 1);
+        const credits = await getUserCredits(u);
+        assert.strictEqual(credits.balance, STARTER_ICON_CREDITS - 1);
+        assert.strictEqual(credits.spent, 1);
+    });
+
+    it('rejects nonsensical costs', async () => {
+        const u = uid();
+        await assert.rejects(() => spendIconCredits(u, 0));
+        await assert.rejects(() => spendIconCredits(u, -1));
+        await assert.rejects(() => refundIconCredits(u, 1.5));
+    });
+});
+
+describe('forgeIconAction — credit gate', () => {
+    let spy: SpyDataService;
+
+    beforeEach(async () => {
+        await db.collection(DB_COLLECTION_CONFIG).doc(ICON_QUEUE_CONFIG_DOC).delete().catch(() => {});
+        spy = new SpyDataService();
+        setDataService(spy);
+    });
+
+    afterEach(async () => {
+        await db.collection(DB_COLLECTION_CONFIG).doc(ICON_QUEUE_CONFIG_DOC).delete().catch(() => {});
+    });
+
+    it('rejects anonymous callers before touching the queue', async () => {
+        setAuthService(new MockAuth(null));
+        const res = await forgeIconAction('r1', 'Carrot');
+        assert.strictEqual(res.success, false);
+        assert.match(res.error || '', /sign in/i);
+        assert.strictEqual(spy.forgeCalls, 0);
+    });
+
+    it('spends one credit on a successful forge and reports the remainder', async () => {
+        const u = uid();
+        setAuthService(new MockAuth({ uid: u, isAdmin: false }));
+
+        const res = await forgeIconAction('r1', 'Carrot');
+        assert.strictEqual(res.success, true);
+        assert.strictEqual(res.creditsRemaining, STARTER_ICON_CREDITS - 1);
+        assert.strictEqual(spy.forgeCalls, 1);
+
+        const credits = await getUserCredits(u);
+        assert.strictEqual(credits.balance, STARTER_ICON_CREDITS - 1);
+    });
+
+    it('blocks a user with an empty balance without forging', async () => {
+        const u = uid();
+        setAuthService(new MockAuth({ uid: u, isAdmin: false }));
+        await spendIconCredits(u, STARTER_ICON_CREDITS);
+
+        const res = await forgeIconAction('r1', 'Carrot');
+        assert.strictEqual(res.success, false);
+        assert.match(res.error || '', /out of icon credits/i);
+        assert.strictEqual(res.creditsRemaining, 0);
+        assert.strictEqual(spy.forgeCalls, 0);
+    });
+
+    it('refunds the credit when the forge fails to enqueue', async () => {
+        const u = uid();
+        setAuthService(new MockAuth({ uid: u, isAdmin: false }));
+        spy.forgeResult = { success: false, error: 'Recipe not found' };
+
+        const res = await forgeIconAction('r1', 'Carrot');
+        assert.strictEqual(res.success, false);
+        assert.strictEqual(res.creditsRemaining, STARTER_ICON_CREDITS);
+
+        const credits = await getUserCredits(u);
+        assert.strictEqual(credits.balance, STARTER_ICON_CREDITS, 'failed forge must not burn a credit');
+        assert.strictEqual(credits.spent, 0);
+    });
+
+    it('getIconCreditsAction reports the live balance for the signed-in user', async () => {
+        const u = uid();
+        setAuthService(new MockAuth({ uid: u, isAdmin: false }));
+
+        assert.deepStrictEqual(await getIconCreditsAction(), { signedIn: true, balance: STARTER_ICON_CREDITS });
+
+        await forgeIconAction('r1', 'Carrot');
+        assert.deepStrictEqual(await getIconCreditsAction(), { signedIn: true, balance: STARTER_ICON_CREDITS - 1 });
+
+        setAuthService(new MockAuth(null));
+        assert.deepStrictEqual(await getIconCreditsAction(), { signedIn: false, balance: 0 });
+    });
+});


### PR DESCRIPTION
First slice of the "users pay for icon generation" direction (`recipe-lanes/docs/icon-shortlist-plan.md` — "Forge is the credit-gated upsell"). No payment flow yet: every account gets a free starter grant.

## Icon credits

- New **Admin-SDK-only** collection `user_credits/{uid}` (`lib/user-credits.ts`): `balance` / `granted` / `spent`, with a lazy **starter grant of 10 credits** seeded transactionally on first touch — no backfill needed. Injectable service (`setUserCreditsService`) with Firestore + memory implementations, following the data-service/auth-service pattern so the emulator-free pure test tier still exercises `forgeIconAction`.
- **Why not `users/{uid}`:** firestore.rules gives users full write access to their own user doc — a balance there would be self-editable. `user_credits` has no rules block (default deny), matching the `icon_forge_usage` precedent; a comment in `firestore.rules` documents this.
- `forgeIconAction` now **requires sign-in** and **spends 1 credit** (transactional spend; refund if the enqueue fails; `creditsRemaining` returned to the UI). The per-user daily cap stays as an abuse backstop. `getIconCreditsAction` reports the live balance.
- Behavior change to flag: **anonymous users can no longer forge node icons** regardless of `allowAnonForge` (credits need an account). `allowAnonForge` still governs the recipe-creation generation gates (`addIngredientNodeAction`, `createVisualRecipeAction`, `saveRecipeAction`) — those flows stay un-credited for now.

## Icon editor modal (replaces cycle + forge buttons)

- One pencil **"Edit icon"** button replaces the `RefreshCw` cycle + `Hammer` forge pair on: ReactFlow nodes (classic + all modern variants), timeline RF nodes, the SVG timeline controls, and the ingredients sidebar.
- It opens `components/icon-shortlist-modal.tsx`: the node's whole shortlist as a grid (click an icon to make it current — new store action `setShortlistIndex`), plus a credit-gated **"Generate a new icon (1 credit)"** button showing the live balance, or a sign-in prompt advertising the free credits.
- Modal open-state (`iconEditorNodeId`) lives in the Zustand store since the openers sit deep inside ReactFlow while the modal renders at page level; `reset()` clears it.

## Impression semantics

- Opening the modal shows every shortlist entry at once, so it counts as an **impression for every entry** — but **not** a rejection (unlike cycling past). New client-owned node flag `shortlistSeenAll` (registered in the #220 field-ownership map): `stampShortlistFlags` stamps `hasImpressed` on all entries when set, while rejections keep the existing selected-index contiguity rules. `shortlistCycled` semantics are untouched.
- Staleness guard: `assignNodeShortlist` with an explicit index (forge prepend / search replace) clears `shortlistSeenAll`/`shortlistCycled`, and `mergeSnapshot` resets `seenAll` when the shortlist contents change — a regenerated shortlist has not been "seen".
- Per `STATE_AND_PERSISTENCE.md`, no per-interaction Firestore write was reintroduced: picks and seen-flags reach Firestore with the next save, exactly like cycling did.

## Tests

- `tests/shortlist-seen-all.test.ts` (pure): seenAll delta semantics, idempotency, cycled untouched, index setter bounds, stale-flag clearing.
- `tests/recipe-store-icon-editor.test.ts` (pure): open/close, no-dirty/no-undo guarantees, mergeSnapshot preserving vs resetting the flags.
- `tests/user-credits.test.ts` (integration, added to the manifest): starter grant, atomic spend / insufficient / refund, forge gate incl. refund-on-failure and anonymous rejection.
- `node-fields`, `lifecycle`, `icon-pipeline` updated for the new field and the credits DI.
- Verified here: lint, typecheck, full pure tier (via the pre-commit hook), and the auth/firestore/storage-emulator integration subset (`user-credits`, `impression-rejection`, `forge-gate-regression`, `icon-queue-config`, `save-reconciliation`, `icon-apply-auth`) — 37/37. The **full** integration tier and e2e could not run in this sandbox (the functions emulator's embedding-model download from huggingface.co is blocked by the network policy), so CI should be the authority there.

## Not in this PR (next phase, per owner)

Generation offering multiple options to choose from, and a generated icon counting as a **named donation** from the generating user. Also the actual credit purchase flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011inCNhvGPhUuoecsqhmwDF

---
_Generated by [Claude Code](https://claude.ai/code/session_011inCNhvGPhUuoecsqhmwDF)_