### PR TITLE
fix(rules): restore client write grants broken by #318 + app-flow rules harness

### DIFF
--- a/recipe-lanes/firestore.rules
+++ b/recipe-lanes/firestore.rules
@@ -2,16 +2,21 @@ rules_version = '2';
 
 // RecipeLanes security rules.
 //
-// Architecture invariant: ALL writes go through server actions / Cloud
-// Functions using the Admin SDK (which bypasses these rules). No client code
-// writes Firestore directly, so no rule below grants `write` — a client write
-// anywhere is either a bug or an attack. This matters because credits (and
-// eventually money) hang off these collections: integrity lives server-side,
-// and these rules only decide what clients may READ.
+// HISTORY / WARNING (2026-08-31): PR #318 tightened these to "clients read,
+// backend writes" on the belief that every write goes through the Admin SDK.
+// That belief was wrong — removing the client write grants broke production
+// (feedback submission among other things). These rules are back to the
+// permissions that production is known to work with.
+//
+// Do NOT re-tighten a grant below without first proving, with a test that
+// exercises the real app flow through RULES-ENFORCED access, that nothing
+// needs it. tests/firestore-rules-app-flows.test.ts is that harness: it
+// replays each Firestore operation the app performs as an ordinary client and
+// asserts it still SUCCEEDS. Admin-SDK integration tests cannot catch this —
+// the Admin SDK bypasses rules entirely, so a rules regression looks green.
 //
 // Collections with no match block are deny-by-default on purpose:
 //   user_credits     — credit balances; Admin-SDK-only (see lib/user-credits.ts)
-//   credit_ledger    — (planned) append-only credit audit trail; Admin-SDK-only
 //   icon_forge_usage — per-user daily forge counters; Admin-SDK-only
 //   config           — runtime config (icon queue abuse controls); server-read
 service cloud.firestore {
@@ -41,33 +46,37 @@ service cloud.firestore {
       allow read: if true;
     }
 
-    // Icon generation queue: public read for the live queue monitor
-    // (components/queue-monitor.tsx). Writes are Admin-SDK-only — the queue
-    // gates credit spends, so a client write here would bypass the credit
-    // charge in forgeIconAction.
-    match /icon_queue/{ingredient} {
-      allow read: if true;
-    }
-
     // Recipes: visibility-gated read (public listing, unlisted link-sharing,
-    // owner access). Saves go through server actions only.
+    // owner access). Saves go through server actions.
     match /recipes/{recipeId} {
       allow read: if resource.data.visibility == 'public'
                   || resource.data.visibility == 'unlisted'
                   || isUser(resource.data.ownerId);
     }
 
-    // User profiles & stars: owner-read only. Profile updates and starring go
-    // through server actions, so display names shown publicly (e.g. future
-    // icon attribution) can never be forged by a client write.
+    // User profiles & stars: owner read AND write.
     match /users/{userId} {
-      allow read: if isUser(userId);
+      allow read, write: if isUser(userId);
 
       match /stars/{starId} {
-        allow read: if isUser(userId);
+        allow read, write: if isUser(userId);
       }
     }
 
-    // Feedback: submitted via a server action (data-service). No client access.
+    // Icon generation queue: public read (queue monitor) and public write.
+    //
+    // KNOWN GAP: the open write lets a client enqueue generation without the
+    // credit spend in forgeIconAction. Closing it is the goal, but #318 showed
+    // it cannot be closed blind — prove the app never writes here from a
+    // rules-enforced context first (app-flow harness above), then close it.
+    match /icon_queue/{ingredient} {
+      allow read, write: if true;
+    }
+
+    // Feedback: create-only, unauthenticated (the feedback modal must work for
+    // logged-out visitors). Removing this in #318 broke feedback in production.
+    match /feedback/{feedbackId} {
+      allow create: if true;
+    }
   }
 }

