### PR TITLE
ci: cache the functions embedding model; retry its download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,18 @@ jobs:
           npm install -g firebase-tools
           firebase experiments:enable webframeworks
 
+      # test-unit-integration.sh downloads the pinned Xenova/all-MiniLM-L6-v2
+      # embedding model from huggingface.co whenever model-cache is absent —
+      # on a fresh runner that was EVERY run, and one connection reset failed
+      # the whole job. Cache it like the Playwright browsers in the e2e job;
+      # bump the key if functions/scripts/download-model.js pins a new model.
+      - name: Cache functions embedding model
+        if: needs.changes.outputs.code == 'true'
+        uses: actions/cache@v4
+        with:
+          path: recipe-lanes/functions/src/vector-search/model-cache
+          key: hf-model-Xenova-all-MiniLM-L6-v2-fp32-v1
+
       - name: Build
         if: needs.changes.outputs.code == 'true'
         run: cd recipe-lanes && npm run build

--- a/recipe-lanes/functions/scripts/download-model.js
+++ b/recipe-lanes/functions/scripts/download-model.js
@@ -10,10 +10,14 @@ const MODEL_CACHE = path.resolve(__dirname, '../src/vector-search/model-cache');
 env.cacheDir = MODEL_CACHE;
 env.allowRemoteModels = true;
 
-async function main() {
-    console.log('Downloading Xenova/all-MiniLM-L6-v2...');
-    console.log('Target:', MODEL_CACHE);
+// huggingface.co resets connections often enough to have failed whole CI runs
+// on a single un-retried fetch, so retry with backoff before giving up.
+const MAX_ATTEMPTS = 3;
+const BACKOFF_MS = [0, 5_000, 15_000];
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function download() {
     const embedder = await pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2', {
         dtype: 'fp32',
     });
@@ -22,9 +26,26 @@ async function main() {
     const out = await embedder('test sentence', { pooling: 'mean', normalize: true });
     const dim = Array.from(out.data).length;
     if (dim !== 384) throw new Error(`Expected 384-dim embedding, got ${dim}`);
+    return dim;
+}
 
-    console.log(`Done. Embedding dim: ${dim}`);
-    process.exit(0);
+async function main() {
+    console.log('Downloading Xenova/all-MiniLM-L6-v2...');
+    console.log('Target:', MODEL_CACHE);
+
+    let lastErr;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        await sleep(BACKOFF_MS[attempt - 1] ?? 0);
+        try {
+            const dim = await download();
+            console.log(`Done. Embedding dim: ${dim}`);
+            process.exit(0);
+        } catch (e) {
+            lastErr = e;
+            console.warn(`Attempt ${attempt}/${MAX_ATTEMPTS} failed:`, e?.message ?? e);
+        }
+    }
+    throw lastErr;
 }
 
 main().catch(e => {


### PR DESCRIPTION
Fixes the test smell the owner flagged: the `integration` CI job depended on a **live huggingface.co download on every run**.

**The smell.** `test-unit-integration.sh` downloads the pinned `Xenova/all-MiniLM-L6-v2` embedding model (~100MB) whenever `functions/src/vector-search/model-cache` is absent — which on a fresh CI runner is *every* run. The download was a single un-retried fetch, so one connection reset failed the whole suite. It has caused three incidents in 24h: the false-red on PR #316 (run 1128 attempt 1, `ECONNRESET` before any test body ran), the manual re-run that forced, and sandboxed agents being unable to run the tier at all (network policy blocks huggingface.co).

**The fix.**
- `ci.yml` integration job: `actions/cache` on `recipe-lanes/functions/src/vector-search/model-cache`, keyed on the pinned model id — mirroring the e2e job's existing Playwright-browser cache. After the first green run seeds the cache, CI stops touching huggingface.co entirely. Bump the key suffix when `download-model.js` pins a new model.
- `functions/scripts/download-model.js`: 3 attempts with 0s/5s/15s backoff as the cold-cache fallback.

**Caveats.**
- This PR's own integration run seeds the cache (the `download-model.js` change counts as code, so the full pipeline runs); the cache-hit path is proven on the *next* code PR.
- `download-model.js` lives under `functions/**`, so merging triggers a prod `deploy-backend` run — harmless (script-only change, functions code untouched).

Verified: `node --check` on the script, YAML parse on the workflow, and the full pure tier via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011inCNhvGPhUuoecsqhmwDF

---
_Generated by [Claude Code](https://claude.ai/code/session_011inCNhvGPhUuoecsqhmwDF)_