--- a/recipe-lanes/scripts/unit-test-manifest.mjs
+++ b/recipe-lanes/scripts/unit-test-manifest.mjs
@@ -44,6 +44,7 @@ export const INTEGRATION_TESTS = [
   'anonymous-publish-integration.test.ts',
   'data-helpers-transaction.test.ts',
   'firestore-rules.test.ts',
+  'firestore-rules-app-flows.test.ts',
   'forge-gate-regression.test.ts',
   'functions-metadata.test.ts',
   'hybrid-integration.test.ts',

--- a/recipe-lanes/tests/firestore-rules-app-flows.test.ts
+++ b/recipe-lanes/tests/firestore-rules-app-flows.test.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2026 Bohemian Miser <https://substack.com/@bohemianmiser>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// RULES REGRESSION HARNESS — "does the app still work?"
+//
+// Why this file exists: PR #318 tightened firestore.rules on the belief that
+// every write goes through the Admin SDK, shipped with a deny-only test suite,
+// and broke production (feedback submission among other things). Nothing went
+// red, because:
+//
+//   * the emulator integration tests drive Firestore through the ADMIN SDK,
+//     which BYPASSES rules entirely — they cannot fail on a rules change; and
+//   * the rules contract suite only asserted that things are DENIED, and
+//     removing a grant makes such assertions *more* true.
+//
+// So this file pins the opposite direction: every Firestore operation the app
+// needs is replayed here through a RULES-ENFORCED client, asserting it still
+// SUCCEEDS. Take a grant out of firestore.rules and the matching case here
+// goes red, naming the user-facing feature that would break.
+//
+// HOW TO KEEP IT HONEST
+//   * Add a case whenever a feature starts touching Firestore from the client
+//     (or from any non-Admin-SDK path, e.g. REST).
+//   * Never "fix" a red case by relaxing the assertion — either the rule needs
+//     restoring, or the app path genuinely moved to the Admin SDK, in which
+//     case delete the case and say so in the commit.
+//
+// Runs under its own emulator project id so it cannot disturb other tests.
+
+import { describe, it, before, after } from 'node:test';
+import {
+    initializeTestEnvironment,
+    assertSucceeds,
+    RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const RULES_PATH = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../firestore.rules'
+);
+
+const VISITOR = 'app-flow-visitor-uid';
+
+let env: RulesTestEnvironment;
+
+const asUser = () => env.authenticatedContext(VISITOR).firestore();
+const asAnon = () => env.unauthenticatedContext().firestore();
+
+before(async () => {
+    const host = process.env.FIRESTORE_EMULATOR_HOST ?? '127.0.0.1:8080';
+    const [hostname, port] = host.split(':');
+    env = await initializeTestEnvironment({
+        projectId: 'rules-app-flows',
+        firestore: {
+            host: hostname,
+            port: Number(port),
+            rules: readFileSync(RULES_PATH, 'utf8'),
+        },
+    });
+
+    await env.withSecurityRulesDisabled(async (ctx) => {
+        const db = ctx.firestore();
+        await db.doc('icon_index/icon1').set({ ingredient_name: 'carrot' });
+        await db.doc('feed_icons/icon1').set({ url: 'https://example/icon.png' });
+        await db.doc('ingredients_new/carrot').set({ icons: [] });
+        await db.doc('icon_queue/Carrot').set({ status: 'pending' });
+        await db.doc('recipes/public1').set({ visibility: 'public', ownerId: 'someone-else' });
+        await db.doc('recipes/unlisted1').set({ visibility: 'unlisted', ownerId: 'someone-else' });
+        await db.doc('recipes/mine1').set({ visibility: 'private', ownerId: VISITOR });
+        await db.doc(`users/${VISITOR}`).set({ displayName: 'Visitor', isAdmin: false });
+    });
+});
+
+after(async () => {
+    await env.cleanup();
+});
+
+describe('app flow: feedback submission', () => {
+    // components/feedback-modal.tsx. This is the case that #318 broke: the
+    // modal must work for logged-OUT visitors, so an unauthenticated create
+    // has to be allowed by whatever path reaches Firestore.
+    it('a logged-out visitor can submit feedback', async () => {
+        await assertSucceeds(
+            asAnon().collection('feedback').add({
+                message: 'the diagram overlaps on mobile',
+                url: 'https://recipelanes.com/lanes?id=abc',
+            })
+        );
+    });
+
+    it('a signed-in visitor can submit feedback', async () => {
+        await assertSucceeds(
+            asUser().collection('feedback').add({
+                message: 'love the timeline view',
+                url: 'https://recipelanes.com/lanes?id=abc',
+                userId: VISITOR,
+            })
+        );
+    });
+});
+
+describe('app flow: viewing recipes', () => {
+    // app/lanes/page.tsx and app/icon_overview/page.tsx subscribe to a recipe
+    // doc with onSnapshot; the gallery lists public recipes.
+    it('anyone can open a public or unlisted (link-shared) recipe', async () => {
+        await assertSucceeds(asAnon().doc('recipes/public1').get());
+        await assertSucceeds(asAnon().doc('recipes/unlisted1').get());
+    });
+
+    it('an owner can open their own private recipe', async () => {
+        await assertSucceeds(asUser().doc('recipes/mine1').get());
+    });
+
+    it('the gallery can list public recipes', async () => {
+        await assertSucceeds(
+            asAnon().collection('recipes').where('visibility', '==', 'public').get()
+        );
+    });
+});
+
+describe('app flow: icon display and search', () => {
+    // lib/icon-search-registry.ts + components/hooks/useHybridIconSearch.ts
+    // read icon_index directly from the browser; the gallery reads feed_icons;
+    // nodes resolve ingredient docs.
+    it('the client can read the icon index, feed icons, and ingredients', async () => {
+        const db = asAnon();
+        await assertSucceeds(db.doc('icon_index/icon1').get());
+        await assertSucceeds(db.collection('icon_index').limit(5).get());
+        await assertSucceeds(db.doc('feed_icons/icon1').get());
+        await assertSucceeds(db.collection('feed_icons').limit(5).get());
+        await assertSucceeds(db.doc('ingredients_new/carrot').get());
+    });
+});
+
+describe('app flow: icon generation queue', () => {
+    // components/queue-monitor.tsx streams the queue with onSnapshot; the
+    // generation pipeline creates and updates queue docs.
+    it('the queue monitor can stream queue docs', async () => {
+        await assertSucceeds(asAnon().collection('icon_queue').limit(5).get());
+        await assertSucceeds(asAnon().doc('icon_queue/Carrot').get());
+    });
+
+    it('a generation request can create and update a queue doc', async () => {
+        await assertSucceeds(
+            asUser().doc('icon_queue/App Flow Probe').set({ status: 'pending' })
+        );
+        await assertSucceeds(
+            asUser().doc('icon_queue/App Flow Probe').update({ status: 'processing' })
+        );
+    });
+});
+
+describe('app flow: user profile and stars', () => {
+    // components/auth-provider.tsx reads the user doc on sign-in (isAdmin for
+    // UI visibility); starring writes under users/{uid}/stars.
+    it('a signed-in user can read their own profile doc', async () => {
+        await assertSucceeds(asUser().doc(`users/${VISITOR}`).get());
+    });
+
+    it('a signed-in user can write their own profile and stars', async () => {
+        await assertSucceeds(
+            asUser().doc(`users/${VISITOR}`).set({ displayName: 'Visitor' }, { merge: true })
+        );
+        await assertSucceeds(
+            asUser().doc(`users/${VISITOR}/stars/public1`).set({ recipeId: 'public1' })
+        );
+        await assertSucceeds(asUser().collection(`users/${VISITOR}/stars`).get());
+        await assertSucceeds(asUser().doc(`users/${VISITOR}/stars/public1`).delete());
+    });
+});

--- a/recipe-lanes/tests/firestore-rules.test.ts
+++ b/recipe-lanes/tests/firestore-rules.test.ts
@@ -15,12 +15,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-// Security-rules contract tests (emulator-backed). The architecture invariant
-// is "clients read, backend writes": every Firestore write goes through the
-// Admin SDK, so firestore.rules must deny ALL client writes and gate reads per
-// collection. These tests pin that contract — especially for the collections
-// credits/money hang off (user_credits, icon_queue) — so a future rules edit
-// that re-opens a write path fails CI instead of shipping.
+// Security-rules contract tests (emulator-backed). These pin what the DEPLOYED
+// rules allow and deny, so an unintended widening fails CI.
+//
+// They are deliberately paired with tests/firestore-rules-app-flows.test.ts,
+// which pins the other direction: the operations the app REQUIRES must keep
+// working. #318 tightened rules with only this half of the coverage and broke
+// production — a deny-only suite happily goes green while the app dies.
 //
 // Uses its own emulator project id ("rules-spec") so loading rules here cannot
 // affect the shared "local-project-id" data other integration tests use.
@@ -76,6 +77,7 @@ before(async () => {
         await db.doc(`users/${OWNER}`).set({ displayName: 'Owner' });
         await db.doc(`users/${OWNER}/stars/s1`).set({ recipeId: 'public1' });
         await db.doc(`user_credits/${OWNER}`).set({ balance: 10, granted: 10, spent: 0 });
+        await db.doc('feedback/seeded1').set({ message: 'seeded', url: 'https://x' });
     });
 });
 
@@ -99,13 +101,14 @@ describe('public catalog collections', () => {
     });
 });
 
-describe('icon_queue (credit-gated pipeline)', () => {
-    it('clients cannot create, update, or delete queue docs', async () => {
-        // A client queue write would bypass the credit spend in forgeIconAction.
-        await assertFails(asAnon().doc('icon_queue/Free Lunch').set({ status: 'pending' }));
-        await assertFails(asOwner().doc('icon_queue/Free Lunch').set({ status: 'pending' }));
-        await assertFails(asOwner().doc('icon_queue/Carrot').update({ status: 'failed' }));
-        await assertFails(asOwner().doc('icon_queue/Carrot').delete());
+describe('icon_queue', () => {
+    // KNOWN GAP, pinned rather than asserted-away: queue writes are currently
+    // open, so a client could enqueue generation without spending a credit.
+    // This test documents the live behaviour; when the gap is closed (with the
+    // app-flow harness proving nothing needs it) flip these to assertFails.
+    it('queue writes are currently open to any client', async () => {
+        await assertSucceeds(asAnon().doc('icon_queue/Rules Probe Anon').set({ status: 'pending' }));
+        await assertSucceeds(asOwner().doc('icon_queue/Carrot').update({ status: 'pending' }));
     });
 });
 
@@ -138,11 +141,15 @@ describe('user profiles & stars', () => {
         await assertFails(asAnon().doc(`users/${OWNER}`).get());
     });
 
-    it('even the owner cannot write their profile from a client', async () => {
-        // Display names may be shown publicly (icon attribution); they must
-        // only change via server actions.
-        await assertFails(asOwner().doc(`users/${OWNER}`).set({ displayName: 'Spoofed' }));
-        await assertFails(asOwner().doc(`users/${OWNER}/stars/s2`).set({ recipeId: 'x' }));
+    it('the owner can write their own profile and stars', async () => {
+        await assertSucceeds(asOwner().doc(`users/${OWNER}`).set({ displayName: 'Owner' }, { merge: true }));
+        await assertSucceeds(asOwner().doc(`users/${OWNER}/stars/s2`).set({ recipeId: 'x' }));
+    });
+
+    it('nobody can write ANOTHER user\'s profile or stars', async () => {
+        await assertFails(asStranger().doc(`users/${OWNER}`).set({ displayName: 'Pwned' }));
+        await assertFails(asStranger().doc(`users/${OWNER}/stars/s3`).set({ recipeId: 'x' }));
+        await assertFails(asAnon().doc(`users/${OWNER}`).set({ displayName: 'Pwned' }));
     });
 });
 
@@ -163,9 +170,16 @@ describe('money-adjacent collections are fully closed', () => {
 });
 
 describe('feedback', () => {
-    it('clients cannot create feedback directly (server action only)', async () => {
-        await assertFails(asAnon().collection('feedback').add({ text: 'hi' }));
-        await assertFails(asOwner().collection('feedback').add({ text: 'hi' }));
+    it('anyone, signed in or not, can create feedback', async () => {
+        await assertSucceeds(asAnon().collection('feedback').add({ message: 'hi' }));
+        await assertSucceeds(asOwner().collection('feedback').add({ message: 'hi' }));
+    });
+
+    it('feedback is not readable, updatable, or deletable by clients', async () => {
+        await assertFails(asAnon().collection('feedback').get());
+        await assertFails(asOwner().doc('feedback/seeded1').get());
+        await assertFails(asOwner().doc('feedback/seeded1').update({ message: 'edited' }));
+        await assertFails(asOwner().doc('feedback/seeded1').delete());
     });
 });
 
@@ -213,7 +227,9 @@ describe('bypass attempts', () => {
         await assertFails(forged.doc(`user_credits/${STRANGER}`).set({ balance: 9999 }));
         await assertFails(forged.doc(`users/${OWNER}`).get());
         await assertFails(forged.doc('recipes/private1').get());
-        await assertFails(forged.doc('icon_queue/Free Lunch').set({ status: 'pending' }));
+        // NB: icon_queue writes are open to everyone right now (known gap), so
+        // there is nothing for a forged claim to gain there — see the
+        // 'icon_queue' suite above.
     });
 
     it('nested paths under closed collections stay closed', async () => {
@@ -231,7 +247,7 @@ describe('bypass attempts', () => {
         const db = asOwner();
         const batch = db.batch();
         batch.set(db.doc(`user_credits/${OWNER}`), { balance: 9999 });
-        batch.set(db.doc('feedback/sneaky'), { text: 'hi' });
+        batch.set(db.doc(`users/${OWNER}`), { displayName: 'Owner' });
         await assertFails(batch.commit());
 
         await assertFails(
@@ -264,6 +280,6 @@ describe('bypass attempts', () => {
     it('one user cannot read or write another user\'s profile or stars', async () => {
         await assertFails(asStranger().doc(`users/${OWNER}/stars/s1`).get());
         await assertFails(asStranger().doc(`users/${OWNER}`).set({ displayName: 'Pwned' }));
-        await assertFails(asStranger().doc(`users/${OWNER}/stars/s2`).set({ recipeId: 'x' }));
+        await assertFails(asStranger().doc(`users/${OWNER}/stars/sX`).set({ recipeId: 'x' }));
     });
 });


### PR DESCRIPTION
**Production hotfix.** #318 was mine and its central premise was wrong: I concluded from a code audit that every Firestore write goes through the Admin SDK, so no client grants were needed. Removing them broke production — feedback submission among other things.

## The fix

`firestore.rules` is restored to **exactly** the permissions that shipped before #318 — verified by diffing the `allow` statements against `68943ea^`, which come out identical:

- `users/{uid}` and `users/{uid}/stars/{id}` — owner **read + write**
- `icon_queue/{ingredient}` — **read + write**
- `feedback/{id}` — unauthenticated **create** (the feedback modal must work for logged-out visitors)

The open `icon_queue` write is left in place but documented in-file as a known gap (a client can enqueue generation without spending a credit). Closing it needs proof that nothing depends on it, not another assumption — the harness below is how that proof gets made.

## Why CI didn't catch it — and what now does

Both existing tiers are structurally blind to this class of break:

- the **emulator integration tests** drive Firestore through the **Admin SDK, which bypasses rules entirely**, so no rules change can ever fail them; and
- the **rules contract suite** only asserted what is *denied* — and removing a grant makes a deny assertion *more* true, so it went green on a change that took production down.

New `tests/firestore-rules-app-flows.test.ts` covers the missing direction: every Firestore operation the app actually performs is replayed through a **rules-enforced** client and asserted to **succeed**, so removing a grant fails CI with the name of the feature that would break. Cases cover feedback submission (logged-out and signed-in), recipe viewing and gallery listing, icon index/feed/ingredient reads, queue monitor streaming and queue writes, and profile/stars reads and writes.

**Verified against the broken rules**: checked out #318's `firestore.rules`, ran the harness, and it fails 4 cases naming feedback submission (both variants), queue writes, and profile/stars writes. Then restored and everything passes.

The existing contract suite is updated to the restored permissions and keeps its adversarial bypass coverage (cross-user access, forged custom claims, nested paths under closed collections, batched/transactional writes, malformed docs). 32 tests pass; lint and typecheck clean.

## Note on scope

I could not reproduce the production failure directly (the sandbox proxy blocks recipelanes.com), so rather than guess at a narrower fix I restored the known-good permission set wholesale. If you have the actual error text from the broken window it's worth pasting — it tells us *which* path hits rules, which is what we need to re-land the lockdown safely rather than by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011inCNhvGPhUuoecsqhmwDF

---
_Generated by [Claude Code](https://claude.ai/code/session_011inCNhvGPhUuoecsqhmwDF)_